### PR TITLE
feat(module-oauth-delegation): readStatePayloadUnverified for consumer routing

### DIFF
--- a/templates/module-oauth-delegation/README.md
+++ b/templates/module-oauth-delegation/README.md
@@ -151,6 +151,27 @@ Each adapter is a plain `OAuthProvider` object that self-registers at import tim
 
 The per-key mutex deduplicates concurrent refreshes within a single Node.js process. Multi-instance deployments may race; inject a shared-state mutex (Redis, for instance) via the `createOAuthRouter` seam if that matters for your throughput.
 
+## Consumer escape hatch — `readStatePayloadUnverified`
+
+Some consumers have a signed `/start` URL as their only caller-identity signal, with no parallel session on the `/callback` side. Their `resolveUserId` needs to answer both cases:
+
+```typescript
+import { readStatePayloadUnverified, type ResolveUserId } from "your-oauth-module";
+
+const resolveUserId: ResolveUserId = async (req) => {
+  const url = new URL(req.url);
+  const signedToken = url.searchParams.get("t");
+  if (signedToken) return verifyMySignedToken(signedToken); // /start
+
+  // /callback — no signed URL token present. Fall back to the cookie.
+  const cookie = req.headers.get("cookie") ?? "";
+  const payload = readStatePayloadUnverified(cookie);
+  return payload?.userId ?? null;
+};
+```
+
+`readStatePayloadUnverified` parses the cookie **without** checking the HMAC — it is a routing aid, not an authorization signal. The module's callback handler re-verifies via `verifyState` before trusting anything in the payload, so a forged cookie is caught there. The `Unverified` suffix is deliberate: do not use the returned payload to make access decisions.
+
 ## module-auth vs module-oauth-delegation
 
 | | `module-auth` | `module-oauth-delegation` |

