### PR TITLE
fix(tests): flaky z-score anomaly detection assertion

### DIFF
--- a/templates/module-llm-gateway/skeleton/src/gateway/__tests__/cost.test.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/__tests__/cost.test.ts
@@ -168,9 +168,15 @@ describe("anomaly detection", () => {
     });
 
     const anomalies = detectAnomalies(entries, 20, 2.0);
-    expect(anomalies.length).toBeGreaterThan(0);
-    expect(anomalies[0].entry.cost).toBe(0.5);
-    expect(anomalies[0].zScore).toBeGreaterThan(2.0);
+
+    // detectAnomalies returns entries in chronological order, not z-score
+    // order, so the injected spike is not guaranteed to be anomalies[0] —
+    // incidental tail draws from the uniform noise can trigger false
+    // positives at earlier window positions. Assert that the spike IS in
+    // the result set (which is what the test name promises).
+    const spike = anomalies.find((a) => a.entry.cost === 0.5);
+    expect(spike).toBeDefined();
+    expect(spike!.zScore).toBeGreaterThan(2.0);
   });
 
   it("returns empty for uniform costs", () => {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
@@ -167,9 +167,15 @@ describe("anomaly detection", () => {
     });
 
     const anomalies = detectAnomalies(entries, 20, 2.0);
-    expect(anomalies.length).toBeGreaterThan(0);
-    expect(anomalies[0].entry.cost).toBe(0.5);
-    expect(anomalies[0].zScore).toBeGreaterThan(2.0);
+
+    // detectAnomalies returns entries in chronological order, not z-score
+    // order, so the injected spike is not guaranteed to be anomalies[0] —
+    // incidental tail draws from the uniform noise can trigger false
+    // positives at earlier window positions. Assert that the spike IS in
+    // the result set (which is what the test name promises).
+    const spike = anomalies.find((a) => a.entry.cost === 0.5);
+    expect(spike).toBeDefined();
+    expect(spike!.zScore).toBeGreaterThan(2.0);
   });
 
   it("returns empty for uniform costs", () => {


### PR DESCRIPTION
## Summary

Two near-identical z-score anomaly-detection tests in `module-llm-observability` and `module-llm-gateway` have been flaking on CI. Root cause is an ordering assumption in the test assertion, not an issue with the detector.

**Reproduced locally:** 2 failures / 30 runs (~7% flake rate) on pre-fix `main`. After the fix: 0 failures / 50 runs on both copies.

## Root cause

The test seeds 25 "normal" cost entries at `0.01 + Math.random() * 0.001`, injects one spike at `cost = 0.5`, then calls `detectAnomalies(entries, 20, 2.0)`. The detector slides a 20-entry window across indices 20–25 and returns hits **in chronological order**, not sorted by z-score.

A 2.0 threshold flags ~5% of points by chance on any distribution. Iterations `i=20..24` each have a small but real chance of producing a false positive on a normal entry. When that happens, the false positive lands at `anomalies[0]` before the spike at `i=25` is even examined. Across 6 iterations this compounds to ~7% end-to-end.

The old assertion `expect(anomalies[0].entry.cost).toBe(0.5)` baked in the false assumption that the spike is always first.

## Fix

Replace the positional assertion with a value-based lookup:

```diff
- expect(anomalies.length).toBeGreaterThan(0);
- expect(anomalies[0].entry.cost).toBe(0.5);
- expect(anomalies[0].zScore).toBeGreaterThan(2.0);
+ const spike = anomalies.find((a) => a.entry.cost === 0.5);
+ expect(spike).toBeDefined();
+ expect(spike!.zScore).toBeGreaterThan(2.0);
```

This matches the test's stated intent ("detects cost spikes using z-score") and tolerates incidental false positives, which are inherent to a thresholded detector — not a bug.

## Alternatives considered and rejected

- **Seed `Math.random`**: invasive (global polyfill or `vi.spyOn`); treats a statistical artifact as if it were noise requiring determinism. The real defect is the assertion, not the RNG.
- **Sort anomalies by `|zScore|` in the detector**: would change a public contract callers may depend on. Chronological ordering is useful and correct.
- **Reduce test noise to zero**: would trip the detector's `stdDev < 1e-10` guard and return zero anomalies, failing the test outright for a different reason.

## Test plan

- [x] Pre-fix: 2 failures / 30 runs on `module-llm-observability` test
- [x] Post-fix: 0 failures / 50 runs on `module-llm-observability` test
- [x] Post-fix: 0 failures / 50 runs on `module-llm-gateway` test
- [x] `./scripts/validate.sh` still clean for both templates
- [ ] CI `Validate Templates` run goes green

## Relationship to other PRs

Unblocks #66 (`spring-boot-service` template), whose CI showed this same flaky failure. Independent of #66 — can merge on its own.