### PR TITLE
feat: module-oauth-delegation — outbound OAuth 2.0 delegation

### DIFF
--- a/templates/module-oauth-delegation/README.md
+++ b/templates/module-oauth-delegation/README.md
@@ -1,0 +1,193 @@
+# module-oauth-delegation
+
+Composable **outbound** OAuth 2.0 delegation module — stores per-user access tokens and calls third-party APIs on the user's behalf.
+
+> **Not inbound auth.** Use [module-auth](../module-auth/) to verify incoming requests. Use this module when your service needs to call Notion, Google, Atlassian, Slack, or HubSpot *as the user*.
+
+## What you get
+
+- **Four HTTP handlers** — `/oauth/:provider/start`, `/oauth/:provider/callback`, `/oauth/:provider/refresh`, `/oauth/:provider/revoke`
+- **Authorization Code + PKCE (S256)** — PKCE is always on by default, including for providers that also take a client secret
+- **HMAC-signed stateless state cookie** — `HttpOnly; Secure; SameSite=Lax`, 10-minute TTL, tamper detection via `timingSafeEqual`
+- **Pluggable token storage** — ships `InMemoryTokenStorage` for tests and `DDBKmsTokenStorage` for production (DynamoDB + KMS envelope encryption with a user+provider-bound encryption context)
+- **Automatic refresh** — `getValidToken()` checks expiry with a lead time and refreshes transparently; per-key mutex prevents thundering herd within a single process
+- **Five provider adapters** — Notion, Google, Atlassian, Slack, HubSpot
+- **Framework-neutral** — handlers take Web-standard `Request` and return `Response`; wire to Hono, Express, Lambda, or raw `node:http` with thin adapters
+- **Safe logging** — a hard-coded redaction list prevents access/refresh tokens from ever reaching log output, enforced by a unit test
+
+## Variables
+
+| Variable | Placeholder | Default | Description |
+|----------|-------------|---------|-------------|
+| `ProjectName` | `__PROJECT_NAME__` | *(required)* | Kebab-case package name |
+| `Description` | `__DESCRIPTION__` | Per-user OAuth 2.0 delegation... | Package description |
+
+## Project layout
+
+```text
+<ProjectName>/
+  src/
+    oauth/
+      index.ts               # createOAuthRouter + public re-exports
+      types.ts               # TokenGrant, OAuthProvider, OAuthRouterConfig, ...
+      router.ts              # factory — wires handlers + getValidToken
+      state.ts               # HMAC-signed state cookie encode/decode
+      pkce.ts                # code_verifier + S256 code_challenge
+      refresh.ts             # refresh-before-expiry + per-key mutex
+      errors.ts              # typed errors — no token material in messages
+      logger.ts              # JSON logger with token-field redaction
+      handlers/
+        start.ts
+        callback.ts
+        refresh.ts
+        revoke.ts
+      providers/
+        types.ts             # OAuthProvider interface
+        registry.ts          # registerProvider / getProvider / listProviders
+        index.ts             # barrel — side-effect imports
+        notion.ts
+        google.ts
+        atlassian.ts
+        slack.ts
+        hubspot.ts
+      storage/
+        types.ts             # TokenStorage interface
+        memory.ts            # InMemoryTokenStorage
+        ddb-kms.ts           # DDBKmsTokenStorage (peer-dep AWS SDK)
+      __tests__/
+        ...
+  package.json
+  tsconfig.json
+```
+
+## Pairs with
+
+- [ts-service](../ts-service/) — attach OAuth handlers to a TypeScript HTTP service
+- [mcp-server-ts](../mcp-server-ts/) — let an MCP server call third-party APIs as the connected user
+
+## Nests inside
+
+- [monorepo](../monorepo/)
+
+## Quick start
+
+```typescript
+import {
+  createOAuthRouter,
+  notionProvider,
+  googleProvider,
+  InMemoryTokenStorage,
+} from "your-oauth-module";
+
+const router = createOAuthRouter({
+  providers: {
+    notion: notionProvider,
+    google: googleProvider,
+  },
+  storage: new InMemoryTokenStorage(),
+  stateSigningSecret: process.env.OAUTH_STATE_SIGNING_SECRET!,
+  resolveUserId: async (req) => {
+    // plug in your inbound auth — e.g., module-auth's getAuthUser()
+    return req.headers.get("x-user-id");
+  },
+  clientCredentials: {
+    notion: {
+      clientId: process.env.NOTION_CLIENT_ID!,
+      clientSecret: process.env.NOTION_CLIENT_SECRET!,
+      redirectUri: process.env.NOTION_REDIRECT_URI!,
+    },
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      redirectUri: process.env.GOOGLE_REDIRECT_URI!,
+    },
+  },
+});
+
+// In steady state, consumer code calls one thing:
+const accessToken = await router.getValidToken(userId, "notion");
+if (accessToken) {
+  await fetch("https://api.notion.com/v1/users/me", {
+    headers: { Authorization: `Bearer ${accessToken}`, "Notion-Version": "2022-06-28" },
+  });
+}
+
+// Wire handlers to your framework (example: raw node:http pattern)
+// app.all("/oauth/*", (req) => router.handlers.start(req) /* or dispatch by path */);
+```
+
+## Providers
+
+Each adapter is a plain `OAuthProvider` object that self-registers at import time.
+
+| Provider | Auth URL | Notes |
+|----------|----------|-------|
+| `notion` | `api.notion.com/v1/oauth/authorize` | No refresh tokens — grants are long-lived |
+| `google` | `accounts.google.com/o/oauth2/v2/auth` | Sends `access_type=offline&prompt=consent` on first grant for refresh; reuses refresh token if response omits it |
+| `atlassian` | `auth.atlassian.com/authorize` | Adds `audience=api.atlassian.com` |
+| `slack` | `slack.com/oauth/v2/authorize` | Reads `authed_user.access_token` for user-scope flows |
+| `hubspot` | `app.hubspot.com/oauth/authorize` | Space-separated scopes |
+
+## Storage backends
+
+| Backend | Use case | Persistence | Encryption |
+|---------|----------|-------------|------------|
+| `InMemoryTokenStorage` | Tests, local dev | Process memory | None |
+| `DDBKmsTokenStorage` | Production | DynamoDB | KMS envelope, `EncryptionContext: { purpose, userId, provider }` |
+
+`DDBKmsTokenStorage` depends on `@aws-sdk/client-dynamodb`, `@aws-sdk/client-kms`, and `@smithy/node-http-handler` as **optional peer dependencies** — install them only if you use this backend. DynamoDB key schema: PK `userId`, SK `provider`. The KMS `EncryptionContext` binds each ciphertext to its user/provider pair, so a leaked blob cannot be decrypted for a different user.
+
+## Security model
+
+1. **PKCE is always on** (S256). The `code_verifier` lives in the signed state cookie — no server-side state table.
+2. **State cookie is HMAC-SHA256 signed** with a server secret. Tampering or expiry (default 10 min) yields a 400.
+3. **Callback verifies `state.userId === resolveUserId(req)`** — the consumer-injected hook that identifies the authenticated caller.
+4. **No token material in logs or errors.** A unit test asserts the logger redaction rules hold.
+5. **KMS EncryptionContext binds ciphertexts** to `{ purpose, userId, provider }` in the production storage backend.
+6. **Refresh failures do not retry.** One attempt — on failure, the token is deleted, a revocation event fires with `reason: "refresh-failed"`, and `getValidToken` returns `null`.
+7. **Redirect URIs are exact-match.** Configured per-provider; mismatches reject at callback.
+
+### Known limitation — multi-instance refresh dedup
+
+The per-key mutex deduplicates concurrent refreshes within a single Node.js process. Multi-instance deployments may race; inject a shared-state mutex (Redis, for instance) via the `createOAuthRouter` seam if that matters for your throughput.
+
+## module-auth vs module-oauth-delegation
+
+| | `module-auth` | `module-oauth-delegation` |
+|---|---|---|
+| Direction | Inbound — verify requests | Outbound — call APIs on user's behalf |
+| Question answered | "Is this request authenticated?" | "Can we call Notion as this user?" |
+| State | Request-scoped (no storage) | Durable per-(userId, provider) row |
+| Surface | Middleware + `requireAuth`/`requireRole` guards | Four handlers + `getValidToken()` |
+| Providers | JWT, Clerk, Auth0, Supabase, API key | Notion, Google, Atlassian, Slack, HubSpot |
+
+Most services want both: `module-auth` to decide who's calling, `module-oauth-delegation` to call downstream services on their behalf.
+
+## Adding a custom provider
+
+```typescript
+import { registerProvider } from "your-oauth-module/providers";
+import type { OAuthProvider } from "your-oauth-module";
+
+const githubProvider: OAuthProvider = {
+  name: "github",
+  authUrl:
+    "https://github.com/login/oauth/authorize" +
+    "?client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}&state={state}" +
+    "&code_challenge={code_challenge}&code_challenge_method={code_challenge_method}",
+  tokenUrl: "https://github.com/login/oauth/access_token",
+  revokeUrl: undefined,
+  defaultScopes: ["repo", "read:user"],
+  usePkce: true,
+  parseTokenResponse(raw) {
+    const r = raw as { access_token: string; refresh_token?: string; expires_in?: number };
+    return {
+      accessToken: r.access_token,
+      refreshToken: r.refresh_token,
+      expiresAt: r.expires_in ? Math.floor(Date.now() / 1000) + r.expires_in : undefined,
+    };
+  },
+};
+
+registerProvider("github", () => githubProvider);
+```

--- a/templates/module-oauth-delegation/skeleton/.env.example
+++ b/templates/module-oauth-delegation/skeleton/.env.example
@@ -1,0 +1,36 @@
+# ── OAuth Delegation Module ──────────────────────────────────────────
+
+# ── State cookie signing ─────────────────────────────────────────────
+# Long random string (e.g., `openssl rand -base64 48`). Used to HMAC the
+# stateless state cookie that carries the CSRF nonce and PKCE verifier.
+OAUTH_STATE_SIGNING_SECRET=change-me
+
+# ── Notion ───────────────────────────────────────────────────────────
+# NOTION_CLIENT_ID=
+# NOTION_CLIENT_SECRET=
+# NOTION_REDIRECT_URI=https://your.app/oauth/notion/callback
+
+# ── Google (Drive / Calendar / Analytics) ────────────────────────────
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# GOOGLE_REDIRECT_URI=https://your.app/oauth/google/callback
+
+# ── Atlassian (Confluence) ───────────────────────────────────────────
+# ATLASSIAN_CLIENT_ID=
+# ATLASSIAN_CLIENT_SECRET=
+# ATLASSIAN_REDIRECT_URI=https://your.app/oauth/atlassian/callback
+
+# ── Slack ────────────────────────────────────────────────────────────
+# SLACK_CLIENT_ID=
+# SLACK_CLIENT_SECRET=
+# SLACK_REDIRECT_URI=https://your.app/oauth/slack/callback
+
+# ── HubSpot ──────────────────────────────────────────────────────────
+# HUBSPOT_CLIENT_ID=
+# HUBSPOT_CLIENT_SECRET=
+# HUBSPOT_REDIRECT_URI=https://your.app/oauth/hubspot/callback
+
+# ── DDBKmsTokenStorage (production backend) ──────────────────────────
+# AWS_REGION=us-east-1
+# OAUTH_TOKEN_TABLE=oauth-tokens
+# OAUTH_KMS_KEY_ID=alias/oauth-tokens

--- a/templates/module-oauth-delegation/skeleton/.gitignore
+++ b/templates/module-oauth-delegation/skeleton/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+*.tsbuildinfo
+*.log
+coverage/

--- a/templates/module-oauth-delegation/skeleton/.prettierrc
+++ b/templates/module-oauth-delegation/skeleton/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/templates/module-oauth-delegation/skeleton/README.md
+++ b/templates/module-oauth-delegation/skeleton/README.md
@@ -1,0 +1,156 @@
+# __PROJECT_NAME__
+
+__DESCRIPTION__
+
+Outbound OAuth 2.0 delegation with Authorization Code + PKCE, HMAC-signed state cookies, pluggable per-user token storage, and automatic refresh-before-expiry. Ships reference adapters for Notion, Google, Atlassian, Slack, and HubSpot.
+
+## Getting Started
+
+```sh
+npm install
+npm run build
+npm test
+```
+
+## Usage
+
+```ts
+import {
+  createOAuthRouter,
+  notionProvider,
+  googleProvider,
+  InMemoryTokenStorage,
+} from "__PROJECT_NAME__";
+
+const router = createOAuthRouter({
+  providers: { notion: notionProvider, google: googleProvider },
+  storage: new InMemoryTokenStorage(),
+  stateSigningSecret: process.env.OAUTH_STATE_SIGNING_SECRET!,
+  resolveUserId: async (req) => req.headers.get("x-user-id"),
+  clientCredentials: {
+    notion: {
+      clientId: process.env.NOTION_CLIENT_ID!,
+      clientSecret: process.env.NOTION_CLIENT_SECRET!,
+      redirectUri: process.env.NOTION_REDIRECT_URI!,
+    },
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      redirectUri: process.env.GOOGLE_REDIRECT_URI!,
+    },
+  },
+});
+
+// The one call most downstream code makes:
+const token = await router.getValidToken(userId, "notion");
+```
+
+### Wiring to a framework
+
+The handlers take a Web-standard `Request` and return a `Response`. For Hono:
+
+```ts
+import { Hono } from "hono";
+const app = new Hono();
+app.get("/oauth/:provider/start", (c) => router.handlers.start(c.req.raw));
+app.get("/oauth/:provider/callback", (c) => router.handlers.callback(c.req.raw));
+app.post("/oauth/:provider/refresh", (c) => router.handlers.refresh(c.req.raw));
+app.post("/oauth/:provider/revoke", (c) => router.handlers.revoke(c.req.raw));
+```
+
+For Express, adapt via `@whatwg-node/server` or similar — the module does not depend on any framework.
+
+## Providers
+
+Built-in adapters self-register on import. Consumers pass the ones they want in `config.providers`.
+
+| Adapter | Refresh tokens | Notes |
+|---------|----------------|-------|
+| `notionProvider` | No | Notion tokens don't expire |
+| `googleProvider` | Yes | `access_type=offline&prompt=consent` |
+| `atlassianProvider` | Yes | `audience=api.atlassian.com` |
+| `slackProvider` | Yes | Reads `authed_user.access_token` |
+| `hubspotProvider` | Yes | Space-separated scopes |
+
+Add a custom provider by calling `registerProvider("name", factoryFn)`.
+
+## Storage backends
+
+- **`InMemoryTokenStorage`** — tests, local dev. No persistence.
+- **`DDBKmsTokenStorage`** — production. DynamoDB with KMS envelope encryption. `EncryptionContext` is bound to `{ purpose, userId, provider }` so leaked blobs cannot be decrypted cross-user.
+
+The AWS SDK packages are declared as **optional peer dependencies**. Install them only if you use `DDBKmsTokenStorage`:
+
+```sh
+npm install @aws-sdk/client-dynamodb @aws-sdk/client-kms @smithy/node-http-handler
+```
+
+## Security
+
+- PKCE (S256) is always on. The `code_verifier` lives in the signed state cookie — no server-side state table.
+- The state cookie uses HMAC-SHA256 with a 10-minute TTL and `timingSafeEqual` comparison.
+- The callback rejects if `state.userId` doesn't match `resolveUserId(req)`.
+- Access and refresh tokens are redacted before they reach the logger.
+- Refresh failures do not retry — the token is deleted, a revocation event fires with `reason: "refresh-failed"`, and `getValidToken` returns `null`.
+
+## Environment variables
+
+| Variable | Required? | Purpose |
+|----------|-----------|---------|
+| `OAUTH_STATE_SIGNING_SECRET` | always | HMAC-SHA256 key for the signed state cookie. Use `openssl rand -base64 48` |
+| `<PROVIDER>_CLIENT_ID` | per enabled provider | OAuth client ID (one set per provider you wire in) |
+| `<PROVIDER>_CLIENT_SECRET` | per enabled provider | OAuth client secret |
+| `<PROVIDER>_REDIRECT_URI` | per enabled provider | Exact-match redirect URI registered with the provider |
+| `AWS_REGION` | DDBKms only | Region for DynamoDB + KMS clients |
+| `OAUTH_TOKEN_TABLE` | DDBKms only | DynamoDB table name — PK `userId` (S), SK `provider` (S) |
+| `OAUTH_KMS_KEY_ID` | DDBKms only | KMS key ID or alias used for envelope encryption |
+
+Full template with commented examples per provider lives in `.env.example`.
+
+## Project Structure
+
+```text
+src/
+  oauth/
+    index.ts
+    types.ts
+    router.ts
+    state.ts
+    pkce.ts
+    refresh.ts
+    errors.ts
+    logger.ts
+    handlers/
+      start.ts
+      callback.ts
+      refresh.ts
+      revoke.ts
+    providers/
+      types.ts
+      registry.ts
+      index.ts
+      notion.ts
+      google.ts
+      atlassian.ts
+      slack.ts
+      hubspot.ts
+    storage/
+      types.ts
+      memory.ts
+      ddb-kms.ts
+    __tests__/
+      state.test.ts
+      pkce.test.ts
+      refresh.test.ts
+      router.test.ts
+      logger-redaction.test.ts
+      providers/
+        notion.test.ts
+        google.test.ts
+        atlassian.test.ts
+        slack.test.ts
+        hubspot.test.ts
+      storage/
+        memory.test.ts
+        ddb-kms.test.ts
+```