--- a/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/state.test.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/__tests__/state.test.ts
@@ -8,6 +8,7 @@ import {
   clearStateCookie,
   generateNonce,
   readStateCookie,
+  readStatePayloadUnverified,
   signState,
   STATE_COOKIE_NAME,
   verifyState,
@@ -110,5 +111,63 @@ describe("state cookie", () => {
   it("generateNonce returns hex of at least 16 bytes", () => {
     const n = generateNonce();
     expect(n).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("readStatePayloadUnverified", () => {
+  it("round-trips a signed payload to its parsed userId/provider", () => {
+    const p = payload();
+    const signed = signState(p, SECRET);
+    const parsed = readStatePayloadUnverified(signed);
+    expect(parsed?.userId).toBe(p.userId);
+    expect(parsed?.provider).toBe(p.provider);
+    expect(parsed?.returnTo).toBe(p.returnTo);
+  });
+
+  it("extracts the state value from a full Cookie: header", () => {
+    const signed = signState(payload(), SECRET);
+    const header = `foo=bar; ${STATE_COOKIE_NAME}=${signed}; baz=qux`;
+    const parsed = readStatePayloadUnverified(header);
+    expect(parsed?.userId).toBe("user-1");
+  });
+
+  it("returns null when cookie is missing from the header", () => {
+    expect(readStatePayloadUnverified("foo=bar; baz=qux")).toBeNull();
+  });
+
+  it("returns null on malformed cookie (no signature separator)", () => {
+    expect(readStatePayloadUnverified("no-dot")).toBeNull();
+    expect(readStatePayloadUnverified("")).toBeNull();
+  });
+
+  it("returns null on non-JSON payload body", () => {
+    const badBody = Buffer.from("not-json", "utf-8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(readStatePayloadUnverified(`${badBody}.anysig`)).toBeNull();
+  });
+
+  it("returns null when JSON doesn't match the StatePayload shape", () => {
+    const wrongShape = { hello: "world" };
+    const body = Buffer.from(JSON.stringify(wrongShape), "utf-8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(readStatePayloadUnverified(`${body}.anysig`)).toBeNull();
+  });
+
+  it("does NOT verify the signature — a tampered sig still yields a payload", () => {
+    // This is the point: the function is explicitly unverified. Callers
+    // must route the cookie through verifyState before trusting it.
+    const signed = signState(payload(), SECRET);
+    const [body] = signed.split(".");
+    const forged = `${body}.this-signature-is-bogus`;
+    const parsed = readStatePayloadUnverified(forged);
+    expect(parsed?.userId).toBe("user-1");
+    // ...but verifyState on the same value must reject it.
+    expect(() => verifyState(forged, SECRET)).toThrow(StateTamperedError);
   });
 });

--- a/templates/module-oauth-delegation/skeleton/src/oauth/index.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/index.ts
@@ -37,6 +37,14 @@ export {
 
 export { logger } from "./logger.js";
 
+// State cookie helpers — `readStatePayloadUnverified` lets consumers peek
+// at the userId / provider / returnTo without verifying the HMAC, which
+// is useful when routing `resolveUserId` signals on `/callback` from a
+// service that has no independent auth source. See its JSDoc for the
+// (narrow) safety contract.
+export { readStatePayloadUnverified } from "./state.js";
+export type { StatePayload } from "./state.js";
+
 // Provider adapters — importing this file also triggers their self-registration
 // via the ./providers barrel.
 export {

--- a/templates/module-oauth-delegation/skeleton/src/oauth/state.ts
+++ b/templates/module-oauth-delegation/skeleton/src/oauth/state.ts
@@ -133,3 +133,65 @@ export function readStateCookie(req: Request): string {
   }
   throw new StateMissingError();
 }
+
+function isStatePayload(value: unknown): value is StatePayload {
+  if (value === null || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.nonce === "string" &&
+    typeof v.userId === "string" &&
+    typeof v.provider === "string" &&
+    typeof v.returnTo === "string" &&
+    typeof v.createdAt === "number" &&
+    typeof v.codeVerifier === "string"
+  );
+}
+
+/**
+ * Parse a state-cookie value **without** verifying the HMAC signature.
+ *
+ * Useful for consumers whose own `resolveUserId` implementation has no
+ * parallel auth signal on `/callback` and needs to recover the userId
+ * from the cookie for routing. The module's handlers re-verify the
+ * HMAC before trusting the payload, so this peek cannot be used to
+ * bypass anything — a forged cookie is caught at the
+ * {@link verifyState} step in the `/callback` handler.
+ *
+ * **Contract:** the returned payload is untrusted. Callers MUST NOT
+ * make authorization decisions from it on their own.
+ *
+ * Accepts either a raw `Cookie:` header string (e.g.
+ * `"foo=bar; __oauth_state=<value>"`) or the already-extracted cookie
+ * value (just the signed `<body>.<sig>` part). Returns `null` when the
+ * cookie is missing, malformed, or the payload doesn't match
+ * {@link StatePayload}.
+ */
+export function readStatePayloadUnverified(cookieHeaderOrValue: string): StatePayload | null {
+  if (!cookieHeaderOrValue) return null;
+
+  // If it's a raw Cookie header (has "name=value" pairs separated by `;`
+  // or `=` appears before the first `.`), extract the state-cookie value.
+  let raw = cookieHeaderOrValue;
+  if (raw.includes(";") || (raw.includes("=") && raw.indexOf("=") < raw.indexOf("."))) {
+    let found: string | null = null;
+    for (const part of raw.split(";")) {
+      const [k, ...rest] = part.trim().split("=");
+      if (k === STATE_COOKIE_NAME) {
+        found = rest.join("=");
+        break;
+      }
+    }
+    if (found === null) return null;
+    raw = found;
+  }
+
+  const dot = raw.lastIndexOf(".");
+  if (dot < 1) return null;
+  const body = raw.slice(0, dot);
+  try {
+    const parsed = JSON.parse(b64urlDecode(body).toString("utf-8"));
+    return isStatePayload(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a public `readStatePayloadUnverified` helper to `module-oauth-delegation`. Lets consumers peek a state cookie's userId / provider for routing on `/callback` without re-implementing the cookie format or weakening the verified path. Purely additive.

## Why

Consumers whose `/start` caller-identity is a signed URL token (e.g., a Slack bot handing a user an outbound OAuth link) have no parallel auth signal when the provider redirects back to `/callback`. Their `resolveUserId` needs to recover the userId from somewhere — and the state cookie already carries it.

Before this change, such consumers had two options, neither great:
1. Reimplement the state-cookie format inline (couples to module internals that could shift in a minor)
2. Always return null on `/callback` (defeats the `resolveUserId` contract)

The `almanac` project in [protohype#11](https://github.com/nanohype/protohype/pull/11) hit this and picked option 1 with an inline cookie parse + a "coupling to module internals" caveat in code. This PR gives them — and any future consumer — a supported API.

## API

```ts
readStatePayloadUnverified(cookieHeaderOrValue: string): StatePayload | null
```

Accepts a raw `Cookie:` header string OR an already-extracted state cookie value. Returns the parsed payload or `null` for malformed/missing/off-shape inputs. Also re-exports `StatePayload` as a public type so consumers can type their `resolveUserId` plumbing.

The function does **not** verify the HMAC. The module's own `/callback` handler re-verifies via `verifyState` before trusting the payload, so this peek cannot be used to bypass anything — a forged cookie is caught at the verified step. The `Unverified` suffix is deliberate.

## Files changed

- `state.ts` — adds private `isStatePayload` type guard and the new `readStatePayloadUnverified` export
- `index.ts` — re-exports the helper + the `StatePayload` type
- `README.md` — new "Consumer escape hatch" section under Security model documenting the pattern with a clear caveat
- `__tests__/state.test.ts` — 7 new cases (signed round-trip, header extraction, missing/malformed/non-JSON/off-shape inputs, and the explicit "does NOT verify" contract)

## Verification

Fresh scaffold + install + tests against the updated template:

```
$ npx nanohype scaffold module-oauth-delegation --local . --var ProjectName=verify-oauth -o /tmp/verify
$ cd /tmp/verify && npm install && npm run typecheck && npm test

Test Files  12 passed (12)
     Tests  88 passed (88)        # was 81; +7 new
```

## Test plan

- [x] All 88 tests pass against a fresh scaffold (was 81)
- [x] `npm run typecheck` clean
- [x] `npm audit` — 0 vulnerabilities
- [x] No existing handler / storage / verify-path behavior changed
- [ ] Reviewer: confirm the README example reads cleanly to someone who hasn't seen the consumer

## Consumer follow-up (out of scope for this PR)

Once this lands and a consumer scaffold pulls in the new helper, the inline cookie parse in `protohype/almanac/src/oauth/router.ts:resolveUserId` swaps to `readStatePayloadUnverified(cookie)`. Tracked separately.