--- a/templates/module-oauth-delegation/skeleton/eslint.config.js
+++ b/templates/module-oauth-delegation/skeleton/eslint.config.js
@@ -1,0 +1,25 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
+  {
+    ignores: ["dist/", "node_modules/"],
+  },
+);

--- a/templates/module-oauth-delegation/skeleton/package.json
+++ b/templates/module-oauth-delegation/skeleton/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "__PROJECT_NAME__",
+  "version": "0.1.0",
+  "description": "__DESCRIPTION__",
+  "type": "module",
+  "main": "dist/oauth/index.js",
+  "types": "dist/oauth/index.d.ts",
+  "exports": {
+    ".": "./dist/oauth/index.js",
+    "./providers": "./dist/oauth/providers/index.js",
+    "./storage": "./dist/oauth/storage/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsx --watch src/oauth/index.ts",
+    "start": "node dist/oauth/index.js",
+    "lint": "eslint src/",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.600.0",
+    "@aws-sdk/client-kms": "^3.600.0",
+    "@smithy/node-http-handler": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-dynamodb": { "optional": true },
+    "@aws-sdk/client-kms": { "optional": true },
+    "@smithy/node-http-handler": { "optional": true }
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.600.0",
+    "@aws-sdk/client-kms": "^3.600.0",
+    "@eslint/js": "^9.20.0",
+    "@smithy/node-http-handler": "^3.0.0",
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
+    "aws-sdk-client-mock": "^4.1.0",
+    "eslint": "^9.20.0",
+    "prettier": "^3.5.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0",
+    "typescript-eslint": "^8.25.0",
+    "vitest": "^3.1.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/logger-redaction.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/logger-redaction.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { logger } from "../logger.js";
+
+function captureStdout(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  const intercept = (chunk: unknown): boolean => {
+    if (typeof chunk === "string") lines.push(chunk);
+    return true;
+  };
+  process.stdout.write = intercept as typeof process.stdout.write;
+  process.stderr.write = intercept as typeof process.stderr.write;
+  return {
+    lines,
+    restore: () => {
+      process.stdout.write = orig;
+      process.stderr.write = origErr;
+    },
+  };
+}
+
+describe("logger redaction", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("never emits accessToken in log output", () => {
+    const cap = captureStdout();
+    try {
+      logger.warn("refresh failed", {
+        accessToken: "supersecret-access",
+        refreshToken: "supersecret-refresh",
+        userId: "u1",
+      });
+    } finally {
+      cap.restore();
+    }
+    const joined = cap.lines.join("");
+    expect(joined).not.toContain("supersecret-access");
+    expect(joined).not.toContain("supersecret-refresh");
+    expect(joined).toContain("[redacted]");
+    expect(joined).toContain("u1");
+  });
+
+  it("redacts nested access_token / refresh_token snake_case", () => {
+    const cap = captureStdout();
+    try {
+      logger.info("token grant parsed", {
+        provider: "google",
+        raw: {
+          access_token: "leaked-one",
+          refresh_token: "leaked-two",
+          scope: "openid",
+        },
+      });
+    } finally {
+      cap.restore();
+    }
+    const joined = cap.lines.join("");
+    expect(joined).not.toContain("leaked-one");
+    expect(joined).not.toContain("leaked-two");
+    expect(joined).toContain("openid");
+    expect(joined).toContain("google");
+  });
+
+  it("redacts code and codeVerifier", () => {
+    const cap = captureStdout();
+    try {
+      logger.debug("exchange", {
+        code: "auth-code-xyz",
+        codeVerifier: "verifier-abc",
+        clientSecret: "shh",
+      });
+    } finally {
+      cap.restore();
+    }
+    const joined = cap.lines.join("");
+    expect(joined).not.toContain("auth-code-xyz");
+    expect(joined).not.toContain("verifier-abc");
+    expect(joined).not.toContain("shh");
+  });
+
+  it("preserves non-sensitive fields through arrays", () => {
+    const cap = captureStdout();
+    try {
+      logger.info("providers listed", { items: [{ name: "notion" }, { name: "google" }] });
+    } finally {
+      cap.restore();
+    }
+    const joined = cap.lines.join("");
+    expect(joined).toContain("notion");
+    expect(joined).toContain("google");
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/pkce.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/pkce.test.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { codeChallenge, generateCodeVerifier } from "../pkce.js";
+
+describe("pkce", () => {
+  it("generates a 43-character base64url verifier", () => {
+    const v = generateCodeVerifier();
+    expect(v).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("produces distinct verifiers per call", () => {
+    const a = generateCodeVerifier();
+    const b = generateCodeVerifier();
+    expect(a).not.toBe(b);
+  });
+
+  it("computes S256 challenge as base64url(sha256(verifier))", () => {
+    const v = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const expected = createHash("sha256")
+      .update(v)
+      .digest("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(codeChallenge(v)).toBe(expected);
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/atlassian.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/atlassian.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { atlassianProvider } from "../../providers/atlassian.js";
+import { getProvider } from "../../providers/registry.js";
+
+describe("atlassianProvider", () => {
+  it("self-registers under name 'atlassian'", () => {
+    expect(getProvider("atlassian")?.name).toBe("atlassian");
+  });
+
+  it("auth URL targets api.atlassian.com audience + PKCE", () => {
+    expect(atlassianProvider.authUrl).toContain("audience=api.atlassian.com");
+    expect(atlassianProvider.authUrl).toContain("{code_challenge}");
+    expect(atlassianProvider.authUrl).toContain("prompt=consent");
+  });
+
+  it("default scopes include offline_access for refresh tokens", () => {
+    expect(atlassianProvider.defaultScopes).toContain("offline_access");
+  });
+
+  it("parses token response with refresh token + scope", () => {
+    const grant = atlassianProvider.parseTokenResponse({
+      access_token: "eyJ.atlassian",
+      refresh_token: "atl-refresh",
+      expires_in: 3600,
+      scope: "read:confluence-content.all",
+    });
+    expect(grant.accessToken).toBe("eyJ.atlassian");
+    expect(grant.refreshToken).toBe("atl-refresh");
+    expect(grant.scope).toContain("confluence-content");
+  });
+
+  it("refresh reuses previous refresh token when absent", () => {
+    const grant = atlassianProvider.refreshTokenResponse!(
+      { access_token: "new", expires_in: 3600 },
+      { accessToken: "old", refreshToken: "keep" },
+    );
+    expect(grant.refreshToken).toBe("keep");
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/google.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/google.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { googleProvider } from "../../providers/google.js";
+import { getProvider } from "../../providers/registry.js";
+
+describe("googleProvider", () => {
+  it("self-registers under name 'google'", () => {
+    expect(getProvider("google")?.name).toBe("google");
+  });
+
+  it("auth URL includes offline access + consent prompt + PKCE", () => {
+    expect(googleProvider.authUrl).toContain("access_type=offline");
+    expect(googleProvider.authUrl).toContain("prompt=consent");
+    expect(googleProvider.authUrl).toContain("{code_challenge}");
+    expect(googleProvider.authUrl).toContain("{scope}");
+  });
+
+  it("parses token response with expiry and refresh token", () => {
+    const before = Math.floor(Date.now() / 1000);
+    const grant = googleProvider.parseTokenResponse({
+      access_token: "ya29.a0AfH6...",
+      refresh_token: "1//0GL...",
+      expires_in: 3599,
+      scope: "https://www.googleapis.com/auth/drive.readonly",
+    });
+    expect(grant.accessToken).toBe("ya29.a0AfH6...");
+    expect(grant.refreshToken).toBe("1//0GL...");
+    expect(grant.expiresAt).toBeGreaterThanOrEqual(before + 3599);
+    expect(grant.scope).toContain("drive.readonly");
+  });
+
+  it("refresh response reuses previous refresh token when missing", () => {
+    const previous = { accessToken: "old", refreshToken: "keep-me" };
+    const grant = googleProvider.refreshTokenResponse!(
+      { access_token: "new", expires_in: 3600 },
+      previous,
+    );
+    expect(grant.accessToken).toBe("new");
+    expect(grant.refreshToken).toBe("keep-me");
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/hubspot.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/hubspot.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { hubspotProvider } from "../../providers/hubspot.js";
+import { getProvider } from "../../providers/registry.js";
+
+describe("hubspotProvider", () => {
+  it("self-registers under name 'hubspot'", () => {
+    expect(getProvider("hubspot")?.name).toBe("hubspot");
+  });
+
+  it("auth URL includes scope placeholder + PKCE", () => {
+    expect(hubspotProvider.authUrl).toContain("{scope}");
+    expect(hubspotProvider.authUrl).toContain("{code_challenge}");
+  });
+
+  it("parses token response with expiry + refresh token", () => {
+    const grant = hubspotProvider.parseTokenResponse({
+      access_token: "hs-access",
+      refresh_token: "hs-refresh",
+      expires_in: 1800,
+    });
+    expect(grant.accessToken).toBe("hs-access");
+    expect(grant.refreshToken).toBe("hs-refresh");
+    expect(grant.expiresAt).toBeGreaterThan(0);
+  });
+
+  it("refresh response reuses previous refresh token when omitted", () => {
+    const grant = hubspotProvider.refreshTokenResponse!(
+      { access_token: "new", expires_in: 1800 },
+      { accessToken: "old", refreshToken: "keep" },
+    );
+    expect(grant.refreshToken).toBe("keep");
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/notion.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/notion.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { notionProvider } from "../../providers/notion.js";
+import { getProvider } from "../../providers/registry.js";
+
+describe("notionProvider", () => {
+  it("self-registers under name 'notion'", () => {
+    const registered = getProvider("notion");
+    expect(registered).toBeDefined();
+    expect(registered!.name).toBe("notion");
+  });
+
+  it("has a PKCE-ready auth URL", () => {
+    expect(notionProvider.authUrl).toContain("{code_challenge}");
+    expect(notionProvider.authUrl).toContain("{code_challenge_method}");
+    expect(notionProvider.authUrl).toContain("{state}");
+    expect(notionProvider.authUrl).toContain("{client_id}");
+    expect(notionProvider.authUrl).toContain("{redirect_uri}");
+    expect(notionProvider.usePkce).toBe(true);
+  });
+
+  it("parses token response with no expiry and no refresh token", () => {
+    const grant = notionProvider.parseTokenResponse({
+      access_token: "secret_notion_token",
+      bot_id: "b1",
+      workspace_id: "w1",
+    });
+    expect(grant.accessToken).toBe("secret_notion_token");
+    expect(grant.expiresAt).toBeUndefined();
+    expect(grant.refreshToken).toBeUndefined();
+    expect(grant.raw).toMatchObject({ bot_id: "b1", workspace_id: "w1" });
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/slack.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/providers/slack.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { slackProvider } from "../../providers/slack.js";
+import { getProvider } from "../../providers/registry.js";
+
+describe("slackProvider", () => {
+  it("self-registers under name 'slack'", () => {
+    expect(getProvider("slack")?.name).toBe("slack");
+  });
+
+  it("auth URL uses user_scope (not scope) and PKCE", () => {
+    expect(slackProvider.authUrl).toContain("user_scope={scope}");
+    expect(slackProvider.authUrl).toContain("{code_challenge}");
+  });
+
+  it("parses token response from authed_user.access_token", () => {
+    const grant = slackProvider.parseTokenResponse({
+      ok: true,
+      access_token: "xoxb-bot", // should be ignored
+      authed_user: {
+        id: "U1",
+        access_token: "xoxp-user",
+        refresh_token: "xoxe-refresh",
+        expires_in: 43200,
+        scope: "channels:read,chat:write",
+      },
+      team: { id: "T1" },
+    });
+    expect(grant.accessToken).toBe("xoxp-user");
+    expect(grant.refreshToken).toBe("xoxe-refresh");
+    expect(grant.scope).toContain("channels:read");
+  });
+
+  it("falls back to top-level access_token when authed_user is absent", () => {
+    const grant = slackProvider.parseTokenResponse({
+      ok: true,
+      access_token: "xoxb-bot",
+    });
+    expect(grant.accessToken).toBe("xoxb-bot");
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/refresh.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/refresh.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TokenRefresher } from "../refresh.js";
+import { InMemoryTokenStorage } from "../storage/memory.js";
+import type { OAuthProvider, RevocationEmitter } from "../types.js";
+
+function testProvider(): OAuthProvider {
+  return {
+    name: "test",
+    authUrl: "https://example.com/authorize?state={state}",
+    tokenUrl: "https://example.com/token",
+    revokeUrl: "https://example.com/revoke",
+    defaultScopes: ["read"],
+    usePkce: true,
+    parseTokenResponse(raw) {
+      const r = raw as { access_token: string; refresh_token?: string; expires_in?: number };
+      return {
+        accessToken: r.access_token,
+        refreshToken: r.refresh_token,
+        expiresAt: r.expires_in ? 2_000_000_000 + r.expires_in : undefined,
+      };
+    },
+  };
+}
+
+function tokenResponse(body: object, ok = true, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status: ok ? status : status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function creds() {
+  return {
+    test: { clientId: "id", clientSecret: "secret", redirectUri: "https://app/cb" },
+  };
+}
+
+describe("TokenRefresher.getValidToken", () => {
+  let storage: InMemoryTokenStorage;
+  let emitted: Array<{ userId: string; provider: string; reason: string }>;
+  let emitter: RevocationEmitter;
+
+  beforeEach(() => {
+    storage = new InMemoryTokenStorage();
+    emitted = [];
+    emitter = {
+      async emit(event) {
+        emitted.push(event);
+      },
+    };
+  });
+
+  it("returns stored token when not expiring", async () => {
+    await storage.put("u1", "test", {
+      accessToken: "current",
+      refreshToken: "r",
+      expiresAt: 9_999_999_999,
+    });
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, now: () => 1_000 },
+      60,
+    );
+    expect(await refresher.getValidToken("u1", "test")).toBe("current");
+  });
+
+  it("returns null when no grant stored", async () => {
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, now: () => 1_000 },
+      60,
+    );
+    expect(await refresher.getValidToken("u1", "test")).toBeNull();
+  });
+
+  it("refreshes when expiresAt is within lead time, passes AbortSignal to fetch", async () => {
+    await storage.put("u1", "test", {
+      accessToken: "old",
+      refreshToken: "r1",
+      expiresAt: 1_000 + 30, // within 60s lead
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      tokenResponse({ access_token: "new", expires_in: 3600 }),
+    );
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, fetchImpl, now: () => 1_000 },
+      60,
+    );
+    expect(await refresher.getValidToken("u1", "test")).toBe("new");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const stored = await storage.get("u1", "test");
+    expect(stored?.accessToken).toBe("new");
+    expect(stored?.refreshToken).toBe("r1"); // reused
+
+    const [, init] = fetchImpl.mock.calls[0];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("deletes and emits on refresh rejection", async () => {
+    await storage.put("u1", "test", {
+      accessToken: "old",
+      refreshToken: "r1",
+      expiresAt: 1_000 + 10,
+    });
+    const fetchImpl = vi.fn(async () => new Response("bad", { status: 401 }));
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, emitter, fetchImpl, now: () => 1_000 },
+      60,
+    );
+    expect(await refresher.getValidToken("u1", "test")).toBeNull();
+    expect(await storage.get("u1", "test")).toBeNull();
+    expect(emitted).toEqual([{ userId: "u1", provider: "test", reason: "refresh-failed" }]);
+  });
+
+  it("deletes and emits on refresh network error", async () => {
+    await storage.put("u1", "test", {
+      accessToken: "old",
+      refreshToken: "r1",
+      expiresAt: 1_000 + 10,
+    });
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("econnreset");
+    });
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, emitter, fetchImpl, now: () => 1_000 },
+      60,
+    );
+    expect(await refresher.getValidToken("u1", "test")).toBeNull();
+    expect(emitted[0].reason).toBe("refresh-failed");
+  });
+
+  it("does not retry on failure — one attempt only", async () => {
+    await storage.put("u1", "test", {
+      accessToken: "old",
+      refreshToken: "r1",
+      expiresAt: 1_000 + 10,
+    });
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 500 }));
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, emitter, fetchImpl, now: () => 1_000 },
+      60,
+    );
+    await refresher.getValidToken("u1", "test");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent refreshes for the same key", async () => {
+    await storage.put("u1", "test", {
+      accessToken: "old",
+      refreshToken: "r1",
+      expiresAt: 1_000 + 10,
+    });
+    let resolve: ((r: Response) => void) | undefined;
+    const firstResponse = new Promise<Response>((r) => {
+      resolve = r;
+    });
+    const fetchImpl = vi.fn(async () => firstResponse);
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, fetchImpl, now: () => 1_000 },
+      60,
+    );
+
+    const a = refresher.getValidToken("u1", "test");
+    const b = refresher.getValidToken("u1", "test");
+    const c = refresher.getValidToken("u1", "test");
+
+    // Allow the inflight map to be populated before resolving.
+    await new Promise((r) => setImmediate(r));
+
+    resolve!(tokenResponse({ access_token: "new", expires_in: 3600 }));
+
+    const [ra, rb, rc] = await Promise.all([a, b, c]);
+    expect(ra).toBe("new");
+    expect(rb).toBe("new");
+    expect(rc).toBe("new");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns existing grant when no refresh token present", async () => {
+    await storage.put("u1", "test", {
+      accessToken: "still-valid",
+      expiresAt: 1_000 + 10, // expiring, but no refresh token
+    });
+    const fetchImpl = vi.fn();
+    const refresher = new TokenRefresher(
+      { test: testProvider() },
+      creds(),
+      { storage, fetchImpl, now: () => 1_000 },
+      60,
+    );
+    expect(await refresher.getValidToken("u1", "test")).toBe("still-valid");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/router.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/router.test.ts
@@ -1,0 +1,427 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createOAuthRouter } from "../router.js";
+import { STATE_COOKIE_NAME, signState, type StatePayload } from "../state.js";
+import { InMemoryTokenStorage } from "../storage/memory.js";
+import type { OAuthProvider, OAuthRouterConfig, RevocationEmitter } from "../types.js";
+
+const SECRET = "test-state-signing-secret-min-16-chars";
+
+function fakeProvider(): OAuthProvider {
+  return {
+    name: "test",
+    authUrl:
+      "https://provider.example/authorize" +
+      "?client_id={client_id}" +
+      "&redirect_uri={redirect_uri}" +
+      "&scope={scope}" +
+      "&state={state}" +
+      "&code_challenge={code_challenge}" +
+      "&code_challenge_method={code_challenge_method}",
+    tokenUrl: "https://provider.example/token",
+    revokeUrl: "https://provider.example/revoke",
+    defaultScopes: ["read"],
+    usePkce: true,
+    parseTokenResponse(raw) {
+      const r = raw as { access_token: string; refresh_token?: string; expires_in?: number };
+      return {
+        accessToken: r.access_token,
+        refreshToken: r.refresh_token,
+        expiresAt: r.expires_in ? 1_000 + r.expires_in : undefined,
+      };
+    },
+  };
+}
+
+function makeConfig(
+  storage: InMemoryTokenStorage,
+  overrides: Partial<OAuthRouterConfig> = {},
+): OAuthRouterConfig {
+  return {
+    providers: { test: fakeProvider() },
+    storage,
+    stateSigningSecret: SECRET,
+    resolveUserId: async (req) => req.headers.get("x-user-id"),
+    clientCredentials: {
+      test: { clientId: "cid", clientSecret: "csec", redirectUri: "https://app/cb" },
+    },
+    ...overrides,
+  };
+}
+
+function tokenResponse(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function signedStateFor(overrides: Partial<StatePayload> = {}, createdAt = 1_000): string {
+  const payload: StatePayload = {
+    nonce: "abc",
+    userId: "u1",
+    provider: "test",
+    returnTo: "/done",
+    createdAt,
+    codeVerifier: "v".repeat(43),
+    ...overrides,
+  };
+  return signState(payload, SECRET);
+}
+
+describe("createOAuthRouter", () => {
+  let storage: InMemoryTokenStorage;
+  let emitted: Array<{ userId: string; provider: string; reason: string }>;
+  let emitter: RevocationEmitter;
+
+  beforeEach(() => {
+    storage = new InMemoryTokenStorage();
+    emitted = [];
+    emitter = {
+      async emit(event) {
+        emitted.push(event);
+      },
+    };
+  });
+
+  describe("start", () => {
+    it("redirects with signed state cookie and PKCE challenge", async () => {
+      const router = createOAuthRouter(makeConfig(storage));
+      const req = new Request("https://app.example/oauth/test/start?returnTo=/after", {
+        headers: { "x-user-id": "u1" },
+      });
+      const res = await router.handlers.start(req);
+      expect(res.status).toBe(302);
+      const location = res.headers.get("location")!;
+      expect(location).toContain("client_id=cid");
+      expect(location).toContain("scope=read");
+      expect(location).toContain("code_challenge_method=S256");
+      expect(location).toMatch(/code_challenge=[A-Za-z0-9%_-]+/);
+      const setCookie = res.headers.get("set-cookie")!;
+      expect(setCookie).toContain(`${STATE_COOKIE_NAME}=`);
+      expect(setCookie).toContain("HttpOnly");
+      expect(setCookie).toContain("Secure");
+    });
+
+    it("401s when the caller is unauthenticated", async () => {
+      const router = createOAuthRouter(makeConfig(storage));
+      const req = new Request("https://app.example/oauth/test/start");
+      const res = await router.handlers.start(req);
+      expect(res.status).toBe(401);
+    });
+
+    it("404s for unknown provider", async () => {
+      const router = createOAuthRouter(makeConfig(storage));
+      const req = new Request("https://app.example/oauth/unknown/start", {
+        headers: { "x-user-id": "u1" },
+      });
+      const res = await router.handlers.start(req);
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects an absolute returnTo and falls back to /", async () => {
+      const router = createOAuthRouter(makeConfig(storage), { now: () => 1_000 });
+      const req = new Request(
+        "https://app.example/oauth/test/start?returnTo=https://evil.example/harvest",
+        { headers: { "x-user-id": "u1" } },
+      );
+      const res = await router.handlers.start(req);
+      expect(res.status).toBe(302);
+      // Pull the signed state cookie, verify its returnTo did not pick up the evil URL.
+      const setCookie = res.headers.get("set-cookie")!;
+      const value = setCookie.split(";")[0].split("=").slice(1).join("=");
+      const [body] = value.split(".");
+      const pad = body.length % 4 === 0 ? "" : "=".repeat(4 - (body.length % 4));
+      const decoded = Buffer.from(
+        body.replace(/-/g, "+").replace(/_/g, "/") + pad,
+        "base64",
+      ).toString("utf-8");
+      expect(JSON.parse(decoded).returnTo).toBe("/");
+    });
+
+    it("rejects a protocol-relative returnTo", async () => {
+      const router = createOAuthRouter(makeConfig(storage), { now: () => 1_000 });
+      const req = new Request(
+        "https://app.example/oauth/test/start?returnTo=//evil.example/steal",
+        { headers: { "x-user-id": "u1" } },
+      );
+      const res = await router.handlers.start(req);
+      expect(res.status).toBe(302);
+      const setCookie = res.headers.get("set-cookie")!;
+      const value = setCookie.split(";")[0].split("=").slice(1).join("=");
+      const [body] = value.split(".");
+      const pad = body.length % 4 === 0 ? "" : "=".repeat(4 - (body.length % 4));
+      const decoded = Buffer.from(
+        body.replace(/-/g, "+").replace(/_/g, "/") + pad,
+        "base64",
+      ).toString("utf-8");
+      expect(JSON.parse(decoded).returnTo).toBe("/");
+    });
+  });
+
+  describe("callback", () => {
+    it("exchanges code, stores tokens, redirects to returnTo", async () => {
+      const fetchImpl = vi.fn<typeof fetch>(
+        async () => tokenResponse({ access_token: "A", refresh_token: "R", expires_in: 3600 }),
+      );
+      const router = createOAuthRouter(makeConfig(storage), { fetchImpl, now: () => 1_000 });
+
+      const signed = signedStateFor({ nonce: "abc" }, 1_000);
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=abc",
+        {
+          headers: {
+            "x-user-id": "u1",
+            cookie: `${STATE_COOKIE_NAME}=${signed}`,
+          },
+        },
+      );
+      const res = await router.handlers.callback(req);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/done");
+
+      const stored = await storage.get("u1", "test");
+      expect(stored?.accessToken).toBe("A");
+      expect(stored?.refreshToken).toBe("R");
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [, init] = fetchImpl.mock.calls[0];
+      const body = (init?.body as URLSearchParams).toString();
+      expect(body).toContain("code=XYZ");
+      expect(body).toContain("code_verifier=");
+    });
+
+    it("rejects a tampered state cookie with 400", async () => {
+      const router = createOAuthRouter(makeConfig(storage), { now: () => 1_000 });
+      const signed = signedStateFor({ nonce: "abc" }, 1_000);
+      const tampered = `${signed}XX`;
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=abc",
+        {
+          headers: {
+            "x-user-id": "u1",
+            cookie: `${STATE_COOKIE_NAME}=${tampered}`,
+          },
+        },
+      );
+      const res = await router.handlers.callback(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects an expired state cookie with 400", async () => {
+      const router = createOAuthRouter(makeConfig(storage), { now: () => 10_000 });
+      const signed = signedStateFor({ nonce: "abc" }, 1_000); // ~9000s old
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=abc",
+        {
+          headers: {
+            "x-user-id": "u1",
+            cookie: `${STATE_COOKIE_NAME}=${signed}`,
+          },
+        },
+      );
+      const res = await router.handlers.callback(req);
+      expect(res.status).toBe(400);
+      expect(await res.text()).toBe("state_expired");
+    });
+
+    it("rejects when the caller's userId does not match state.userId", async () => {
+      const router = createOAuthRouter(makeConfig(storage), { now: () => 1_000 });
+      const signed = signedStateFor({ nonce: "abc", userId: "u1" }, 1_000);
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=abc",
+        {
+          headers: {
+            "x-user-id": "u2", // different from u1
+            cookie: `${STATE_COOKIE_NAME}=${signed}`,
+          },
+        },
+      );
+      const res = await router.handlers.callback(req);
+      expect(res.status).toBe(400);
+      expect(await res.text()).toBe("user_mismatch");
+    });
+
+    it("rejects when the nonce in query does not match state", async () => {
+      const router = createOAuthRouter(makeConfig(storage), { now: () => 1_000 });
+      const signed = signedStateFor({ nonce: "abc" }, 1_000);
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=different",
+        {
+          headers: {
+            "x-user-id": "u1",
+            cookie: `${STATE_COOKIE_NAME}=${signed}`,
+          },
+        },
+      );
+      const res = await router.handlers.callback(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("sends code_verifier in the token exchange body", async () => {
+      const fetchImpl = vi.fn<typeof fetch>(async () =>
+        tokenResponse({ access_token: "A", expires_in: 3600 }),
+      );
+      const router = createOAuthRouter(makeConfig(storage), { fetchImpl, now: () => 1_000 });
+      const signed = signedStateFor({ nonce: "abc", codeVerifier: "my-verifier-value" }, 1_000);
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=abc",
+        {
+          headers: {
+            "x-user-id": "u1",
+            cookie: `${STATE_COOKIE_NAME}=${signed}`,
+          },
+        },
+      );
+      await router.handlers.callback(req);
+      const [, init] = fetchImpl.mock.calls[0];
+      const body = (init?.body as URLSearchParams).toString();
+      expect(body).toContain("code_verifier=my-verifier-value");
+    });
+
+    it("passes an AbortSignal to the token endpoint fetch", async () => {
+      const fetchImpl = vi.fn<typeof fetch>(async () =>
+        tokenResponse({ access_token: "A", expires_in: 3600 }),
+      );
+      const router = createOAuthRouter(makeConfig(storage), { fetchImpl, now: () => 1_000 });
+      const signed = signedStateFor({ nonce: "abc" }, 1_000);
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=abc",
+        {
+          headers: {
+            "x-user-id": "u1",
+            cookie: `${STATE_COOKIE_NAME}=${signed}`,
+          },
+        },
+      );
+      await router.handlers.callback(req);
+      const [, init] = fetchImpl.mock.calls[0];
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("returns 502 when the provider rejects the code exchange", async () => {
+      const fetchImpl = vi.fn(async () => new Response("bad", { status: 400 }));
+      const router = createOAuthRouter(makeConfig(storage), { fetchImpl, now: () => 1_000 });
+      const signed = signedStateFor({ nonce: "abc" }, 1_000);
+      const req = new Request(
+        "https://app.example/oauth/test/callback?code=XYZ&state=abc",
+        {
+          headers: {
+            "x-user-id": "u1",
+            cookie: `${STATE_COOKIE_NAME}=${signed}`,
+          },
+        },
+      );
+      const res = await router.handlers.callback(req);
+      expect(res.status).toBe(502);
+    });
+  });
+
+  describe("getValidToken", () => {
+    it("triggers refresh when stored token is expiring", async () => {
+      const fetchImpl = vi.fn(
+        async () => tokenResponse({ access_token: "refreshed", expires_in: 3600 }),
+      );
+      const router = createOAuthRouter(makeConfig(storage, { revocationEmitter: emitter }), {
+        fetchImpl,
+        now: () => 1_000,
+      });
+      await storage.put("u1", "test", {
+        accessToken: "old",
+        refreshToken: "r1",
+        expiresAt: 1_010,
+      });
+      const token = await router.getValidToken("u1", "test");
+      expect(token).toBe("refreshed");
+      expect((await storage.get("u1", "test"))!.accessToken).toBe("refreshed");
+    });
+
+    it("returns null and purges storage when refresh fails", async () => {
+      const fetchImpl = vi.fn(async () => new Response("bad", { status: 401 }));
+      const router = createOAuthRouter(makeConfig(storage, { revocationEmitter: emitter }), {
+        fetchImpl,
+        now: () => 1_000,
+      });
+      await storage.put("u1", "test", {
+        accessToken: "old",
+        refreshToken: "r1",
+        expiresAt: 1_010,
+      });
+      const token = await router.getValidToken("u1", "test");
+      expect(token).toBeNull();
+      expect(await storage.get("u1", "test")).toBeNull();
+      expect(emitted[0].reason).toBe("refresh-failed");
+    });
+
+    it("returns null when provider is unknown", async () => {
+      const router = createOAuthRouter(makeConfig(storage));
+      expect(await router.getValidToken("u1", "never-registered")).toBeNull();
+    });
+  });
+
+  describe("revocation", () => {
+    it("revokeTokens deletes stored grant and emits event", async () => {
+      const router = createOAuthRouter(makeConfig(storage, { revocationEmitter: emitter }));
+      await storage.put("u1", "test", { accessToken: "A" });
+      await router.revokeTokens("u1", "test");
+      expect(await storage.get("u1", "test")).toBeNull();
+      expect(emitted).toEqual([{ userId: "u1", provider: "test", reason: "user" }]);
+    });
+
+    it("revokeAllForUser wipes the user and emits per provider with offboarding reason", async () => {
+      const router = createOAuthRouter(makeConfig(storage, { revocationEmitter: emitter }));
+      await storage.put("u1", "test", { accessToken: "A" });
+      await router.revokeAllForUser("u1");
+      expect(await storage.get("u1", "test")).toBeNull();
+      expect(emitted).toEqual([{ userId: "u1", provider: "test", reason: "offboarding" }]);
+    });
+
+    it("revoke handler calls provider revoke URL and deletes", async () => {
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+      const router = createOAuthRouter(
+        makeConfig(storage, { revocationEmitter: emitter }),
+        { fetchImpl },
+      );
+      await storage.put("u1", "test", { accessToken: "A" });
+      const req = new Request("https://app.example/oauth/test/revoke", {
+        method: "POST",
+        headers: { "x-user-id": "u1" },
+      });
+      const res = await router.handlers.revoke(req);
+      expect(res.status).toBe(204);
+      expect(fetchImpl).toHaveBeenCalledWith(
+        "https://provider.example/revoke",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(await storage.get("u1", "test")).toBeNull();
+      expect(emitted[0].reason).toBe("user");
+    });
+  });
+
+  describe("refresh handler", () => {
+    it("forces a refresh for the given user+provider", async () => {
+      const fetchImpl = vi.fn(async () =>
+        tokenResponse({ access_token: "forced", expires_in: 3600 }),
+      );
+      const router = createOAuthRouter(makeConfig(storage), { fetchImpl, now: () => 1_000 });
+      await storage.put("u1", "test", {
+        accessToken: "old",
+        refreshToken: "r1",
+        expiresAt: 9_999_999_999, // not expiring, but refresh handler forces it
+      });
+      const req = new Request("https://app.example/oauth/test/refresh", {
+        method: "POST",
+        headers: { "x-user-id": "u1" },
+      });
+      const res = await router.handlers.refresh(req);
+      expect(res.status).toBe(200);
+      expect((await storage.get("u1", "test"))!.accessToken).toBe("forced");
+    });
+  });
+
+  it("throws when stateSigningSecret is too short", () => {
+    expect(() =>
+      createOAuthRouter(makeConfig(new InMemoryTokenStorage(), { stateSigningSecret: "short" })),
+    ).toThrow(/at least 16/);
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/state.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/state.test.ts
@@ -1,0 +1,114 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { StateExpiredError, StateMissingError, StateTamperedError } from "../errors.js";
+import {
+  assertStateFresh,
+  buildStateCookie,
+  clearStateCookie,
+  generateNonce,
+  readStateCookie,
+  signState,
+  STATE_COOKIE_NAME,
+  verifyState,
+  type StatePayload,
+} from "../state.js";
+
+const SECRET = "test-signing-secret-very-long-and-random";
+
+function payload(overrides: Partial<StatePayload> = {}): StatePayload {
+  return {
+    nonce: "nonce-1",
+    userId: "user-1",
+    provider: "notion",
+    returnTo: "/done",
+    createdAt: 1_000_000,
+    codeVerifier: "v".repeat(43),
+    ...overrides,
+  };
+}
+
+describe("state cookie", () => {
+  it("round-trips a signed payload", () => {
+    const signed = signState(payload(), SECRET);
+    const parsed = verifyState(signed, SECRET);
+    expect(parsed.nonce).toBe("nonce-1");
+    expect(parsed.userId).toBe("user-1");
+  });
+
+  it("rejects a tampered body", () => {
+    const signed = signState(payload(), SECRET);
+    const [body, sig] = signed.split(".");
+    // Mutate the body but keep the old signature.
+    const tampered = `${body}XX.${sig}`;
+    expect(() => verifyState(tampered, SECRET)).toThrow(StateTamperedError);
+  });
+
+  it("rejects a wrong signing key", () => {
+    const signed = signState(payload(), SECRET);
+    expect(() => verifyState(signed, "different-secret")).toThrow(StateTamperedError);
+  });
+
+  it("rejects a missing signature", () => {
+    expect(() => verifyState("no-dot", SECRET)).toThrow(StateTamperedError);
+  });
+
+  it("rejects non-JSON body with valid signature", () => {
+    const body = Buffer.from("not-json", "utf-8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const sig = createHmac("sha256", SECRET)
+      .update(body)
+      .digest("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(() => verifyState(`${body}.${sig}`, SECRET)).toThrow(StateTamperedError);
+  });
+
+  it("assertStateFresh rejects when older than TTL", () => {
+    const p = payload({ createdAt: 1_000 });
+    expect(() => assertStateFresh(p, 600, 1_000 + 601)).toThrow(StateExpiredError);
+  });
+
+  it("assertStateFresh accepts within TTL", () => {
+    const p = payload({ createdAt: 1_000 });
+    expect(() => assertStateFresh(p, 600, 1_000 + 599)).not.toThrow();
+  });
+
+  it("buildStateCookie sets required attributes", () => {
+    const cookie = buildStateCookie("value", 600, "example.com");
+    expect(cookie).toContain(`${STATE_COOKIE_NAME}=value`);
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).toContain("Max-Age=600");
+    expect(cookie).toContain("Domain=example.com");
+  });
+
+  it("clearStateCookie uses Max-Age=0", () => {
+    const cookie = clearStateCookie();
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("readStateCookie parses the header", () => {
+    const req = new Request("https://example.com/oauth/notion/callback", {
+      headers: { cookie: `foo=bar; ${STATE_COOKIE_NAME}=signed.value; baz=qux` },
+    });
+    expect(readStateCookie(req)).toBe("signed.value");
+  });
+
+  it("readStateCookie throws when cookie missing", () => {
+    const req = new Request("https://example.com/oauth/notion/callback", {
+      headers: { cookie: "foo=bar" },
+    });
+    expect(() => readStateCookie(req)).toThrow(StateMissingError);
+  });
+
+  it("generateNonce returns hex of at least 16 bytes", () => {
+    const n = generateNonce();
+    expect(n).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/storage/ddb-kms.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/storage/ddb-kms.test.ts
@@ -1,0 +1,146 @@
+import {
+  DeleteItemCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import { DecryptCommand, EncryptCommand, KMSClient } from "@aws-sdk/client-kms";
+import { mockClient } from "aws-sdk-client-mock";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DDBKmsTokenStorage } from "../../storage/ddb-kms.js";
+
+const ddbMock = mockClient(DynamoDBClient);
+const kmsMock = mockClient(KMSClient);
+
+const TABLE = "oauth-tokens";
+const KEY_ID = "alias/oauth-tokens";
+
+function makeStorage(): DDBKmsTokenStorage {
+  return new DDBKmsTokenStorage({
+    tableName: TABLE,
+    keyId: KEY_ID,
+    ddbClient: new DynamoDBClient({}),
+    kmsClient: new KMSClient({}),
+  });
+}
+
+describe("DDBKmsTokenStorage", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    kmsMock.reset();
+  });
+
+  afterEach(() => {
+    ddbMock.reset();
+    kmsMock.reset();
+  });
+
+  it("put encrypts via KMS with EncryptionContext bound to userId+provider", async () => {
+    kmsMock
+      .on(EncryptCommand)
+      .resolves({ CiphertextBlob: new Uint8Array([1, 2, 3, 4]) });
+    ddbMock.on(PutItemCommand).resolves({});
+
+    const storage = makeStorage();
+    await storage.put("user-abc", "notion", { accessToken: "A", refreshToken: "R" });
+
+    const encryptCalls = kmsMock.commandCalls(EncryptCommand);
+    expect(encryptCalls).toHaveLength(1);
+    const input = encryptCalls[0].args[0].input;
+    expect(input.KeyId).toBe(KEY_ID);
+    expect(input.EncryptionContext).toEqual({
+      purpose: "oauth-token",
+      userId: "user-abc",
+      provider: "notion",
+    });
+
+    const putCalls = ddbMock.commandCalls(PutItemCommand);
+    expect(putCalls).toHaveLength(1);
+    const putInput = putCalls[0].args[0].input;
+    expect(putInput.TableName).toBe(TABLE);
+    expect(putInput.Item?.userId).toEqual({ S: "user-abc" });
+    expect(putInput.Item?.provider).toEqual({ S: "notion" });
+    expect(putInput.Item?.ciphertext?.B).toBeInstanceOf(Buffer);
+  });
+
+  it("get decrypts with the same EncryptionContext", async () => {
+    const plaintext = Buffer.from(JSON.stringify({ accessToken: "A", refreshToken: "R" }));
+    ddbMock.on(GetItemCommand).resolves({
+      Item: {
+        userId: { S: "user-abc" },
+        provider: { S: "notion" },
+        ciphertext: { B: Buffer.from([1, 2, 3, 4]) },
+      },
+    });
+    kmsMock.on(DecryptCommand).resolves({ Plaintext: plaintext });
+
+    const storage = makeStorage();
+    const grant = await storage.get("user-abc", "notion");
+    expect(grant).toEqual({ accessToken: "A", refreshToken: "R" });
+
+    const decryptCalls = kmsMock.commandCalls(DecryptCommand);
+    expect(decryptCalls[0].args[0].input.EncryptionContext).toEqual({
+      purpose: "oauth-token",
+      userId: "user-abc",
+      provider: "notion",
+    });
+  });
+
+  it("get returns null when the item is missing", async () => {
+    ddbMock.on(GetItemCommand).resolves({});
+    const storage = makeStorage();
+    expect(await storage.get("u", "notion")).toBeNull();
+  });
+
+  it("delete issues a DeleteItemCommand with composite key", async () => {
+    ddbMock.on(DeleteItemCommand).resolves({});
+    const storage = makeStorage();
+    await storage.delete("user-abc", "notion");
+
+    const calls = ddbMock.commandCalls(DeleteItemCommand);
+    expect(calls).toHaveLength(1);
+    const key = calls[0].args[0].input.Key!;
+    expect(key.userId).toEqual({ S: "user-abc" });
+    expect(key.provider).toEqual({ S: "notion" });
+  });
+
+  it("deleteAllForUser queries by userId PK then deletes each provider row", async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { userId: { S: "u" }, provider: { S: "notion" } },
+        { userId: { S: "u" }, provider: { S: "google" } },
+      ],
+      LastEvaluatedKey: undefined,
+    });
+    ddbMock.on(DeleteItemCommand).resolves({});
+
+    const storage = makeStorage();
+    await storage.deleteAllForUser("u");
+
+    const deleteCalls = ddbMock.commandCalls(DeleteItemCommand);
+    expect(deleteCalls).toHaveLength(2);
+    const providers = deleteCalls.map((c) => c.args[0].input.Key!.provider as { S: string });
+    expect(providers.map((p) => p.S).sort()).toEqual(["google", "notion"]);
+  });
+
+  it("rejects when KMS Encrypt returns no ciphertext", async () => {
+    kmsMock.on(EncryptCommand).resolves({});
+    const storage = makeStorage();
+    await expect(storage.put("u", "notion", { accessToken: "A" })).rejects.toThrow(/no ciphertext/);
+  });
+
+  it("rejects when KMS Decrypt returns no plaintext", async () => {
+    ddbMock.on(GetItemCommand).resolves({
+      Item: {
+        userId: { S: "u" },
+        provider: { S: "notion" },
+        ciphertext: { B: Buffer.from([1, 2]) },
+      },
+    });
+    kmsMock.on(DecryptCommand).resolves({});
+    const storage = makeStorage();
+    await expect(storage.get("u", "notion")).rejects.toThrow(/no plaintext/);
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/storage/memory.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/storage/memory.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { InMemoryTokenStorage } from "../../storage/memory.js";
+
+describe("InMemoryTokenStorage", () => {
+  let storage: InMemoryTokenStorage;
+
+  beforeEach(() => {
+    storage = new InMemoryTokenStorage();
+  });
+
+  it("round-trips a grant for a (userId, provider) pair", async () => {
+    await storage.put("u1", "notion", { accessToken: "A" });
+    expect(await storage.get("u1", "notion")).toEqual({ accessToken: "A" });
+  });
+
+  it("returns null for a missing pair", async () => {
+    expect(await storage.get("u1", "notion")).toBeNull();
+  });
+
+  it("isolates per-user + per-provider", async () => {
+    await storage.put("u1", "notion", { accessToken: "notion-A" });
+    await storage.put("u1", "google", { accessToken: "google-A" });
+    await storage.put("u2", "notion", { accessToken: "notion-B" });
+
+    expect((await storage.get("u1", "notion"))?.accessToken).toBe("notion-A");
+    expect((await storage.get("u1", "google"))?.accessToken).toBe("google-A");
+    expect((await storage.get("u2", "notion"))?.accessToken).toBe("notion-B");
+  });
+
+  it("delete removes a single pair", async () => {
+    await storage.put("u1", "notion", { accessToken: "A" });
+    await storage.put("u1", "google", { accessToken: "B" });
+    await storage.delete("u1", "notion");
+    expect(await storage.get("u1", "notion")).toBeNull();
+    expect((await storage.get("u1", "google"))?.accessToken).toBe("B");
+  });
+
+  it("delete is a no-op when absent", async () => {
+    await expect(storage.delete("nobody", "notion")).resolves.toBeUndefined();
+  });
+
+  it("deleteAllForUser wipes every provider under a user", async () => {
+    await storage.put("u1", "notion", { accessToken: "A" });
+    await storage.put("u1", "google", { accessToken: "B" });
+    await storage.put("u2", "notion", { accessToken: "C" });
+
+    await storage.deleteAllForUser("u1");
+
+    expect(await storage.get("u1", "notion")).toBeNull();
+    expect(await storage.get("u1", "google")).toBeNull();
+    expect((await storage.get("u2", "notion"))?.accessToken).toBe("C");
+    expect(storage._size()).toBe(1);
+  });
+});

--- a/templates/module-oauth-delegation/skeleton/src/oauth/errors.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/errors.ts
@@ -1,0 +1,104 @@
+// ── Typed errors ─────────────────────────────────────────────────────
+//
+// All error messages are stable, code-shaped strings that expose only
+// the error kind and (where safe) the provider name. Token material —
+// access tokens, refresh tokens, authorization codes, code verifiers,
+// client secrets — must never appear in an error message.
+
+export class OAuthError extends Error {
+  readonly code: string;
+  readonly provider?: string;
+
+  constructor(code: string, message: string, provider?: string) {
+    super(message);
+    this.name = "OAuthError";
+    this.code = code;
+    this.provider = provider;
+  }
+}
+
+export class StateTamperedError extends OAuthError {
+  constructor() {
+    super("state_tampered", "state cookie signature mismatch");
+  }
+}
+
+export class StateExpiredError extends OAuthError {
+  constructor() {
+    super("state_expired", "state cookie expired");
+  }
+}
+
+export class StateMissingError extends OAuthError {
+  constructor() {
+    super("state_missing", "state cookie not present on callback");
+  }
+}
+
+export class UserMismatchError extends OAuthError {
+  constructor() {
+    super("user_mismatch", "state userId does not match authenticated caller");
+  }
+}
+
+export class UnauthenticatedError extends OAuthError {
+  constructor() {
+    super("unauthenticated", "resolveUserId returned null");
+  }
+}
+
+export class UnknownProviderError extends OAuthError {
+  constructor(provider: string) {
+    super("unknown_provider", `no provider registered: ${provider}`, provider);
+  }
+}
+
+export class MissingCredentialsError extends OAuthError {
+  constructor(provider: string) {
+    super("missing_credentials", `no clientCredentials for provider: ${provider}`, provider);
+  }
+}
+
+export class RedirectMismatchError extends OAuthError {
+  constructor(provider: string) {
+    super("redirect_mismatch", `redirect_uri does not match registered value`, provider);
+  }
+}
+
+export class RefreshFailedError extends OAuthError {
+  readonly status?: number;
+  constructor(provider: string, status?: number) {
+    super("refresh_failed", `refresh rejected by provider`, provider);
+    this.status = status;
+  }
+}
+
+export class ProviderError extends OAuthError {
+  readonly status?: number;
+  constructor(provider: string, code: string, message: string, status?: number) {
+    super(code, message, provider);
+    this.status = status;
+  }
+}
+
+export class ConfigError extends OAuthError {
+  constructor(message: string) {
+    super("config_error", message);
+  }
+}
+
+/**
+ * Typed-narrow alternative to `(err as Error).message`. Accepts thrown values
+ * that JavaScript allows to be non-Error (strings, nulls, anything) and
+ * returns a string suitable for logging without leaking token material —
+ * callers are still expected to scrub the result via the redacting logger.
+ */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/handlers/callback.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/handlers/callback.ts
@@ -1,0 +1,148 @@
+// ── /oauth/:provider/callback ────────────────────────────────────────
+//
+// The provider redirects the user back here with `code` and `state`.
+// We verify the state cookie's HMAC, confirm it hasn't expired, confirm
+// the caller's identity matches `state.userId`, then exchange the code
+// for tokens and persist them.
+
+import {
+  OAuthError,
+  ProviderError,
+  RedirectMismatchError,
+  StateExpiredError,
+  StateMissingError,
+  StateTamperedError,
+  UnauthenticatedError,
+  UnknownProviderError,
+  UserMismatchError,
+  MissingCredentialsError,
+  errorMessage,
+} from "../errors.js";
+import { logger } from "../logger.js";
+import {
+  assertStateFresh,
+  clearStateCookie,
+  readStateCookie,
+  verifyState,
+} from "../state.js";
+import type {
+  ClientCredentials,
+  OAuthProvider,
+  OAuthRouterConfig,
+  RequestHandler,
+  TokenGrant,
+} from "../types.js";
+import { extractProvider, postForm } from "./shared.js";
+
+export interface CallbackDeps {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+export function createCallbackHandler(
+  config: OAuthRouterConfig,
+  deps: CallbackDeps = {},
+): RequestHandler {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
+  const stateTtl = config.stateTtlSeconds ?? 600;
+
+  return async (req) => {
+    try {
+      const providerName = extractProvider(req.url, "callback");
+      const adapter: OAuthProvider | undefined = config.providers[providerName];
+      if (!adapter) throw new UnknownProviderError(providerName);
+
+      const creds: ClientCredentials | undefined = config.clientCredentials[providerName];
+      if (!creds) throw new MissingCredentialsError(providerName);
+
+      const u = new URL(req.url);
+      const code = u.searchParams.get("code");
+      const stateNonce = u.searchParams.get("state");
+      if (!code || !stateNonce) throw new StateMissingError();
+
+      const signed = readStateCookie(req);
+      const state = verifyState(signed, config.stateSigningSecret);
+      assertStateFresh(state, stateTtl, now());
+
+      if (state.nonce !== stateNonce) throw new StateTamperedError();
+      if (state.provider !== providerName) throw new StateTamperedError();
+
+      const userId = await config.resolveUserId(req);
+      if (!userId) throw new UnauthenticatedError();
+      if (userId !== state.userId) throw new UserMismatchError();
+
+      // Exact-match redirect URI. Some providers echo it back on the callback;
+      // where they don't, we still compare against the configured value used in start.
+      const echoedRedirect = u.searchParams.get("redirect_uri");
+      if (echoedRedirect && echoedRedirect !== creds.redirectUri) {
+        throw new RedirectMismatchError(providerName);
+      }
+
+      const body = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: creds.clientId,
+        client_secret: creds.clientSecret,
+        redirect_uri: creds.redirectUri,
+      });
+      if (adapter.usePkce && state.codeVerifier) {
+        body.set("code_verifier", state.codeVerifier);
+      }
+
+      const raw = await postForm(fetchImpl, adapter.tokenUrl, body, providerName);
+      const grant: TokenGrant = adapter.parseTokenResponse(raw);
+      if (!grant.accessToken) {
+        throw new ProviderError(providerName, "missing_access_token", "token response missing access_token");
+      }
+
+      await config.storage.put(userId, providerName, grant);
+
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: state.returnTo || "/",
+          "set-cookie": clearStateCookie(config.cookieDomain),
+        },
+      });
+    } catch (err) {
+      return handleCallbackError(err, config.cookieDomain);
+    }
+  };
+}
+
+function handleCallbackError(err: unknown, cookieDomain?: string): Response {
+  const clear = clearStateCookie(cookieDomain);
+  if (err instanceof StateTamperedError || err instanceof StateMissingError) {
+    logger.warn("callback rejected — state invalid", { code: (err as OAuthError).code });
+    return new Response("state_invalid", { status: 400, headers: { "set-cookie": clear } });
+  }
+  if (err instanceof StateExpiredError) {
+    logger.warn("callback rejected — state expired");
+    return new Response("state_expired", { status: 400, headers: { "set-cookie": clear } });
+  }
+  if (err instanceof UserMismatchError) {
+    logger.warn("callback rejected — user mismatch");
+    return new Response("user_mismatch", { status: 400, headers: { "set-cookie": clear } });
+  }
+  if (err instanceof RedirectMismatchError) {
+    logger.warn("callback rejected — redirect mismatch", { provider: err.provider });
+    return new Response("redirect_mismatch", { status: 400, headers: { "set-cookie": clear } });
+  }
+  if (err instanceof UnauthenticatedError) {
+    return new Response("unauthenticated", { status: 401, headers: { "set-cookie": clear } });
+  }
+  if (err instanceof UnknownProviderError) {
+    return new Response(err.message, { status: 404 });
+  }
+  if (err instanceof ProviderError) {
+    logger.warn("callback provider error", { provider: err.provider, code: err.code, status: err.status });
+    return new Response(err.code, { status: 502, headers: { "set-cookie": clear } });
+  }
+  if (err instanceof OAuthError) {
+    logger.warn("callback error", { code: err.code, provider: err.provider });
+    return new Response(err.code, { status: 400, headers: { "set-cookie": clear } });
+  }
+  logger.error("callback unexpected error", { error: errorMessage(err) });
+  return new Response("internal_error", { status: 500, headers: { "set-cookie": clear } });
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/handlers/errorMapping.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/handlers/errorMapping.ts
@@ -1,0 +1,30 @@
+// ── Shared error → Response mapper ───────────────────────────────────
+//
+// The start / refresh / revoke handlers all fall through to the same
+// catch-all: Unauthenticated → 401, UnknownProvider → 404, OAuthError →
+// 400 with code, anything else → 500. Callback does more (clears the
+// state cookie, distinguishes state/provider errors) so it keeps its
+// own custom mapping.
+
+import {
+  OAuthError,
+  UnauthenticatedError,
+  UnknownProviderError,
+  errorMessage,
+} from "../errors.js";
+import { logger } from "../logger.js";
+
+export function mapHandlerError(err: unknown, context: string): Response {
+  if (err instanceof UnauthenticatedError) {
+    return new Response("unauthenticated", { status: 401 });
+  }
+  if (err instanceof UnknownProviderError) {
+    return new Response(err.message, { status: 404 });
+  }
+  if (err instanceof OAuthError) {
+    logger.warn(`${context} handler error`, { code: err.code, provider: err.provider });
+    return new Response(err.code, { status: 400 });
+  }
+  logger.error(`${context} handler unexpected error`, { error: errorMessage(err) });
+  return new Response("internal_error", { status: 500 });
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/handlers/refresh.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/handlers/refresh.ts
@@ -1,0 +1,42 @@
+// ── /oauth/:provider/refresh ─────────────────────────────────────────
+//
+// Service-internal handler that forces a refresh for a specific
+// (userId, provider). Useful for ops endpoints and scheduled sweepers.
+// Not user-facing — the authorization check below ensures the caller
+// is authenticated, but additional access control (e.g., restricting
+// to admin tokens) is the consumer's responsibility.
+
+import { UnauthenticatedError, UnknownProviderError } from "../errors.js";
+import type { OAuthRouterConfig, RequestHandler } from "../types.js";
+import type { TokenRefresher } from "../refresh.js";
+import { mapHandlerError } from "./errorMapping.js";
+import { extractProvider } from "./shared.js";
+
+export function createRefreshHandler(
+  config: OAuthRouterConfig,
+  refresher: TokenRefresher,
+): RequestHandler {
+  return async (req) => {
+    try {
+      const providerName = extractProvider(req.url, "refresh");
+      if (!config.providers[providerName]) throw new UnknownProviderError(providerName);
+
+      const userId = await config.resolveUserId(req);
+      if (!userId) throw new UnauthenticatedError();
+
+      const grant = await refresher.refresh(userId, providerName);
+      if (!grant) {
+        return new Response(JSON.stringify({ ok: false }), {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ ok: true, expiresAt: grant.expiresAt ?? null }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    } catch (err) {
+      return mapHandlerError(err, "refresh");
+    }
+  };
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/handlers/revoke.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/handlers/revoke.ts
@@ -1,0 +1,79 @@
+// ── /oauth/:provider/revoke ──────────────────────────────────────────
+//
+// User-initiated disconnect. Best-effort call to the provider's
+// revocation endpoint (if any), unconditional storage delete, and a
+// revocation event with reason `user`.
+
+import { UnauthenticatedError, UnknownProviderError, errorMessage } from "../errors.js";
+import { logger } from "../logger.js";
+import type { OAuthProvider, OAuthRouterConfig, RequestHandler } from "../types.js";
+import { mapHandlerError } from "./errorMapping.js";
+import { FETCH_TIMEOUT_MS, extractProvider } from "./shared.js";
+
+export interface RevokeDeps {
+  fetchImpl?: typeof fetch;
+}
+
+export function createRevokeHandler(
+  config: OAuthRouterConfig,
+  deps: RevokeDeps = {},
+): RequestHandler {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  return async (req) => {
+    try {
+      const providerName = extractProvider(req.url, "revoke");
+      const adapter: OAuthProvider | undefined = config.providers[providerName];
+      if (!adapter) throw new UnknownProviderError(providerName);
+
+      const userId = await config.resolveUserId(req);
+      if (!userId) throw new UnauthenticatedError();
+
+      const existing = await config.storage.get(userId, providerName);
+      if (existing && adapter.revokeUrl) {
+        const body = new URLSearchParams({ token: existing.accessToken });
+        const creds = config.clientCredentials[providerName];
+        if (creds) {
+          body.set("client_id", creds.clientId);
+          body.set("client_secret", creds.clientSecret);
+        }
+        try {
+          const response = await fetchImpl(adapter.revokeUrl, {
+            method: "POST",
+            headers: { "content-type": "application/x-www-form-urlencoded" },
+            body,
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+          });
+          if (!response.ok) {
+            logger.warn("provider revoke returned non-2xx", {
+              provider: providerName,
+              status: response.status,
+            });
+          }
+        } catch (err) {
+          logger.warn("provider revoke network error", {
+            provider: providerName,
+            error: errorMessage(err),
+          });
+        }
+      }
+
+      await config.storage.delete(userId, providerName);
+
+      if (config.revocationEmitter) {
+        try {
+          await config.revocationEmitter.emit({ userId, provider: providerName, reason: "user" });
+        } catch (err) {
+          logger.warn("revocation emit failed", {
+            provider: providerName,
+            error: errorMessage(err),
+          });
+        }
+      }
+
+      return new Response(null, { status: 204 });
+    } catch (err) {
+      return mapHandlerError(err, "revoke");
+    }
+  };
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/handlers/shared.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/handlers/shared.ts
@@ -1,0 +1,94 @@
+// ── Handler-shared helpers ───────────────────────────────────────────
+
+import { ConfigError, errorMessage, ProviderError } from "../errors.js";
+import type { OAuthProvider, OAuthRouterConfig } from "../types.js";
+
+/** Default timeout for provider token/revoke endpoints. */
+export const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Pull the provider name out of a URL like `/oauth/notion/start`. The
+ * `action` segment (`start` / `callback` / `refresh` / `revoke`) is
+ * expected at the end — we find the segment immediately before it and
+ * call that the provider.
+ */
+export function extractProvider(url: string, action: string): string {
+  const { pathname } = new URL(url);
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length < 2) throw new ConfigError(`unroutable path: ${pathname}`);
+  const last = segments[segments.length - 1];
+  if (last !== action) throw new ConfigError(`expected action ${action} at end of ${pathname}`);
+  return segments[segments.length - 2];
+}
+
+/**
+ * Pull `returnTo` from the query string, but only accept same-origin paths.
+ *
+ * Rejects absolute URLs (`http://evil.com`), protocol-relative URLs
+ * (`//evil.com`), and anything that doesn't start with a single `/`. This
+ * closes the classic OAuth-adjacent open-redirect footgun where an attacker
+ * crafts `/oauth/foo/start?returnTo=https://evil.com` and the callback
+ * bounces the authenticated user off-site.
+ *
+ * Consumers who need cross-origin `returnTo` should layer an allowlist on
+ * top — it's safer to extend from "deny by default" than the reverse.
+ */
+export function extractReturnTo(url: string): string {
+  const u = new URL(url);
+  const raw = u.searchParams.get("returnTo");
+  if (!raw) return "/";
+  if (!raw.startsWith("/")) return "/";
+  if (raw.startsWith("//")) return "/";
+  if (raw.startsWith("/\\")) return "/";
+  return raw;
+}
+
+export function providerScopes(
+  adapter: OAuthProvider,
+  providerName: string,
+  config: OAuthRouterConfig,
+): string[] {
+  const override = config.scopes?.[providerName];
+  return override && override.length > 0 ? override : adapter.defaultScopes;
+}
+
+/**
+ * Post to the provider's token endpoint with a URL-encoded body. Wraps
+ * fetch errors so upstream code gets a typed {@link ProviderError}.
+ */
+export async function postForm(
+  fetchImpl: typeof fetch,
+  url: string,
+  body: URLSearchParams,
+  provider: string,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        accept: "application/json",
+      },
+      body,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new ProviderError(provider, "network_error", errorMessage(err));
+  }
+
+  if (!response.ok) {
+    throw new ProviderError(
+      provider,
+      "token_endpoint_error",
+      `token endpoint returned ${response.status}`,
+      response.status,
+    );
+  }
+
+  try {
+    return await response.json();
+  } catch (err) {
+    throw new ProviderError(provider, "invalid_json", errorMessage(err), response.status);
+  }
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/handlers/start.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/handlers/start.ts
@@ -1,0 +1,86 @@
+// ── /oauth/:provider/start ───────────────────────────────────────────
+//
+// Builds the auth URL with PKCE challenge + signed state cookie, then
+// redirects the user to the provider. Returns 302 + Set-Cookie.
+
+import {
+  MissingCredentialsError,
+  UnauthenticatedError,
+  UnknownProviderError,
+} from "../errors.js";
+import { codeChallenge, generateCodeVerifier } from "../pkce.js";
+import {
+  buildStateCookie,
+  generateNonce,
+  signState,
+  type StatePayload,
+} from "../state.js";
+import type {
+  ClientCredentials,
+  OAuthProvider,
+  OAuthRouterConfig,
+  RequestHandler,
+} from "../types.js";
+import { mapHandlerError } from "./errorMapping.js";
+import { extractProvider, extractReturnTo, providerScopes } from "./shared.js";
+
+export function createStartHandler(config: OAuthRouterConfig): RequestHandler {
+  const stateTtl = config.stateTtlSeconds ?? 600;
+
+  return async (req) => {
+    try {
+      const providerName = extractProvider(req.url, "start");
+      const adapter: OAuthProvider | undefined = config.providers[providerName];
+      if (!adapter) throw new UnknownProviderError(providerName);
+
+      const creds: ClientCredentials | undefined = config.clientCredentials[providerName];
+      if (!creds) throw new MissingCredentialsError(providerName);
+
+      const userId = await config.resolveUserId(req);
+      if (!userId) throw new UnauthenticatedError();
+
+      const verifier = adapter.usePkce ? generateCodeVerifier() : "";
+      const challenge = verifier ? codeChallenge(verifier) : "";
+      const nonce = generateNonce();
+      const returnTo = extractReturnTo(req.url);
+
+      const payload: StatePayload = {
+        nonce,
+        userId,
+        provider: providerName,
+        returnTo,
+        createdAt: Math.floor(Date.now() / 1000),
+        codeVerifier: verifier,
+      };
+      const signed = signState(payload, config.stateSigningSecret);
+
+      const scopes = providerScopes(adapter, providerName, config);
+      const authUrl = buildAuthUrl(adapter.authUrl, {
+        client_id: creds.clientId,
+        redirect_uri: creds.redirectUri,
+        scope: scopes.join(" "),
+        state: nonce,
+        code_challenge: challenge,
+        code_challenge_method: challenge ? "S256" : "",
+      });
+
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: authUrl,
+          "set-cookie": buildStateCookie(signed, stateTtl, config.cookieDomain),
+        },
+      });
+    } catch (err) {
+      return mapHandlerError(err, "start");
+    }
+  };
+}
+
+function buildAuthUrl(template: string, vars: Record<string, string>): string {
+  let out = template;
+  for (const [k, v] of Object.entries(vars)) {
+    out = out.split(`{${k}}`).join(encodeURIComponent(v));
+  }
+  return out;
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/index.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/index.ts
@@ -1,0 +1,56 @@
+// ── Public API ───────────────────────────────────────────────────────
+//
+// Everything importable from the package root. Provider and storage
+// modules are also re-exported via the `/providers` and `/storage`
+// subpath exports in package.json.
+
+export { createOAuthRouter } from "./router.js";
+export type { CreateOAuthRouterDeps } from "./router.js";
+
+export type {
+  TokenGrant,
+  TokenStorage,
+  RevocationReason,
+  RevocationEmitter,
+  OAuthProvider,
+  ClientCredentials,
+  RequestHandler,
+  ResolveUserId,
+  OAuthRouterConfig,
+  OAuthRouter,
+} from "./types.js";
+
+export {
+  OAuthError,
+  StateTamperedError,
+  StateExpiredError,
+  StateMissingError,
+  UserMismatchError,
+  UnauthenticatedError,
+  UnknownProviderError,
+  MissingCredentialsError,
+  RedirectMismatchError,
+  RefreshFailedError,
+  ProviderError,
+  ConfigError,
+} from "./errors.js";
+
+export { logger } from "./logger.js";
+
+// Provider adapters — importing this file also triggers their self-registration
+// via the ./providers barrel.
+export {
+  registerProvider,
+  getProvider,
+  listProviders,
+  notionProvider,
+  googleProvider,
+  atlassianProvider,
+  slackProvider,
+  hubspotProvider,
+} from "./providers/index.js";
+
+// Storage backends.
+export { InMemoryTokenStorage } from "./storage/memory.js";
+export { DDBKmsTokenStorage } from "./storage/ddb-kms.js";
+export type { DDBKmsTokenStorageConfig } from "./storage/ddb-kms.js";

--- a/templates/module-oauth-delegation/skeleton/src/oauth/logger.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/logger.ts
@@ -1,0 +1,75 @@
+// ── Redacting JSON logger ────────────────────────────────────────────
+//
+// Every log line is a single JSON object on stdout. Fields whose names
+// appear in REDACT_FIELDS are replaced with "[redacted]" before
+// serialization, at any depth. This is the enforcement mechanism for
+// the "tokens never in logs" invariant.
+
+/**
+ * Depth at which redaction stops recursing. 32 is well past the deepest
+ * plausible OAuth token response (provider `raw` shapes are typically 2-3
+ * levels). The cap exists purely to bound pathological inputs; it should
+ * never fire in normal use.
+ */
+const MAX_REDACT_DEPTH = 32;
+
+const REDACT_FIELDS = new Set([
+  "accessToken",
+  "refreshToken",
+  "access_token",
+  "refresh_token",
+  "code",
+  "codeVerifier",
+  "code_verifier",
+  "clientSecret",
+  "client_secret",
+  "authorization",
+  "Authorization",
+  "ciphertext",
+  "Ciphertext",
+  "CiphertextBlob",
+  "Plaintext",
+]);
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+type LogFields = Record<string, unknown>;
+
+function redact(value: unknown, depth = 0): unknown {
+  if (depth > MAX_REDACT_DEPTH) return value;
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map((v) => redact(v, depth + 1));
+  if (typeof value !== "object") return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (REDACT_FIELDS.has(k)) {
+      out[k] = "[redacted]";
+    } else {
+      out[k] = redact(v, depth + 1);
+    }
+  }
+  return out;
+}
+
+function write(level: LogLevel, message: string, fields?: LogFields): void {
+  const payload = {
+    level,
+    time: new Date().toISOString(),
+    message,
+    ...(fields ? (redact(fields) as LogFields) : {}),
+  };
+  const line = JSON.stringify(payload);
+  if (level === "error" || level === "warn") process.stderr.write(line + "\n");
+  else process.stdout.write(line + "\n");
+}
+
+export const logger = {
+  debug: (message: string, fields?: LogFields) => write("debug", message, fields),
+  info: (message: string, fields?: LogFields) => write("info", message, fields),
+  warn: (message: string, fields?: LogFields) => write("warn", message, fields),
+  error: (message: string, fields?: LogFields) => write("error", message, fields),
+};
+
+/** Exposed for tests — the set of field names that get redacted. */
+export const _redactFields = REDACT_FIELDS;

--- a/templates/module-oauth-delegation/skeleton/src/oauth/pkce.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/pkce.ts
@@ -1,0 +1,28 @@
+// ── PKCE (RFC 7636) ──────────────────────────────────────────────────
+//
+// S256 only. The verifier lives in the signed state cookie; the
+// challenge goes on the wire to the auth server. The same verifier is
+// replayed to the token endpoint on the callback's code exchange.
+
+import { createHash, randomBytes } from "node:crypto";
+
+function base64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * 32 random bytes → base64url, which yields a 43-character verifier.
+ * That's well within RFC 7636's 43–128 range and gives 256 bits of entropy.
+ */
+export function generateCodeVerifier(): string {
+  return base64url(randomBytes(32));
+}
+
+/** S256: base64url(sha256(verifier)). */
+export function codeChallenge(verifier: string): string {
+  return base64url(createHash("sha256").update(verifier).digest());
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/atlassian.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/atlassian.ts
@@ -1,0 +1,59 @@
+// ── Atlassian (Confluence / Jira) ────────────────────────────────────
+//
+// Atlassian's OAuth 2.0 (3LO) endpoint. Requires `audience=api.atlassian.com`
+// on the auth URL; tokens are short-lived (typically ~1h) and refreshable.
+
+import type { OAuthProvider, TokenGrant } from "./types.js";
+import { registerProvider } from "./registry.js";
+import { expiresAtFromExpiresIn } from "./shared.js";
+
+interface AtlassianTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+}
+
+function parse(raw: unknown, previous?: TokenGrant): TokenGrant {
+  const r = raw as AtlassianTokenResponse;
+  return {
+    accessToken: r.access_token,
+    refreshToken: r.refresh_token ?? previous?.refreshToken,
+    expiresAt: expiresAtFromExpiresIn(r.expires_in),
+    scope: r.scope,
+    raw: r as unknown as Record<string, unknown>,
+  };
+}
+
+export const atlassianProvider: OAuthProvider = {
+  name: "atlassian",
+  authUrl:
+    "https://auth.atlassian.com/authorize" +
+    "?audience=api.atlassian.com" +
+    "&response_type=code" +
+    "&prompt=consent" +
+    "&client_id={client_id}" +
+    "&redirect_uri={redirect_uri}" +
+    "&scope={scope}" +
+    "&state={state}" +
+    "&code_challenge={code_challenge}" +
+    "&code_challenge_method={code_challenge_method}",
+  tokenUrl: "https://auth.atlassian.com/oauth/token",
+  defaultScopes: [
+    "read:confluence-content.all",
+    "read:confluence-space.summary",
+    "offline_access",
+  ],
+  usePkce: true,
+
+  parseTokenResponse(raw) {
+    return parse(raw);
+  },
+
+  refreshTokenResponse(raw, previous) {
+    return parse(raw, previous);
+  },
+};
+
+registerProvider("atlassian", () => atlassianProvider);

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/google.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/google.ts
@@ -1,0 +1,64 @@
+// ── Google (Drive / Calendar / Analytics / ...) ──────────────────────
+//
+// Google's v2 OAuth endpoint. Refresh tokens are only returned when
+// `access_type=offline&prompt=consent` are set on the auth URL — both
+// are baked into the template. On refresh responses, Google omits
+// `refresh_token`; the refresh path in refresh.ts reuses the previous
+// one when missing.
+
+import type { OAuthProvider, TokenGrant } from "./types.js";
+import { registerProvider } from "./registry.js";
+import { expiresAtFromExpiresIn } from "./shared.js";
+
+interface GoogleTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+  id_token?: string;
+}
+
+function parse(raw: unknown, previous?: TokenGrant): TokenGrant {
+  const r = raw as GoogleTokenResponse;
+  return {
+    accessToken: r.access_token,
+    refreshToken: r.refresh_token ?? previous?.refreshToken,
+    expiresAt: expiresAtFromExpiresIn(r.expires_in),
+    scope: r.scope,
+    raw: r as unknown as Record<string, unknown>,
+  };
+}
+
+export const googleProvider: OAuthProvider = {
+  name: "google",
+  authUrl:
+    "https://accounts.google.com/o/oauth2/v2/auth" +
+    "?response_type=code" +
+    "&access_type=offline" +
+    "&prompt=consent" +
+    "&include_granted_scopes=true" +
+    "&client_id={client_id}" +
+    "&redirect_uri={redirect_uri}" +
+    "&scope={scope}" +
+    "&state={state}" +
+    "&code_challenge={code_challenge}" +
+    "&code_challenge_method={code_challenge_method}",
+  tokenUrl: "https://oauth2.googleapis.com/token",
+  revokeUrl: "https://oauth2.googleapis.com/revoke",
+  defaultScopes: [
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/calendar.readonly",
+  ],
+  usePkce: true,
+
+  parseTokenResponse(raw) {
+    return parse(raw);
+  },
+
+  refreshTokenResponse(raw, previous) {
+    return parse(raw, previous);
+  },
+};
+
+registerProvider("google", () => googleProvider);

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/hubspot.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/hubspot.ts
@@ -1,0 +1,52 @@
+// ── HubSpot ──────────────────────────────────────────────────────────
+//
+// HubSpot OAuth. Scopes are space-separated in the auth URL. Tokens
+// expire (~30 minutes) and are refreshable. Refresh responses include
+// a fresh refresh_token that replaces the old one.
+
+import type { OAuthProvider, TokenGrant } from "./types.js";
+import { registerProvider } from "./registry.js";
+import { expiresAtFromExpiresIn } from "./shared.js";
+
+interface HubSpotTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+function parse(raw: unknown, previous?: TokenGrant): TokenGrant {
+  const r = raw as HubSpotTokenResponse;
+  return {
+    accessToken: r.access_token,
+    refreshToken: r.refresh_token ?? previous?.refreshToken,
+    expiresAt: expiresAtFromExpiresIn(r.expires_in),
+    raw: r as unknown as Record<string, unknown>,
+  };
+}
+
+export const hubspotProvider: OAuthProvider = {
+  name: "hubspot",
+  authUrl:
+    "https://app.hubspot.com/oauth/authorize" +
+    "?response_type=code" +
+    "&client_id={client_id}" +
+    "&redirect_uri={redirect_uri}" +
+    "&scope={scope}" +
+    "&state={state}" +
+    "&code_challenge={code_challenge}" +
+    "&code_challenge_method={code_challenge_method}",
+  tokenUrl: "https://api.hubapi.com/oauth/v1/token",
+  defaultScopes: ["oauth", "crm.objects.contacts.read"],
+  usePkce: true,
+
+  parseTokenResponse(raw) {
+    return parse(raw);
+  },
+
+  refreshTokenResponse(raw, previous) {
+    return parse(raw, previous);
+  },
+};
+
+registerProvider("hubspot", () => hubspotProvider);

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/index.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/index.ts
@@ -1,0 +1,21 @@
+// ── Providers barrel ─────────────────────────────────────────────────
+//
+// Side-effect imports register the built-in providers; named re-exports
+// let consumers pass the adapter objects directly to `createOAuthRouter`
+// without going through the registry.
+
+import "./notion.js";
+import "./google.js";
+import "./atlassian.js";
+import "./slack.js";
+import "./hubspot.js";
+
+export { notionProvider } from "./notion.js";
+export { googleProvider } from "./google.js";
+export { atlassianProvider } from "./atlassian.js";
+export { slackProvider } from "./slack.js";
+export { hubspotProvider } from "./hubspot.js";
+
+export { registerProvider, getProvider, listProviders } from "./registry.js";
+export type { OAuthProviderFactory } from "./registry.js";
+export type { OAuthProvider, TokenGrant } from "./types.js";

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/notion.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/notion.ts
@@ -1,0 +1,47 @@
+// ── Notion ───────────────────────────────────────────────────────────
+//
+// Notion OAuth integrations issue a single long-lived access token —
+// there are no refresh tokens and no expiry. We still require PKCE
+// because Notion's /v1/oauth/token endpoint accepts it and rejecting
+// PKCE by default adds meaningful resistance to code-interception
+// attacks even when the redirect is on HTTPS.
+
+import type { OAuthProvider, TokenGrant } from "./types.js";
+import { registerProvider } from "./registry.js";
+
+interface NotionTokenResponse {
+  access_token: string;
+  token_type?: string;
+  bot_id?: string;
+  workspace_id?: string;
+  workspace_name?: string;
+  workspace_icon?: string;
+  owner?: unknown;
+}
+
+export const notionProvider: OAuthProvider = {
+  name: "notion",
+  authUrl:
+    "https://api.notion.com/v1/oauth/authorize" +
+    "?owner=user" +
+    "&response_type=code" +
+    "&client_id={client_id}" +
+    "&redirect_uri={redirect_uri}" +
+    "&state={state}" +
+    "&code_challenge={code_challenge}" +
+    "&code_challenge_method={code_challenge_method}",
+  tokenUrl: "https://api.notion.com/v1/oauth/token",
+  defaultScopes: [],
+  usePkce: true,
+
+  parseTokenResponse(raw) {
+    const r = raw as NotionTokenResponse;
+    const grant: TokenGrant = {
+      accessToken: r.access_token,
+      raw: r as unknown as Record<string, unknown>,
+    };
+    return grant;
+  },
+};
+
+registerProvider("notion", () => notionProvider);

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/registry.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/registry.ts
@@ -1,0 +1,30 @@
+// ── Provider Registry ────────────────────────────────────────────────
+//
+// Central registry that maps provider names to factory functions.
+// Built-in providers self-register at import time; consumers may call
+// `registerProvider` to add custom ones. `getProvider` always returns a
+// fresh instance via the factory so tests can swap implementations.
+
+import type { OAuthProvider } from "./types.js";
+
+export type OAuthProviderFactory = () => OAuthProvider;
+
+const factories = new Map<string, OAuthProviderFactory>();
+
+export function registerProvider(name: string, factory: OAuthProviderFactory): void {
+  factories.set(name, factory);
+}
+
+export function getProvider(name: string): OAuthProvider | undefined {
+  const factory = factories.get(name);
+  return factory ? factory() : undefined;
+}
+
+export function listProviders(): string[] {
+  return Array.from(factories.keys());
+}
+
+/** Exposed for tests that want a clean slate. */
+export function _clearRegistry(): void {
+  factories.clear();
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/shared.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/shared.ts
@@ -1,0 +1,11 @@
+// ── Provider-shared helpers ──────────────────────────────────────────
+
+/**
+ * Convert an `expires_in` (seconds-from-now, the shape OAuth servers
+ * return) into an absolute unix-seconds `expiresAt`. Returns undefined
+ * when the provider omits expiry (e.g., Notion's long-lived grants).
+ */
+export function expiresAtFromExpiresIn(expiresIn?: number): number | undefined {
+  if (!expiresIn) return undefined;
+  return Math.floor(Date.now() / 1000) + expiresIn;
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/slack.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/slack.ts
@@ -1,0 +1,66 @@
+// ── Slack ────────────────────────────────────────────────────────────
+//
+// Slack's v2 OAuth returns a nested structure: when the user approves
+// user-scope scopes, the access token lives at `authed_user.access_token`
+// and `authed_user.refresh_token`. Bot tokens use the top-level
+// `access_token`. This adapter reads the user-scope path by default;
+// override `parseTokenResponse` if you want the bot token.
+
+import type { OAuthProvider, TokenGrant } from "./types.js";
+import { registerProvider } from "./registry.js";
+import { expiresAtFromExpiresIn } from "./shared.js";
+
+interface SlackTokenResponse {
+  ok: boolean;
+  access_token?: string; // bot token
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  authed_user?: {
+    id?: string;
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    scope?: string;
+  };
+  team?: { id?: string; name?: string };
+}
+
+function parse(raw: unknown, previous?: TokenGrant): TokenGrant {
+  const r = raw as SlackTokenResponse;
+  const u = r.authed_user ?? {};
+  return {
+    accessToken: u.access_token ?? r.access_token ?? "",
+    refreshToken: u.refresh_token ?? r.refresh_token ?? previous?.refreshToken,
+    expiresAt: expiresAtFromExpiresIn(u.expires_in ?? r.expires_in),
+    scope: u.scope ?? r.scope,
+    raw: r as unknown as Record<string, unknown>,
+  };
+}
+
+export const slackProvider: OAuthProvider = {
+  name: "slack",
+  authUrl:
+    "https://slack.com/oauth/v2/authorize" +
+    "?response_type=code" +
+    "&client_id={client_id}" +
+    "&redirect_uri={redirect_uri}" +
+    "&user_scope={scope}" +
+    "&state={state}" +
+    "&code_challenge={code_challenge}" +
+    "&code_challenge_method={code_challenge_method}",
+  tokenUrl: "https://slack.com/api/oauth.v2.access",
+  revokeUrl: "https://slack.com/api/auth.revoke",
+  defaultScopes: ["channels:read", "chat:write"],
+  usePkce: true,
+
+  parseTokenResponse(raw) {
+    return parse(raw);
+  },
+
+  refreshTokenResponse(raw, previous) {
+    return parse(raw, previous);
+  },
+};
+
+registerProvider("slack", () => slackProvider);

--- a/templates/module-oauth-delegation/skeleton/src/oauth/providers/types.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/providers/types.ts
@@ -1,0 +1,3 @@
+// Re-export the OAuthProvider interface so providers can import from a
+// local path that doesn't reach up into the oauth root.
+export type { OAuthProvider, TokenGrant } from "../types.js";

--- a/templates/module-oauth-delegation/skeleton/src/oauth/refresh.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/refresh.ts
@@ -1,0 +1,185 @@
+// ── Refresh-before-expiry with per-key dedup ─────────────────────────
+//
+// When a caller asks for a valid token we check `expiresAt`. If it is
+// within `leadTimeSeconds` of now we refresh before returning. Multiple
+// concurrent callers in the same process share a single refresh via the
+// `inflight` map.
+//
+// Failures do not retry. On any non-2xx refresh we delete the stored
+// grant, emit a revocation event with reason `refresh-failed`, and
+// return null so the next call forces re-auth.
+
+import { errorMessage } from "./errors.js";
+import { logger } from "./logger.js";
+import type {
+  ClientCredentials,
+  OAuthProvider,
+  RevocationEmitter,
+  TokenGrant,
+  TokenStorage,
+} from "./types.js";
+
+/** Token-endpoint timeout. A slow provider must not tie up the event loop. */
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface RefreshDeps {
+  storage: TokenStorage;
+  emitter?: RevocationEmitter;
+  /** Injectable for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests. Defaults to Date.now / 1000. */
+  now?: () => number;
+}
+
+export class TokenRefresher {
+  private readonly inflight = new Map<string, Promise<TokenGrant | null>>();
+
+  constructor(
+    private readonly providers: Record<string, OAuthProvider>,
+    private readonly credentials: Record<string, ClientCredentials>,
+    private readonly deps: RefreshDeps,
+    private readonly leadTimeSeconds: number,
+  ) {}
+
+  private now(): number {
+    return (this.deps.now ?? (() => Math.floor(Date.now() / 1000)))();
+  }
+
+  private fetch(input: string, init?: RequestInit): Promise<Response> {
+    return (this.deps.fetchImpl ?? fetch)(input, init);
+  }
+
+  private key(userId: string, provider: string): string {
+    return `${userId}::${provider}`;
+  }
+
+  private isExpiring(grant: TokenGrant): boolean {
+    if (grant.expiresAt === undefined) return false;
+    return grant.expiresAt < this.now() + this.leadTimeSeconds;
+  }
+
+  async getValidToken(userId: string, provider: string): Promise<string | null> {
+    const grant = await this.deps.storage.get(userId, provider);
+    if (!grant) return null;
+    if (!this.isExpiring(grant)) return grant.accessToken;
+
+    const refreshed = await this.refreshCoalesced(userId, provider, grant);
+    return refreshed?.accessToken ?? null;
+  }
+
+  async refresh(userId: string, provider: string): Promise<TokenGrant | null> {
+    const grant = await this.deps.storage.get(userId, provider);
+    if (!grant) return null;
+    return this.refreshCoalesced(userId, provider, grant);
+  }
+
+  private refreshCoalesced(
+    userId: string,
+    provider: string,
+    previous: TokenGrant,
+  ): Promise<TokenGrant | null> {
+    const key = this.key(userId, provider);
+    const existing = this.inflight.get(key);
+    if (existing) return existing;
+
+    const task = this.doRefresh(userId, provider, previous).finally(() => {
+      this.inflight.delete(key);
+    });
+    this.inflight.set(key, task);
+    return task;
+  }
+
+  private async doRefresh(
+    userId: string,
+    provider: string,
+    previous: TokenGrant,
+  ): Promise<TokenGrant | null> {
+    const adapter = this.providers[provider];
+    const creds = this.credentials[provider];
+
+    if (!adapter || !creds) {
+      logger.warn("refresh aborted — provider not configured", { provider });
+      return null;
+    }
+    if (!previous.refreshToken) {
+      // Provider doesn't issue refresh tokens (e.g., Notion) — nothing to do.
+      return previous;
+    }
+
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: previous.refreshToken,
+      client_id: creds.clientId,
+      client_secret: creds.clientSecret,
+    });
+
+    let response: Response;
+    try {
+      response = await this.fetch(adapter.tokenUrl, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+        body,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (err) {
+      logger.warn("refresh network error", {
+        provider,
+        userId,
+        error: errorMessage(err),
+      });
+      await this.purgeAndEmit(userId, provider);
+      return null;
+    }
+
+    if (!response.ok) {
+      logger.warn("refresh rejected", {
+        provider,
+        userId,
+        status: response.status,
+      });
+      await this.purgeAndEmit(userId, provider);
+      return null;
+    }
+
+    let raw: unknown;
+    try {
+      raw = await response.json();
+    } catch {
+      logger.warn("refresh response not JSON", { provider, userId });
+      await this.purgeAndEmit(userId, provider);
+      return null;
+    }
+
+    const parsed = adapter.refreshTokenResponse
+      ? adapter.refreshTokenResponse(raw, previous)
+      : adapter.parseTokenResponse(raw);
+
+    // Providers like Google omit refresh_token on refresh — reuse the previous one.
+    const next: TokenGrant = {
+      ...parsed,
+      refreshToken: parsed.refreshToken ?? previous.refreshToken,
+    };
+
+    await this.deps.storage.put(userId, provider, next);
+    return next;
+  }
+
+  private async purgeAndEmit(userId: string, provider: string): Promise<void> {
+    try {
+      await this.deps.storage.delete(userId, provider);
+    } catch (err) {
+      logger.warn("storage delete failed after refresh failure", {
+        provider,
+        userId,
+        error: errorMessage(err),
+      });
+    }
+    if (this.deps.emitter) {
+      try {
+        await this.deps.emitter.emit({ userId, provider, reason: "refresh-failed" });
+      } catch (err) {
+        logger.warn("revocation emit failed", { provider, userId, error: errorMessage(err) });
+      }
+    }
+  }
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/router.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/router.ts
@@ -1,0 +1,96 @@
+// ── createOAuthRouter ────────────────────────────────────────────────
+//
+// Top-level factory. Builds the four handlers, wires the refresher, and
+// exposes the steady-state `getValidToken` / `revokeTokens` /
+// `revokeAllForUser` calls.
+
+import { createCallbackHandler, type CallbackDeps } from "./handlers/callback.js";
+import { createRefreshHandler } from "./handlers/refresh.js";
+import { createRevokeHandler, type RevokeDeps } from "./handlers/revoke.js";
+import { createStartHandler } from "./handlers/start.js";
+import { logger } from "./logger.js";
+import { TokenRefresher } from "./refresh.js";
+import type { OAuthRouter, OAuthRouterConfig } from "./types.js";
+
+export interface CreateOAuthRouterDeps {
+  /** Injectable for tests — used by callback, refresh, and revoke handlers + refresher. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests — used for state freshness and refresh expiry math. */
+  now?: () => number;
+}
+
+export function createOAuthRouter(
+  config: OAuthRouterConfig,
+  deps: CreateOAuthRouterDeps = {},
+): OAuthRouter {
+  if (!config.stateSigningSecret || config.stateSigningSecret.length < 16) {
+    throw new Error("stateSigningSecret must be at least 16 characters");
+  }
+
+  const leadTime = config.leadTimeSeconds ?? 60;
+
+  const refresher = new TokenRefresher(
+    config.providers,
+    config.clientCredentials,
+    {
+      storage: config.storage,
+      emitter: config.revocationEmitter,
+      fetchImpl: deps.fetchImpl,
+      now: deps.now,
+    },
+    leadTime,
+  );
+
+  const callbackDeps: CallbackDeps = { fetchImpl: deps.fetchImpl, now: deps.now };
+  const revokeDeps: RevokeDeps = { fetchImpl: deps.fetchImpl };
+
+  return {
+    handlers: {
+      start: createStartHandler(config),
+      callback: createCallbackHandler(config, callbackDeps),
+      refresh: createRefreshHandler(config, refresher),
+      revoke: createRevokeHandler(config, revokeDeps),
+    },
+
+    async getValidToken(userId, provider) {
+      if (!config.providers[provider]) return null;
+      return refresher.getValidToken(userId, provider);
+    },
+
+    async revokeTokens(userId, provider) {
+      await config.storage.delete(userId, provider);
+      if (config.revocationEmitter) {
+        try {
+          await config.revocationEmitter.emit({ userId, provider, reason: "user" });
+        } catch (err) {
+          logger.warn("revocation emit failed", {
+            provider,
+            userId,
+            error: (err as Error).message,
+          });
+        }
+      }
+    },
+
+    async revokeAllForUser(userId) {
+      await config.storage.deleteAllForUser(userId);
+      if (config.revocationEmitter) {
+        for (const providerName of Object.keys(config.providers)) {
+          try {
+            await config.revocationEmitter.emit({
+              userId,
+              provider: providerName,
+              reason: "offboarding",
+            });
+          } catch (err) {
+            logger.warn("revocation emit failed", {
+              provider: providerName,
+              userId,
+              error: (err as Error).message,
+            });
+          }
+        }
+      }
+    },
+  };
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/state.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/state.ts
@@ -1,0 +1,135 @@
+// ── Signed stateless state cookie ────────────────────────────────────
+//
+// The state cookie carries the PKCE code verifier and CSRF nonce across
+// the redirect boundary. It is HMAC-SHA256 signed so there is no
+// server-side state table. On callback we recompute the HMAC with
+// timingSafeEqual and reject on mismatch.
+
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import {
+  StateExpiredError,
+  StateMissingError,
+  StateTamperedError,
+} from "./errors.js";
+
+export interface StatePayload {
+  /** Opaque nonce — echoed back by the provider as the `state` query param. */
+  nonce: string;
+  userId: string;
+  provider: string;
+  returnTo: string;
+  /** Unix seconds. */
+  createdAt: number;
+  /** PKCE code verifier (base64url). Empty when provider.usePkce is false. */
+  codeVerifier: string;
+}
+
+export const STATE_COOKIE_NAME = "__oauth_state";
+
+function b64urlEncode(s: string | Buffer): string {
+  const buf = typeof s === "string" ? Buffer.from(s, "utf-8") : s;
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(s: string): Buffer {
+  // Restore padding to make Buffer.from('base64') happy.
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  const normalized = s.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  return Buffer.from(normalized, "base64");
+}
+
+function hmac(secret: string, body: string): Buffer {
+  return createHmac("sha256", secret).update(body).digest();
+}
+
+/**
+ * Encode and sign a state payload. Format: `<b64url(JSON)>.<b64url(hmac)>`.
+ */
+export function signState(payload: StatePayload, secret: string): string {
+  const body = b64urlEncode(JSON.stringify(payload));
+  const sig = b64urlEncode(hmac(secret, body));
+  return `${body}.${sig}`;
+}
+
+/**
+ * Verify the HMAC signature and parse the payload. Throws
+ * {@link StateTamperedError} on signature mismatch.
+ */
+export function verifyState(signed: string, secret: string): StatePayload {
+  const dot = signed.lastIndexOf(".");
+  if (dot < 1 || dot === signed.length - 1) throw new StateTamperedError();
+
+  const body = signed.slice(0, dot);
+  const sig = signed.slice(dot + 1);
+
+  const expected = hmac(secret, body);
+  const actual = b64urlDecode(sig);
+
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    throw new StateTamperedError();
+  }
+
+  let payload: StatePayload;
+  try {
+    payload = JSON.parse(b64urlDecode(body).toString("utf-8")) as StatePayload;
+  } catch {
+    throw new StateTamperedError();
+  }
+
+  return payload;
+}
+
+/** Reject when `now - createdAt > ttlSeconds`. */
+export function assertStateFresh(payload: StatePayload, ttlSeconds: number, now: number): void {
+  if (now - payload.createdAt > ttlSeconds) throw new StateExpiredError();
+}
+
+export function generateNonce(): string {
+  return randomBytes(16).toString("hex");
+}
+
+/**
+ * Serialize a `Set-Cookie` header for the state cookie. `HttpOnly`,
+ * `Secure`, `SameSite=Lax` — the cookie is only attached on top-level
+ * navigations to the callback, which is enough for the OAuth flow and
+ * resists CSRF.
+ */
+export function buildStateCookie(value: string, ttlSeconds: number, domain?: string): string {
+  const parts = [
+    `${STATE_COOKIE_NAME}=${value}`,
+    "Path=/oauth",
+    `Max-Age=${ttlSeconds}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ];
+  if (domain) parts.push(`Domain=${domain}`);
+  return parts.join("; ");
+}
+
+/** Serialize a `Set-Cookie` header that clears the state cookie. */
+export function clearStateCookie(domain?: string): string {
+  const parts = [
+    `${STATE_COOKIE_NAME}=`,
+    "Path=/oauth",
+    "Max-Age=0",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ];
+  if (domain) parts.push(`Domain=${domain}`);
+  return parts.join("; ");
+}
+
+/**
+ * Read the signed state cookie value from a request's `Cookie` header,
+ * or throw {@link StateMissingError} when absent.
+ */
+export function readStateCookie(req: Request): string {
+  const raw = req.headers.get("cookie") ?? "";
+  for (const part of raw.split(";")) {
+    const [k, ...rest] = part.trim().split("=");
+    if (k === STATE_COOKIE_NAME) return rest.join("=");
+  }
+  throw new StateMissingError();
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/storage/ddb-kms.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/storage/ddb-kms.ts
@@ -1,0 +1,167 @@
+// ── DDBKmsTokenStorage ───────────────────────────────────────────────
+//
+// Production backend. One DDB row per (userId, provider). Each row
+// stores the full TokenGrant JSON encrypted with a KMS data key.
+// `EncryptionContext: { purpose, userId, provider }` binds the
+// ciphertext to its user/provider pair — a leaked blob cannot be
+// decrypted cross-user because KMS checks the context on Decrypt.
+//
+// The AWS SDK packages are optional peer dependencies. Install them
+// alongside this module if you use this backend.
+
+import {
+  DeleteItemCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+  QueryCommand,
+  type AttributeValue,
+  type QueryCommandOutput,
+} from "@aws-sdk/client-dynamodb";
+import { DecryptCommand, EncryptCommand, KMSClient } from "@aws-sdk/client-kms";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+
+import type { TokenGrant, TokenStorage } from "./types.js";
+
+const ENCRYPTION_PURPOSE = "oauth-token";
+const TWO_YEARS_SECONDS = 2 * 365 * 24 * 3600;
+
+export interface DDBKmsTokenStorageConfig {
+  tableName: string;
+  keyId: string;
+  region?: string;
+  /** Override the DynamoDB client (tests). */
+  ddbClient?: DynamoDBClient;
+  /** Override the KMS client (tests). */
+  kmsClient?: KMSClient;
+  /** Override the TTL attribute value (seconds from now). Default: 2 years. */
+  ttlSeconds?: number;
+}
+
+export class DDBKmsTokenStorage implements TokenStorage {
+  private readonly ddb: DynamoDBClient;
+  private readonly kms: KMSClient;
+  private readonly tableName: string;
+  private readonly keyId: string;
+  private readonly ttlSeconds: number;
+
+  constructor(config: DDBKmsTokenStorageConfig) {
+    this.tableName = config.tableName;
+    this.keyId = config.keyId;
+    this.ttlSeconds = config.ttlSeconds ?? TWO_YEARS_SECONDS;
+
+    const handler = new NodeHttpHandler({ connectionTimeout: 1000, requestTimeout: 5000 });
+    this.ddb =
+      config.ddbClient ??
+      new DynamoDBClient({ region: config.region, requestHandler: handler });
+    this.kms =
+      config.kmsClient ??
+      new KMSClient({ region: config.region, requestHandler: handler });
+  }
+
+  async get(userId: string, provider: string): Promise<TokenGrant | null> {
+    const response = await this.ddb.send(
+      new GetItemCommand({
+        TableName: this.tableName,
+        Key: {
+          userId: { S: userId },
+          provider: { S: provider },
+        },
+      }),
+    );
+    const ciphertext = response.Item?.ciphertext?.B;
+    if (!ciphertext) return null;
+    return this.decrypt(Buffer.from(ciphertext), userId, provider);
+  }
+
+  async put(userId: string, provider: string, grant: TokenGrant): Promise<void> {
+    const ciphertext = await this.encrypt(grant, userId, provider);
+    const now = Math.floor(Date.now() / 1000);
+    await this.ddb.send(
+      new PutItemCommand({
+        TableName: this.tableName,
+        Item: {
+          userId: { S: userId },
+          provider: { S: provider },
+          ciphertext: { B: ciphertext },
+          updatedAt: { S: new Date().toISOString() },
+          ttl: { N: String(now + this.ttlSeconds) },
+        },
+      }),
+    );
+  }
+
+  async delete(userId: string, provider: string): Promise<void> {
+    await this.ddb.send(
+      new DeleteItemCommand({
+        TableName: this.tableName,
+        Key: {
+          userId: { S: userId },
+          provider: { S: provider },
+        },
+      }),
+    );
+  }
+
+  async deleteAllForUser(userId: string): Promise<void> {
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined = undefined;
+    do {
+      const response: QueryCommandOutput = await this.ddb.send(
+        new QueryCommand({
+          TableName: this.tableName,
+          KeyConditionExpression: "userId = :u",
+          ExpressionAttributeValues: { ":u": { S: userId } },
+          ProjectionExpression: "userId, #p",
+          ExpressionAttributeNames: { "#p": "provider" },
+          ExclusiveStartKey: exclusiveStartKey,
+        }),
+      );
+      for (const item of response.Items ?? []) {
+        const provider = item.provider?.S;
+        if (!provider) continue;
+        await this.ddb.send(
+          new DeleteItemCommand({
+            TableName: this.tableName,
+            Key: {
+              userId: { S: userId },
+              provider: { S: provider },
+            },
+          }),
+        );
+      }
+      exclusiveStartKey = response.LastEvaluatedKey;
+    } while (exclusiveStartKey);
+  }
+
+  private async encrypt(grant: TokenGrant, userId: string, provider: string): Promise<Buffer> {
+    const plaintext = Buffer.from(JSON.stringify(grant), "utf-8");
+    const response = await this.kms.send(
+      new EncryptCommand({
+        KeyId: this.keyId,
+        Plaintext: plaintext,
+        EncryptionContext: { purpose: ENCRYPTION_PURPOSE, userId, provider },
+      }),
+    );
+    if (!response.CiphertextBlob) {
+      throw new Error("KMS Encrypt returned no ciphertext");
+    }
+    return Buffer.from(response.CiphertextBlob);
+  }
+
+  private async decrypt(
+    ciphertext: Buffer,
+    userId: string,
+    provider: string,
+  ): Promise<TokenGrant> {
+    const response = await this.kms.send(
+      new DecryptCommand({
+        CiphertextBlob: ciphertext,
+        EncryptionContext: { purpose: ENCRYPTION_PURPOSE, userId, provider },
+      }),
+    );
+    if (!response.Plaintext) {
+      throw new Error("KMS Decrypt returned no plaintext");
+    }
+    return JSON.parse(Buffer.from(response.Plaintext).toString("utf-8")) as TokenGrant;
+  }
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/storage/memory.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/storage/memory.ts
@@ -1,0 +1,41 @@
+// ── InMemoryTokenStorage ─────────────────────────────────────────────
+//
+// Volatile, single-process storage. Good for tests and local dev.
+// Do not use in production — tokens vanish on restart.
+
+import type { TokenGrant, TokenStorage } from "./types.js";
+
+export class InMemoryTokenStorage implements TokenStorage {
+  private readonly byUser = new Map<string, Map<string, TokenGrant>>();
+
+  async get(userId: string, provider: string): Promise<TokenGrant | null> {
+    return this.byUser.get(userId)?.get(provider) ?? null;
+  }
+
+  async put(userId: string, provider: string, grant: TokenGrant): Promise<void> {
+    let inner = this.byUser.get(userId);
+    if (!inner) {
+      inner = new Map();
+      this.byUser.set(userId, inner);
+    }
+    inner.set(provider, grant);
+  }
+
+  async delete(userId: string, provider: string): Promise<void> {
+    const inner = this.byUser.get(userId);
+    if (!inner) return;
+    inner.delete(provider);
+    if (inner.size === 0) this.byUser.delete(userId);
+  }
+
+  async deleteAllForUser(userId: string): Promise<void> {
+    this.byUser.delete(userId);
+  }
+
+  /** Test-only: count stored grants (total across all users). */
+  _size(): number {
+    let n = 0;
+    for (const inner of this.byUser.values()) n += inner.size;
+    return n;
+  }
+}

--- a/templates/module-oauth-delegation/skeleton/src/oauth/storage/types.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/storage/types.ts
@@ -1,0 +1,1 @@
+export type { TokenStorage, TokenGrant } from "../types.js";

--- a/templates/module-oauth-delegation/skeleton/src/oauth/types.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/types.ts
@@ -1,0 +1,128 @@
+// ── Public type surface ──────────────────────────────────────────────
+//
+// These interfaces are the contract between the module and its
+// consumers. They are re-exported from `./index.ts` so consumers import
+// from the package root, not from here.
+
+/**
+ * An OAuth 2.0 access grant as returned by the provider's token endpoint
+ * (post-parsing). `accessToken` is mandatory; the rest are provider-dependent.
+ */
+export interface TokenGrant {
+  accessToken: string;
+  refreshToken?: string;
+  /** Absolute expiry, unix seconds. Missing means the provider doesn't expire tokens (e.g., Notion). */
+  expiresAt?: number;
+  scope?: string;
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * Durable per-(userId, provider) storage of {@link TokenGrant}s.
+ *
+ * Implementations must tolerate concurrent access — the router dedups
+ * in-flight refreshes within a single process, but the storage itself
+ * may still see concurrent writes from other instances.
+ */
+export interface TokenStorage {
+  get(userId: string, provider: string): Promise<TokenGrant | null>;
+  put(userId: string, provider: string, grant: TokenGrant): Promise<void>;
+  delete(userId: string, provider: string): Promise<void>;
+  deleteAllForUser(userId: string): Promise<void>;
+}
+
+/**
+ * Reason codes for a revocation event. `user` — user-initiated disconnect.
+ * `offboarding` — bulk removal (e.g., when a user leaves the workspace).
+ * `refresh-failed` — the provider rejected the refresh; the token has
+ * been deleted and re-auth is required.
+ */
+export type RevocationReason = "user" | "offboarding" | "refresh-failed";
+
+/**
+ * Optional sink for revocation events. Default is a no-op; consumers may
+ * inject a webhook or pub/sub publisher to propagate disconnects to
+ * downstream systems.
+ */
+export interface RevocationEmitter {
+  emit(event: { userId: string; provider: string; reason: RevocationReason }): Promise<void>;
+}
+
+/**
+ * Adapter for a single OAuth 2.0 provider. Ship one per provider; call
+ * {@link registerProvider} at import time to make it discoverable.
+ *
+ * `authUrl` is a template string containing placeholders that the router
+ * substitutes: `{client_id}`, `{redirect_uri}`, `{scope}`, `{state}`,
+ * `{code_challenge}`, `{code_challenge_method}`. Provider-specific extras
+ * (e.g., `access_type=offline`) can be baked into the template.
+ */
+export interface OAuthProvider {
+  readonly name: string;
+  readonly authUrl: string;
+  readonly tokenUrl: string;
+  readonly revokeUrl?: string;
+  readonly defaultScopes: string[];
+  readonly usePkce: boolean;
+
+  parseTokenResponse(raw: unknown): TokenGrant;
+  /**
+   * Optional override for refresh responses when they differ in shape from
+   * the initial authorization-code response (e.g., Google omits
+   * `refresh_token` on refresh — the caller is expected to reuse the
+   * existing one).
+   */
+  refreshTokenResponse?(raw: unknown, previous: TokenGrant): TokenGrant;
+}
+
+/** Per-client credentials — one record per provider. Redirect URIs are exact-matched. */
+export interface ClientCredentials {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+/**
+ * Framework-neutral HTTP handler. Accepts a Web-standard {@link Request}
+ * and returns a {@link Response}. Consumers wire this into Hono, Express,
+ * Lambda, or raw `node:http` with thin adapters.
+ */
+export type RequestHandler = (req: Request) => Promise<Response>;
+
+/** Caller-identity resolution — injected by the consumer. Returns null if unauthenticated. */
+export type ResolveUserId = (req: Request) => Promise<string | null>;
+
+export interface OAuthRouterConfig {
+  providers: Record<string, OAuthProvider>;
+  storage: TokenStorage;
+  /** HMAC-SHA256 signing key for the state cookie. Any random string ≥ 32 bytes works. */
+  stateSigningSecret: string;
+  resolveUserId: ResolveUserId;
+  clientCredentials: Record<string, ClientCredentials>;
+  /** Optional Domain attribute on the state cookie. */
+  cookieDomain?: string;
+  /** Refresh window — refresh when `expiresAt < now + leadTimeSeconds`. Default 60. */
+  leadTimeSeconds?: number;
+  /** State cookie TTL. Default 600 (10 minutes). */
+  stateTtlSeconds?: number;
+  /** Optional revocation event sink. Default is a no-op. */
+  revocationEmitter?: RevocationEmitter;
+  /**
+   * Optional scope override per provider. Falls back to the adapter's
+   * `defaultScopes` when absent. Lets one consumer request Notion
+   * read-only while another requests read-write.
+   */
+  scopes?: Record<string, string[]>;
+}
+
+export interface OAuthRouter {
+  handlers: {
+    start: RequestHandler;
+    callback: RequestHandler;
+    refresh: RequestHandler;
+    revoke: RequestHandler;
+  };
+  getValidToken(userId: string, provider: string): Promise<string | null>;
+  revokeTokens(userId: string, provider: string): Promise<void>;
+  revokeAllForUser(userId: string): Promise<void>;
+}

--- a/templates/module-oauth-delegation/skeleton/tsconfig.json
+++ b/templates/module-oauth-delegation/skeleton/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2024"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/module-oauth-delegation/skeleton/vitest.config.ts
+++ b/templates/module-oauth-delegation/skeleton/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      thresholds: {
+        statements: 75,
+        branches: 75,
+        functions: 75,
+        lines: 75,
+      },
+      include: ["src/**/*.ts"],
+      exclude: [
+        "dist/**",
+        "**/__tests__/**",
+        "**/*.config.ts",
+        "src/oauth/index.ts",
+      ],
+    },
+  },
+});

--- a/templates/module-oauth-delegation/template.yaml
+++ b/templates/module-oauth-delegation/template.yaml
@@ -1,0 +1,55 @@
+apiVersion: nanohype/v1
+
+name: module-oauth-delegation
+displayName: "OAuth Delegation Module"
+description: >
+  Composable outbound OAuth 2.0 delegation module. Handles the Authorization
+  Code flow with PKCE, HMAC-signed state cookies, durable per-user token
+  storage, and automatic refresh-before-expiry. Ships reference adapters for
+  Notion, Google (Drive/Calendar/Analytics), Atlassian (Confluence), Slack,
+  and HubSpot, plus in-memory and DynamoDB+KMS envelope-encrypted storage
+  backends. Complements module-auth — that verifies inbound requests, this
+  delegates outbound calls on a user's behalf.
+version: "0.1.0"
+license: Apache-2.0
+persona: [engineering]
+category: composable-modules
+tags: [oauth, oauth2, pkce, delegation, integrations, typescript, security]
+
+variables:
+  - name: ProjectName
+    type: string
+    placeholder: "__PROJECT_NAME__"
+    description: "Kebab-case project name, used as package name and directory"
+    prompt: "Project name"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be lowercase kebab-case starting with a letter"
+
+  - name: Description
+    type: string
+    placeholder: "__DESCRIPTION__"
+    description: "Short project description for package.json and README"
+    prompt: "Project description"
+    default: "Per-user OAuth 2.0 delegation with PKCE, token storage, and automatic refresh"
+
+hooks:
+  post:
+    - name: install-dependencies
+      description: "Install npm dependencies"
+      run: "npm install"
+      workdir: "."
+
+composition:
+  pairsWith: [ts-service, mcp-server-ts]
+  nestsInside: [monorepo]
+
+prerequisites:
+  - name: node
+    version: ">=22"
+    purpose: "Node.js runtime for the OAuth delegation module"
+    optional: false
+  - name: aws-cli
+    purpose: "Provision the DynamoDB table and KMS key used by DDBKmsTokenStorage"
+    optional: true


### PR DESCRIPTION
## Summary

- New composable module `templates/module-oauth-delegation/` for outbound OAuth 2.0 delegation — the complement to `module-auth`. Stores per-user tokens and calls third-party APIs on the user's behalf.
- Ships adapters for Notion, Google, Atlassian, Slack, HubSpot and two storage backends (in-memory + DynamoDB/KMS envelope-encrypted).
- Drive-by fix to `sdk/src/sources/local.ts`: `walkDir` was flattening nested paths; this made every scaffolded template land as a single flat directory. Fix threads `baseDir` through the recursion and also excludes `dist/` and `coverage/` from the skeleton walk.
- Second follow-up commit (4504f9d) addresses the quality audit: `AbortSignal.timeout` on every outbound fetch (catalog convention from aec17fb), same-origin-only `returnTo` validation, raised logger redaction depth, shared error/expires helpers, richer skeleton README, and a drive-by fix to `templates/vscode-ext` whose test was failing CI on main (ESM module cache-bust via `?t=Date.now()` doesn't actually cache-bust, so a module-level `Map` leaked across tests).

## Design

- Framework-neutral: handlers take Web-standard `Request` → `Response`. Wire to Hono, Express, Lambda, or raw `node:http`.
- PKCE (S256) always on. Code verifier lives in the HMAC-signed state cookie — no server-side state table.
- State cookie: HMAC-SHA256, 10-minute TTL, `timingSafeEqual` compare. Callback verifies `state.userId === resolveUserId(req)` using a consumer-injected hook.
- Refresh-before-expiry with a per-key mutex to coalesce concurrent refreshes within a process. Refresh failures do not retry: delete + emit `refresh-failed` + return null.
- Tokens never in logs. Logger has a hard-coded redaction list for `accessToken`/`refreshToken`/`code`/`codeVerifier`/`clientSecret` at any nesting depth; a unit test asserts this holds.
- `DDBKmsTokenStorage` key schema: PK `userId`, SK `provider`. KMS `EncryptionContext` = `{ purpose, userId, provider }` so a leaked blob cannot be decrypted cross-user. AWS SDK packages are declared as optional peer deps.
- All outbound fetches carry `AbortSignal.timeout(10_000)` so a slow provider can't pin a socket.

## How it differs from `module-auth`

| | `module-auth` | `module-oauth-delegation` |
|---|---|---|
| Direction | Inbound — verify requests | Outbound — call APIs for the user |
| State | Request-scoped | Durable per-(user, provider) |
| Surface | Middleware + guards | Four handlers + `getValidToken()` |

Most services want both: `module-auth` to say who's calling, `module-oauth-delegation` to call downstream on their behalf.

## Test plan

- [x] `npm run validate:schema` — passes
- [x] `./scripts/validate.sh templates/module-oauth-delegation` — passes
- [x] `npm run validate:catalog` — 0 errors, 0 warnings
- [x] Skeleton in place: `typecheck`, `lint`, `test:coverage` — all pass, 81/81 tests, coverage 88.89% stmts / 77.85% branches / 90.72% funcs / 88.89% lines
- [x] SDK tests green after the `walkDir` fix
- [x] `templates/vscode-ext` skeleton tests green after the test-isolation fix
- [x] Scaffold smoke test: `node sdk/dist/bin/nanohype.js scaffold module-oauth-delegation --local . --output /tmp/oauth-scaffold-test ...` produces the correct directory tree, placeholders substitute, and the scaffolded project's `typecheck`/`lint`/`test` all pass
- [ ] Manual end-to-end flow against a real provider (left for the consuming service — this PR ships the template)

---

cc @stxkxsbot

Co-authored-by: stxkxsbot <275011021+stxkxsbot@users.noreply.github.com>