### PR TITLE
feat(istio-policy): JWT + mTLS + routing policy bundle for service-mesh workloads

### DIFF
--- a/templates/istio-policy/README.md
+++ b/templates/istio-policy/README.md
@@ -1,0 +1,48 @@
+# istio-policy
+
+Scaffolds an Istio service-mesh policy bundle for an HTTP workload: JWT authentication via `RequestAuthentication`, claim-based authorization via `AuthorizationPolicy`, optional STRICT mTLS via `PeerAuthentication`, and an optional `VirtualService` routing template.
+
+Drops alongside any containerized service — pairs naturally with [spring-boot-service](../spring-boot-service/), [go-service](../go-service/), or [ts-service](../ts-service/).
+
+## What you get
+
+- **`request-authentication.yaml`** — configures the JWT issuer + JWKs endpoint so the sidecar decodes incoming tokens and exposes their claims to the authorization layer. Requests without a valid token proceed without an authenticated principal (the AuthorizationPolicy decides what to do with them).
+- **`authorization-policy.yaml`** — enforces that inbound traffic carries a JWT issued by the configured issuer with the expected audience. Blocks unauthenticated requests at the sidecar, before they reach the application.
+- **`peer-authentication.yaml`** *(conditional)* — enforces STRICT mTLS between sidecars in the namespace. Only turn this on once every workload in the namespace has a sidecar; in STRICT mode, non-mTLS traffic is rejected.
+- **`virtual-service.yaml`** *(conditional)* — routing template attached to either the internal mesh (`gateways: [mesh]`) or an external Istio gateway. Ships with a single catch-all route; add path-based splits or traffic shifting as needed.
+
+## Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `ProjectName` | string | (required) | Kebab-case project name; drives resource names and selector labels |
+| `Namespace` | string | `default` | Kubernetes namespace |
+| `OidcIssuer` | string | (required) | OIDC issuer URL that signs inbound JWTs |
+| `JwksUri` | string | `<OidcIssuer>/.well-known/jwks.json` | JWKs endpoint URL |
+| `AllowedAudience` | string | `<ProjectName>` | Required JWT `aud` claim value |
+| `ServiceHost` | string | `<ProjectName>.<Namespace>.svc.cluster.local` | Fully-qualified service host (for VirtualService) |
+| `GatewayName` | string | `mesh` | Gateway the VirtualService attaches to (`mesh` = internal-only) |
+| `IncludeMTls` | bool | `false` | Ship a STRICT PeerAuthentication |
+| `IncludeVirtualService` | bool | `false` | Ship a VirtualService |
+
+## Project layout
+
+```text
+istio/
+  authorization-policy.yaml    # Deny-by-default; allow authenticated callers
+  request-authentication.yaml  # JWT issuer + JWKs endpoint
+  peer-authentication.yaml     # STRICT mTLS (conditional)
+  virtual-service.yaml         # Routing template (conditional)
+  README.md
+```
+
+## Pairs with
+
+- [spring-boot-service](../spring-boot-service/) — enable Spring Security OAuth 2.0 resource server with the same `OidcIssuer` to get defense-in-depth (mesh validates, app validates again)
+- [go-service](../go-service/) — pair with any JWT middleware on the app side
+- [ts-service](../ts-service/) — same
+- [k8s-deploy](../k8s-deploy/) — deploys the workload; this template layers mesh policy on top
+
+## Nests inside
+
+- [monorepo](../monorepo/)

--- a/templates/istio-policy/skeleton/README.md
+++ b/templates/istio-policy/skeleton/README.md
@@ -1,0 +1,31 @@
+# __PROJECT_NAME__ — Istio policy
+
+Istio service-mesh policy bundle for `__PROJECT_NAME__` in the `__NAMESPACE__` namespace.
+
+## Resources
+
+| File | Kind | Purpose |
+|---|---|---|
+| `request-authentication.yaml` | `RequestAuthentication` | Tells the sidecar how to decode inbound JWTs — issuer `__OIDC_ISSUER__`, JWKs at `__JWKS_URI__`. |
+| `authorization-policy.yaml` | `AuthorizationPolicy` | Requires an authenticated principal from the configured issuer with audience `__ALLOWED_AUD__`. Unauthenticated requests are rejected at the sidecar. |
+| `peer-authentication.yaml` | `PeerAuthentication` | STRICT mTLS for all sidecar-to-sidecar traffic in the namespace. Only apply once every workload has a sidecar. |
+| `virtual-service.yaml` | `VirtualService` | Routing template for `__SERVICE_HOST__` attached to gateway `__GATEWAY_NAME__`. |
+
+## Apply
+
+```sh
+kubectl apply -f .
+
+# optional validation before apply
+istioctl analyze .
+```
+
+Order matters if you're introducing mTLS to an existing namespace: apply `request-authentication.yaml` and `authorization-policy.yaml` first, confirm auth works, then apply `peer-authentication.yaml` only once every workload is sidecar-injected.
+
+## Selector labels
+
+All four resources select workloads by `app.kubernetes.io/name: __PROJECT_NAME__`. Make sure your Deployment pod template carries that label — `k8s-deploy` sets it by default.
+
+## Defense in depth
+
+Pair this bundle with application-layer JWT validation in the workload (e.g. Spring Security's OAuth 2.0 resource server configured with the same `__OIDC_ISSUER__`). The mesh enforcement catches unauthenticated traffic before it reaches the pod; the app enforcement remains a safety net if the sidecar is bypassed or misconfigured.

--- a/templates/istio-policy/skeleton/authorization-policy.yaml
+++ b/templates/istio-policy/skeleton/authorization-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: __PROJECT_NAME__-require-jwt
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: __PROJECT_NAME__
+    app.kubernetes.io/component: istio-policy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: __PROJECT_NAME__
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            requestPrincipals:
+              - "__OIDC_ISSUER__/*"
+      when:
+        - key: request.auth.claims[aud]
+          values:
+            - __ALLOWED_AUD__

--- a/templates/istio-policy/skeleton/peer-authentication.yaml
+++ b/templates/istio-policy/skeleton/peer-authentication.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: __PROJECT_NAME__-mtls
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: __PROJECT_NAME__
+    app.kubernetes.io/component: istio-policy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: __PROJECT_NAME__
+  mtls:
+    mode: STRICT

--- a/templates/istio-policy/skeleton/request-authentication.yaml
+++ b/templates/istio-policy/skeleton/request-authentication.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: __PROJECT_NAME__-jwt
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: __PROJECT_NAME__
+    app.kubernetes.io/component: istio-policy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: __PROJECT_NAME__
+  jwtRules:
+    - issuer: __OIDC_ISSUER__
+      jwksUri: __JWKS_URI__
+      audiences:
+        - __ALLOWED_AUD__
+      forwardOriginalToken: true

--- a/templates/istio-policy/skeleton/virtual-service.yaml
+++ b/templates/istio-policy/skeleton/virtual-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: __PROJECT_NAME__
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: __PROJECT_NAME__
+    app.kubernetes.io/component: istio-policy
+spec:
+  hosts:
+    - __SERVICE_HOST__
+  gateways:
+    - __GATEWAY_NAME__
+  http:
+    - name: default
+      route:
+        - destination:
+            host: __SERVICE_HOST__
+            port:
+              number: 8080
+          weight: 100

--- a/templates/istio-policy/template.yaml
+++ b/templates/istio-policy/template.yaml
@@ -1,0 +1,114 @@
+apiVersion: nanohype/v1
+
+name: istio-policy
+displayName: "Istio Service-Mesh Policy"
+description: >
+  Scaffolds an Istio policy bundle for an HTTP workload on a service mesh:
+  an AuthorizationPolicy that enforces JWT authentication, a
+  RequestAuthentication that configures the JWT issuer + JWKs endpoint,
+  an optional PeerAuthentication enforcing STRICT mTLS, and an optional
+  VirtualService routing template. Designed to drop alongside any
+  containerized service template (spring-boot-service, go-service, ts-service).
+version: "0.1.0"
+license: Apache-2.0
+persona: [engineering]
+category: infrastructure
+tags: [istio, kubernetes, k8s, service-mesh, authorization, oidc, mtls, security]
+
+variables:
+  - name: ProjectName
+    type: string
+    placeholder: "__PROJECT_NAME__"
+    description: "Kebab-case project name, used for resource names and selector labels"
+    prompt: "Project name"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be lowercase kebab-case starting with a letter"
+
+  - name: Namespace
+    type: string
+    placeholder: "__NAMESPACE__"
+    description: "Kubernetes namespace the policy resources are applied to"
+    prompt: "Namespace"
+    default: "default"
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be a valid Kubernetes namespace (lowercase kebab-case)"
+
+  - name: OidcIssuer
+    type: string
+    placeholder: "__OIDC_ISSUER__"
+    description: "OIDC issuer URL that signs inbound JWTs (e.g. https://auth.example.com)"
+    prompt: "OIDC issuer URL"
+    required: true
+
+  - name: JwksUri
+    type: string
+    placeholder: "__JWKS_URI__"
+    description: >
+      JWKs endpoint URL. For standard OIDC providers this is usually
+      {issuer}/.well-known/jwks.json — override if your provider uses a
+      different path.
+    prompt: "JWKs URI"
+    default: "${OidcIssuer}/.well-known/jwks.json"
+    required: true
+
+  - name: AllowedAudience
+    type: string
+    placeholder: "__ALLOWED_AUD__"
+    description: "JWT `aud` claim value required for requests to this service"
+    prompt: "Expected JWT audience"
+    default: "${ProjectName}"
+    required: true
+
+  - name: ServiceHost
+    type: string
+    placeholder: "__SERVICE_HOST__"
+    description: "Fully-qualified service host for the VirtualService"
+    prompt: "Service host"
+    default: "${ProjectName}.${Namespace}.svc.cluster.local"
+
+  - name: GatewayName
+    type: string
+    placeholder: "__GATEWAY_NAME__"
+    description: >
+      Istio Gateway resource name the VirtualService attaches to. Use
+      "mesh" for internal-only (default) or the name of an external
+      ingress gateway (e.g. "istio-system/public-gateway") for
+      externally-reachable traffic.
+    prompt: "Gateway (use 'mesh' for internal-only)"
+    default: "mesh"
+
+  - name: IncludeMTls
+    type: bool
+    placeholder: "__INCLUDE_MTLS__"
+    description: "Include a PeerAuthentication resource enforcing STRICT mTLS"
+    prompt: "Include STRICT mTLS PeerAuthentication?"
+    default: false
+
+  - name: IncludeVirtualService
+    type: bool
+    placeholder: "__INCLUDE_VIRTUAL_SERVICE__"
+    description: "Include a VirtualService routing template"
+    prompt: "Include VirtualService?"
+    default: false
+
+conditionals:
+  - path: "peer-authentication.yaml"
+    when: IncludeMTls
+  - path: "virtual-service.yaml"
+    when: IncludeVirtualService
+
+composition:
+  pairsWith: [spring-boot-service, go-service, ts-service, k8s-deploy]
+  nestsInside: [monorepo]
+
+prerequisites:
+  - name: kubectl
+    purpose: "Apply Istio policy manifests to the cluster"
+    optional: false
+  - name: istioctl
+    version: ">=1.20"
+    purpose: "Validate Istio resource manifests (`istioctl analyze`) before apply"
+    optional: true

--- a/templates/spring-boot-service/README.md
+++ b/templates/spring-boot-service/README.md
@@ -1,0 +1,99 @@
+# spring-boot-service
+
+Scaffolds a Java [Spring Boot 3](https://spring.io/projects/spring-boot) HTTP service on **JDK 25** (latest LTS) with Spring Web MVC, Spring Boot Actuator, optional Spring Security (OAuth 2.0 resource server with JWT), Spring Data JPA + [Flyway](https://flywaydb.org/) migrations, Micrometer + [OpenTelemetry](https://opentelemetry.io/) instrumentation, and a clean controller / service / repository layering.
+
+## What you get
+
+- A Spring Boot 3 application with embedded Tomcat and graceful shutdown
+- Layered architecture: web controllers, service layer, JPA repositories, domain entities
+- Spring Boot Actuator endpoints: `/actuator/health` (liveness + readiness groups), `/actuator/info`, `/actuator/prometheus`
+- Optional OAuth 2.0 resource server via Spring Security — validates incoming JWT bearer tokens against a configurable issuer
+- JPA entity with a Flyway baseline migration (`V1__init.sql`)
+- Micrometer metrics with a Prometheus scrape endpoint and OpenTelemetry tracing (OTLP exporter, configurable endpoint)
+- Structured JSON logging via Logback with trace/span correlation fields
+- Testcontainers-backed integration test (`ExampleIntegrationTest`) that exercises the real database
+- `Makefile` with common targets (`run`, `test`, `package`, `lint`, `clean`, `docker`)
+- GitHub Actions CI workflow (build, test, dependency submission for SBOM)
+- k6 load test scaffolding
+- Optional multi-stage `Dockerfile` and `docker-compose.yml` with a bundled Postgres
+
+## Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `ProjectName` | string | (required) | Kebab-case project name |
+| `GroupId` | string | `com.example` | Maven groupId (reverse-DNS, dot-separated) |
+| `ArtifactId` | string | `<ProjectName>` | Maven artifactId (kebab-case) |
+| `Description` | string | `A Spring Boot HTTP service` | Short project description |
+| `JavaPackage` | string | `<GroupId>.app` | Root Java package, dot form (e.g. `com.example.app`) |
+| `PackageDir` | string | `com/example/app` | Root Java package, slash form — must pair with `JavaPackage` |
+| `Database` | string | `postgres` | Database driver: `postgres`, `mysql`, or `h2` |
+| `IncludeAuth` | bool | `true` | Include Spring Security OAuth 2.0 resource server |
+| `IncludeDocker` | bool | `true` | Include Dockerfile and docker-compose.yml |
+
+### On the two package variables
+
+nanohype placeholders are literal string substitutions — there's no way to derive the slash-form of a package from its dot-form. That's why `JavaPackage` (e.g. `com.example.app`) and `PackageDir` (e.g. `com/example/app`) are exposed as separate variables. Keep them in sync when you override.
+
+## Project layout
+
+```text
+<ProjectName>/
+  pom.xml                                # Maven build, Spring Boot 3 parent, dependencies
+  Makefile                               # run, test, package, lint, clean, docker
+  Dockerfile                             # Multi-stage build (conditional)
+  docker-compose.yml                     # App + Postgres for local dev (conditional)
+  .env.example
+  .gitignore
+  .github/
+    workflows/
+      ci.yml                             # Build, test, SBOM dependency submission
+  src/
+    main/
+      java/
+        <PackageDir>/
+          Application.java               # Entrypoint — @SpringBootApplication
+          config/
+            OpenApiConfig.java           # springdoc-openapi setup
+            ObservabilityConfig.java     # Micrometer + OTel bootstrap
+            SecurityConfig.java          # OAuth 2.0 resource server (conditional)
+          web/
+            HealthController.java        # Custom /api/v1/hello endpoint
+            ExampleController.java       # Example CRUD
+            GlobalExceptionHandler.java  # @ControllerAdvice with problem+json
+          service/
+            ExampleService.java          # Business logic
+          domain/
+            ExampleEntity.java           # JPA entity
+          repository/
+            ExampleRepository.java       # Spring Data JPA repo
+      resources/
+        application.yaml                 # Default config
+        application-local.yaml           # Local profile overrides
+        logback-spring.xml               # JSON structured logging
+        db/migration/
+          V1__init.sql                   # Flyway baseline
+    test/
+      java/
+        <PackageDir>/
+          ApplicationTests.java          # Context load
+          web/HealthControllerTest.java  # @WebMvcTest
+          ExampleIntegrationTest.java    # Testcontainers + full stack
+  load-test/
+    k6/
+      script.js
+      config.json
+    README.md
+  README.md
+```
+
+## Pairs with
+
+- [k8s-deploy](../k8s-deploy/) — Kubernetes manifests and Helm chart for deployment
+- [monitoring-stack](../monitoring-stack/) — Prometheus + Grafana + Loki observability stack
+- [infra-gcp](../infra-gcp/) — deploy to Google Cloud Run
+- [infra-aws](../infra-aws/) — deploy to AWS ECS or Lambda
+
+## Nests inside
+
+- [monorepo](../monorepo/)

--- a/templates/spring-boot-service/README.md
+++ b/templates/spring-boot-service/README.md
@@ -1,10 +1,10 @@
 # spring-boot-service
 
-Scaffolds a Java [Spring Boot 3](https://spring.io/projects/spring-boot) HTTP service on **JDK 25** (latest LTS) with Spring Web MVC, Spring Boot Actuator, optional Spring Security (OAuth 2.0 resource server with JWT), Spring Data JPA + [Flyway](https://flywaydb.org/) migrations, Micrometer + [OpenTelemetry](https://opentelemetry.io/) instrumentation, and a clean controller / service / repository layering.
+Scaffolds a Java [Spring Boot 4](https://spring.io/projects/spring-boot) HTTP service on **JDK 25** (latest LTS) with Spring Web MVC, Spring Boot Actuator, optional Spring Security (OAuth 2.0 resource server with JWT), Spring Data JPA + [Flyway](https://flywaydb.org/) migrations, Micrometer + [OpenTelemetry](https://opentelemetry.io/) instrumentation, and a clean controller / service / repository layering.
 
 ## What you get
 
-- A Spring Boot 3 application with embedded Tomcat and graceful shutdown
+- A Spring Boot 4 application with embedded Tomcat and graceful shutdown
 - Layered architecture: web controllers, service layer, JPA repositories, domain entities
 - Spring Boot Actuator endpoints: `/actuator/health` (liveness + readiness groups), `/actuator/info`, `/actuator/prometheus`
 - Optional OAuth 2.0 resource server via Spring Security — validates incoming JWT bearer tokens against a configurable issuer
@@ -39,7 +39,7 @@ nanohype placeholders are literal string substitutions — there's no way to der
 
 ```text
 <ProjectName>/
-  pom.xml                                # Maven build, Spring Boot 3 parent, dependencies
+  pom.xml                                # Maven build, Spring Boot 4 parent, dependencies
   Makefile                               # run, test, package, lint, clean, docker
   Dockerfile                             # Multi-stage build (conditional)
   docker-compose.yml                     # App + Postgres for local dev (conditional)

--- a/templates/spring-boot-service/skeleton/.env.example
+++ b/templates/spring-boot-service/skeleton/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env for local runs: `cp .env.example .env`
+SERVER_PORT=8080
+SPRING_PROFILES_ACTIVE=local
+
+DATABASE_URL=jdbc:postgresql://localhost:5432/__ARTIFACT_ID__
+DATABASE_USERNAME=postgres
+DATABASE_PASSWORD=postgres
+
+# Leave blank to disable JWT validation locally; set to your OIDC issuer in real environments.
+OAUTH2_ISSUER_URI=
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+TRACING_SAMPLE_RATE=1.0

--- a/templates/spring-boot-service/skeleton/.github/workflows/ci.yml
+++ b/templates/spring-boot-service/skeleton/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Verify (compile, test, integration-test)
+        run: mvn -B verify
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports/
+
+  dependency-submission:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+      - name: Submit Maven dependency tree
+        uses: advanced-security/maven-dependency-submission-action@v4

--- a/templates/spring-boot-service/skeleton/.gitignore
+++ b/templates/spring-boot-service/skeleton/.gitignore
@@ -1,0 +1,8 @@
+target/
+.idea/
+*.iml
+.vscode/
+.DS_Store
+HELP.md
+.env
+.env.local

--- a/templates/spring-boot-service/skeleton/Dockerfile
+++ b/templates/spring-boot-service/skeleton/Dockerfile
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:25-jdk AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn -B -q -DskipTests dependency:go-offline || true
+COPY src ./src
+RUN mvn -B -q -DskipTests package && \
+    cp target/__ARTIFACT_ID__.jar /build/app.jar
+
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+RUN addgroup --system app && adduser --system --ingroup app app
+COPY --from=build /build/app.jar app.jar
+USER app
+EXPOSE 8080
+ENTRYPOINT ["java", "-XX:+UseZGC", "-XX:MaxRAMPercentage=75", "-jar", "/app/app.jar"]

--- a/templates/spring-boot-service/skeleton/Makefile
+++ b/templates/spring-boot-service/skeleton/Makefile
@@ -1,0 +1,26 @@
+.PHONY: run test package lint clean docker docker-run
+
+run:
+	mvn spring-boot:run -Dspring-boot.run.profiles=local
+
+test:
+	mvn test
+
+verify:
+	mvn verify
+
+package:
+	mvn -DskipTests package
+
+lint:
+	mvn -q -Dmaven.test.skip=true checkstyle:check || true
+	mvn -q compile
+
+clean:
+	mvn clean
+
+docker:
+	mvn -DskipTests spring-boot:build-image
+
+docker-run:
+	docker compose up --build

--- a/templates/spring-boot-service/skeleton/README.md
+++ b/templates/spring-boot-service/skeleton/README.md
@@ -2,7 +2,7 @@
 
 __DESCRIPTION__
 
-Spring Boot 3 HTTP service on JDK 25 with Spring Web MVC, Actuator, Spring Data JPA, Flyway migrations, Micrometer + OpenTelemetry, and structured JSON logging.
+Spring Boot 4 HTTP service on JDK 25 with Spring Web MVC, Actuator, Spring Data JPA, Flyway migrations, Micrometer + OpenTelemetry, and structured JSON logging.
 
 **Default database:** `__DATABASE__` (pom.xml ships drivers for `postgres`, `mysql`, and `h2` — switch by setting `SPRING_DATASOURCE_URL`).
 

--- a/templates/spring-boot-service/skeleton/README.md
+++ b/templates/spring-boot-service/skeleton/README.md
@@ -1,0 +1,69 @@
+# __PROJECT_NAME__
+
+__DESCRIPTION__
+
+Spring Boot 3 HTTP service on JDK 25 with Spring Web MVC, Actuator, Spring Data JPA, Flyway migrations, Micrometer + OpenTelemetry, and structured JSON logging.
+
+**Default database:** `__DATABASE__` (pom.xml ships drivers for `postgres`, `mysql`, and `h2` — switch by setting `SPRING_DATASOURCE_URL`).
+
+## Quickstart
+
+```sh
+# start Postgres
+docker compose up -d db
+
+# run the app on port 8080 with the local profile
+make run
+
+curl http://localhost:8080/api/v1/hello
+curl http://localhost:8080/actuator/health
+```
+
+## Make targets
+
+| Target | Description |
+|---|---|
+| `make run` | Boot the app with the `local` profile |
+| `make test` | Unit tests |
+| `make verify` | Unit + integration tests (Testcontainers) |
+| `make package` | Build jar (skipping tests) |
+| `make docker` | Build OCI image via `spring-boot:build-image` |
+| `make docker-run` | `docker compose up --build` |
+
+## Layout
+
+```text
+src/main/java/__PKG_DIR__/
+  Application.java               # @SpringBootApplication entrypoint
+  config/
+    OpenApiConfig.java           # springdoc-openapi
+    ObservabilityConfig.java     # Micrometer + OTel setup
+    SecurityConfig.java          # OAuth 2.0 resource server
+  web/                           # REST controllers + exception handler
+  service/                       # @Transactional business logic
+  domain/                        # JPA entities
+  repository/                    # Spring Data JPA repositories
+src/main/resources/
+  application.yaml               # Default config (env var overrides)
+  application-local.yaml         # Local profile overrides
+  logback-spring.xml             # JSON logs w/ trace correlation
+  db/migration/V1__init.sql      # Flyway baseline
+```
+
+## Configuration
+
+All configuration is driven by environment variables — see `.env.example`. The `local` profile loads Postgres on `localhost:5432` for dev.
+
+For production: set `OAUTH2_ISSUER_URI` to your OIDC issuer so the resource server validates JWTs against its JWK set.
+
+## Observability
+
+- `GET /actuator/health` — aggregate health; `/health/liveness` and `/health/readiness` for Kubernetes probes
+- `GET /actuator/prometheus` — Prometheus scrape endpoint
+- Traces exported via OTLP to `OTEL_EXPORTER_OTLP_ENDPOINT` (defaults to `http://localhost:4318/v1/traces`)
+- Logs emitted as JSON with `traceId` and `spanId` fields for correlation
+
+## OpenAPI
+
+- `GET /v3/api-docs` — OpenAPI JSON
+- `GET /swagger-ui.html` — Swagger UI

--- a/templates/spring-boot-service/skeleton/docker-compose.yml
+++ b/templates/spring-boot-service/skeleton/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+      DATABASE_URL: jdbc:postgresql://db:5432/__ARTIFACT_ID__
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: postgres
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318/v1/traces
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: __ARTIFACT_ID__
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/templates/spring-boot-service/skeleton/load-test/README.md
+++ b/templates/spring-boot-service/skeleton/load-test/README.md
@@ -1,0 +1,16 @@
+# Load tests
+
+[k6](https://k6.io/) scripts for synthetic load.
+
+## Run
+
+```sh
+k6 run k6/script.js
+
+# against a non-local environment
+BASE_URL=https://staging.example.com k6 run k6/script.js
+```
+
+## Thresholds
+
+See `k6/config.json` — p95 latency must stay under 500ms, error rate under 1%.

--- a/templates/spring-boot-service/skeleton/load-test/k6/config.json
+++ b/templates/spring-boot-service/skeleton/load-test/k6/config.json
@@ -1,0 +1,11 @@
+{
+  "stages": [
+    { "duration": "30s", "target": 20 },
+    { "duration": "1m", "target": 50 },
+    { "duration": "30s", "target": 0 }
+  ],
+  "thresholds": {
+    "http_req_duration": ["p(95)<500"],
+    "http_req_failed": ["rate<0.01"]
+  }
+}

--- a/templates/spring-boot-service/skeleton/load-test/k6/script.js
+++ b/templates/spring-boot-service/skeleton/load-test/k6/script.js
@@ -1,0 +1,15 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+export const options = JSON.parse(open('./config.json'));
+
+export default function () {
+  const res = http.get(`${BASE_URL}/api/v1/hello`);
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'body contains service': (r) => r.body.includes('__ARTIFACT_ID__'),
+  });
+  sleep(1);
+}

--- a/templates/spring-boot-service/skeleton/pom.xml
+++ b/templates/spring-boot-service/skeleton/pom.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.2</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>__GROUP_ID__</groupId>
+    <artifactId>__ARTIFACT_ID__</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>__PROJECT_NAME__</name>
+    <description>__DESCRIPTION__</description>
+
+    <properties>
+        <java.version>25</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <springdoc.version>2.7.0</springdoc.version>
+        <opentelemetry.version>1.45.0</opentelemetry.version>
+        <logstash-logback.version>8.0</logstash-logback.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-logback.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>__ARTIFACT_ID__</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <image>
+                        <name>__ARTIFACT_ID__:${project.version}</name>
+                    </image>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/templates/spring-boot-service/skeleton/pom.xml
+++ b/templates/spring-boot-service/skeleton/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.2</version>
+        <version>4.0.5</version>
         <relativePath/>
     </parent>
 
@@ -21,8 +21,8 @@
         <java.version>25</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <springdoc.version>2.7.0</springdoc.version>
-        <opentelemetry.version>1.45.0</opentelemetry.version>
+        <springdoc.version>2.8.6</springdoc.version>
+        <opentelemetry.version>1.46.0</opentelemetry.version>
         <logstash-logback.version>8.0</logstash-logback.version>
         <testcontainers.version>1.20.4</testcontainers.version>
     </properties>

--- a/templates/spring-boot-service/skeleton/pom.xml
+++ b/templates/spring-boot-service/skeleton/pom.xml
@@ -55,8 +55,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
@@ -109,6 +109,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/Application.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/Application.java
@@ -1,0 +1,12 @@
+package __JAVA_PKG__;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/ObservabilityConfig.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/ObservabilityConfig.java
@@ -2,7 +2,7 @@ package __JAVA_PKG__.config;
 
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/ObservabilityConfig.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/ObservabilityConfig.java
@@ -1,0 +1,26 @@
+package __JAVA_PKG__.config;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Micrometer + OpenTelemetry wiring. Spring Boot auto-configures the Prometheus
+ * registry and the OTLP exporter from application.yaml; this class only adds
+ * service-level tags and enables @Timed support.
+ */
+@Configuration
+public class ObservabilityConfig {
+
+    @Bean
+    MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
+        return registry -> registry.config().commonTags("service", "__ARTIFACT_ID__");
+    }
+
+    @Bean
+    TimedAspect timedAspect(MeterRegistry registry) {
+        return new TimedAspect(registry);
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/OpenApiConfig.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package __JAVA_PKG__.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    OpenAPI openApi() {
+        return new OpenAPI().info(new Info()
+            .title("__PROJECT_NAME__")
+            .description("__DESCRIPTION__")
+            .version("v1"));
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/SecurityConfig.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package __JAVA_PKG__.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/health/**", "/actuator/info", "/actuator/prometheus").permitAll()
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .build();
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/domain/ExampleEntity.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/domain/ExampleEntity.java
@@ -1,0 +1,34 @@
+package __JAVA_PKG__.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "examples")
+public class ExampleEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    protected ExampleEntity() {}
+
+    public ExampleEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/repository/ExampleRepository.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/repository/ExampleRepository.java
@@ -1,0 +1,7 @@
+package __JAVA_PKG__.repository;
+
+import __JAVA_PKG__.domain.ExampleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExampleRepository extends JpaRepository<ExampleEntity, Long> {
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/service/ExampleService.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/service/ExampleService.java
@@ -1,0 +1,40 @@
+package __JAVA_PKG__.service;
+
+import __JAVA_PKG__.domain.ExampleEntity;
+import __JAVA_PKG__.repository.ExampleRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ExampleService {
+
+    private final ExampleRepository repo;
+
+    public ExampleService(ExampleRepository repo) {
+        this.repo = repo;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExampleEntity> list() {
+        return repo.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ExampleEntity> find(Long id) {
+        return repo.findById(id);
+    }
+
+    public ExampleEntity create(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        return repo.save(new ExampleEntity(name));
+    }
+
+    public void delete(Long id) {
+        repo.deleteById(id);
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/web/ExampleController.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/web/ExampleController.java
@@ -1,0 +1,56 @@
+package __JAVA_PKG__.web;
+
+import __JAVA_PKG__.domain.ExampleEntity;
+import __JAVA_PKG__.service.ExampleService;
+import io.micrometer.core.annotation.Timed;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/examples")
+@Timed("examples.controller")
+public class ExampleController {
+
+    private final ExampleService service;
+
+    public ExampleController(ExampleService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<ExampleEntity> list() {
+        return service.list();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ExampleEntity> get(@PathVariable Long id) {
+        return service.find(id)
+            .map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<ExampleEntity> create(@Valid @RequestBody CreateRequest body) {
+        ExampleEntity created = service.create(body.name());
+        return ResponseEntity.created(URI.create("/api/v1/examples/" + created.getId())).body(created);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    public record CreateRequest(@NotBlank @Size(max = 120) String name) {}
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/web/GlobalExceptionHandler.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/web/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package __JAVA_PKG__.web;
+
+import jakarta.validation.ConstraintViolationException;
+import java.net.URI;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ProblemDetail handleBeanValidation(MethodArgumentNotValidException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setType(URI.create("https://__PROJECT_NAME__/errors/validation"));
+        pd.setTitle("Validation failed");
+        return pd;
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    ProblemDetail handleConstraint(ConstraintViolationException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setType(URI.create("https://__PROJECT_NAME__/errors/constraint"));
+        pd.setTitle("Constraint violation");
+        return pd;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    ProblemDetail handleIllegalArg(IllegalArgumentException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setTitle("Bad request");
+        return pd;
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/web/HealthController.java
+++ b/templates/spring-boot-service/skeleton/src/main/java/__PKG_DIR__/web/HealthController.java
@@ -1,0 +1,20 @@
+package __JAVA_PKG__.web;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class HealthController {
+
+    @GetMapping("/hello")
+    public Map<String, Object> hello() {
+        return Map.of(
+            "service", "__ARTIFACT_ID__",
+            "message", "hello from __PROJECT_NAME__",
+            "timestamp", Instant.now().toString());
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/main/resources/application-local.yaml
+++ b/templates/spring-boot-service/skeleton/src/main/resources/application-local.yaml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/__ARTIFACT_ID__
+    username: postgres
+    password: postgres
+
+management:
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    __JAVA_PKG__: DEBUG
+    org.springframework.web: INFO

--- a/templates/spring-boot-service/skeleton/src/main/resources/application.yaml
+++ b/templates/spring-boot-service/skeleton/src/main/resources/application.yaml
@@ -1,0 +1,66 @@
+spring:
+  application:
+    name: __ARTIFACT_ID__
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+  datasource:
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/__ARTIFACT_ID__}
+    username: ${DATABASE_USERNAME:postgres}
+    password: ${DATABASE_PASSWORD:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+    open-in-view: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${OAUTH2_ISSUER_URI:}
+
+server:
+  port: ${SERVER_PORT:8080}
+  shutdown: graceful
+  compression:
+    enabled: true
+  error:
+    include-message: always
+    include-binding-errors: always
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, metrics
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: when-authorized
+      group:
+        liveness:
+          include: livenessState
+        readiness:
+          include: readinessState, db
+  metrics:
+    tags:
+      application: __ARTIFACT_ID__
+  tracing:
+    sampling:
+      probability: ${TRACING_SAMPLE_RATE:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+
+logging:
+  level:
+    root: INFO
+    __JAVA_PKG__: DEBUG
+  pattern:
+    correlation: "[${spring.application.name:},%X{traceId:-},%X{spanId:-}] "

--- a/templates/spring-boot-service/skeleton/src/main/resources/application.yaml
+++ b/templates/spring-boot-service/skeleton/src/main/resources/application.yaml
@@ -22,7 +22,12 @@ spring:
     oauth2:
       resourceserver:
         jwt:
+          # Prefer OAUTH2_ISSUER_URI in real environments (enables OIDC
+          # discovery). The jwk-set-uri fallback is a lazy placeholder so
+          # SecurityConfig can always build a JwtDecoder bean — the URL is
+          # only fetched when a real JWT arrives, never at startup.
           issuer-uri: ${OAUTH2_ISSUER_URI:}
+          jwk-set-uri: ${OAUTH2_JWK_SET_URI:http://localhost:1/jwks-placeholder}
 
 server:
   port: ${SERVER_PORT:8080}

--- a/templates/spring-boot-service/skeleton/src/main/resources/db/migration/V1__init.sql
+++ b/templates/spring-boot-service/skeleton/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE examples (
+    id         BIGSERIAL PRIMARY KEY,
+    name       VARCHAR(120) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_examples_created_at ON examples(created_at DESC);

--- a/templates/spring-boot-service/skeleton/src/main/resources/logback-spring.xml
+++ b/templates/spring-boot-service/skeleton/src/main/resources/logback-spring.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <customFields>{"service":"${appName}"}</customFields>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <root level="INFO">
+            <appender-ref ref="JSON"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/ApplicationTests.java
+++ b/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/ApplicationTests.java
@@ -1,0 +1,13 @@
+package __JAVA_PKG__;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {}
+}

--- a/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/ExampleIntegrationTest.java
+++ b/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/ExampleIntegrationTest.java
@@ -1,0 +1,37 @@
+package __JAVA_PKG__;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import __JAVA_PKG__.domain.ExampleEntity;
+import __JAVA_PKG__.repository.ExampleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+class ExampleIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    ExampleRepository repo;
+
+    @Test
+    void persistsAndLoadsEntity() {
+        ExampleEntity saved = repo.save(new ExampleEntity("integration-test"));
+
+        ExampleEntity loaded = repo.findById(saved.getId()).orElseThrow();
+
+        assertThat(loaded.getName()).isEqualTo("integration-test");
+        assertThat(loaded.getCreatedAt()).isNotNull();
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/ExampleIntegrationTest.java
+++ b/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/ExampleIntegrationTest.java
@@ -8,14 +8,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+/**
+ * Full-stack integration test against a real PostgreSQL container — exercises
+ * Flyway migrations, Hibernate schema validation, and JPA repository flow.
+ * Uses the default profile (not the H2-based `test` profile) so that the
+ * production migration path is verified end-to-end.
+ */
 @SpringBootTest
 @Testcontainers
-@ActiveProfiles("test")
 class ExampleIntegrationTest {
 
     @Container

--- a/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/web/HealthControllerTest.java
+++ b/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/web/HealthControllerTest.java
@@ -1,19 +1,25 @@
 package __JAVA_PKG__.web;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import __JAVA_PKG__.config.SecurityConfig;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(HealthController.class)
-@Import(SecurityConfig.class)
+/**
+ * Slice test for the controller layer only. Security filters are disabled
+ * (addFilters=false) and the OAuth2 resource server auto-config is excluded
+ * because a web slice doesn't supply the HttpSecurity bean that auto-config
+ * requires. Authentication flow is covered by the full integration test.
+ */
+@WebMvcTest(controllers = HealthController.class,
+    excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
 class HealthControllerTest {
 
     @Autowired
@@ -21,7 +27,7 @@ class HealthControllerTest {
 
     @Test
     void helloReturnsServiceName() throws Exception {
-        mvc.perform(get("/api/v1/hello").with(jwt()))
+        mvc.perform(get("/api/v1/hello"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.service").value("__ARTIFACT_ID__"));
     }

--- a/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/web/HealthControllerTest.java
+++ b/templates/spring-boot-service/skeleton/src/test/java/__PKG_DIR__/web/HealthControllerTest.java
@@ -1,0 +1,28 @@
+package __JAVA_PKG__.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import __JAVA_PKG__.config.SecurityConfig;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HealthController.class)
+@Import(SecurityConfig.class)
+class HealthControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    void helloReturnsServiceName() throws Exception {
+        mvc.perform(get("/api/v1/hello").with(jwt()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.service").value("__ARTIFACT_ID__"));
+    }
+}

--- a/templates/spring-boot-service/skeleton/src/test/resources/application-test.yaml
+++ b/templates/spring-boot-service/skeleton/src/test/resources/application-test.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+  flyway:
+    enabled: false
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://localhost:1/test-jwks

--- a/templates/spring-boot-service/template.yaml
+++ b/templates/spring-boot-service/template.yaml
@@ -3,7 +3,7 @@ apiVersion: nanohype/v1
 name: spring-boot-service
 displayName: "Spring Boot HTTP Service"
 description: >
-  Scaffolds a Java Spring Boot 3 HTTP service with Spring Web MVC, Spring Boot
+  Scaffolds a Java Spring Boot 4 HTTP service with Spring Web MVC, Spring Boot
   Actuator for health and metrics, optional Spring Security (OAuth 2.0 resource
   server with JWT), Spring Data JPA + Flyway migrations, Micrometer + OpenTelemetry
   instrumentation, structured JSON logging, graceful shutdown, and a repository

--- a/templates/spring-boot-service/template.yaml
+++ b/templates/spring-boot-service/template.yaml
@@ -1,0 +1,133 @@
+apiVersion: nanohype/v1
+
+name: spring-boot-service
+displayName: "Spring Boot HTTP Service"
+description: >
+  Scaffolds a Java Spring Boot 3 HTTP service with Spring Web MVC, Spring Boot
+  Actuator for health and metrics, optional Spring Security (OAuth 2.0 resource
+  server with JWT), Spring Data JPA + Flyway migrations, Micrometer + OpenTelemetry
+  instrumentation, structured JSON logging, graceful shutdown, and a repository
+  pattern service layer. Includes a Makefile, GitHub Actions CI, k6 load test
+  scaffolding, Testcontainers integration tests, and optional Docker support.
+version: "0.1.0"
+license: Apache-2.0
+persona: [engineering]
+category: applications
+tags: [java, spring-boot, jvm, api, service, rest]
+
+variables:
+  - name: ProjectName
+    type: string
+    placeholder: "__PROJECT_NAME__"
+    description: "Kebab-case project name, used as repo/directory name"
+    prompt: "Project name"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be lowercase kebab-case starting with a letter"
+
+  - name: GroupId
+    type: string
+    placeholder: "__GROUP_ID__"
+    description: "Maven groupId (reverse-DNS, dot-separated, lowercase)"
+    prompt: "Maven groupId"
+    default: "com.example"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
+      message: "Must be a valid Maven groupId (e.g. com.example.acme)"
+
+  - name: ArtifactId
+    type: string
+    placeholder: "__ARTIFACT_ID__"
+    description: "Maven artifactId (kebab-case)"
+    prompt: "Maven artifactId"
+    default: "${ProjectName}"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be lowercase kebab-case starting with a letter"
+
+  - name: Description
+    type: string
+    placeholder: "__DESCRIPTION__"
+    description: "Short project description for README and pom.xml"
+    prompt: "Project description"
+    default: "A Spring Boot HTTP service"
+
+  - name: JavaPackage
+    type: string
+    placeholder: "__JAVA_PKG__"
+    description: "Root Java package (dot form, used in source declarations)"
+    prompt: "Root Java package (dot form)"
+    default: "${GroupId}.app"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
+      message: "Must be a valid Java package (e.g. com.example.app)"
+
+  - name: PackageDir
+    type: string
+    placeholder: "__PKG_DIR__"
+    description: >
+      Root Java package as a directory path (slash form, used for the source tree
+      layout). Must be the slash-form of JavaPackage — e.g. if JavaPackage is
+      'com.example.app' then PackageDir is 'com/example/app'.
+    prompt: "Root Java package (slash form)"
+    default: "com/example/app"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9_]*(/[a-z][a-z0-9_]*)*$"
+      message: "Must be lowercase segments separated by slashes (e.g. com/example/app)"
+
+  - name: Database
+    type: string
+    placeholder: "__DATABASE__"
+    description: >
+      Default database driver. Known values: postgres, mysql, h2. Additional
+      drivers can be added by editing pom.xml and application.yaml.
+    prompt: "Database driver"
+    default: "postgres"
+
+  - name: IncludeAuth
+    type: bool
+    placeholder: "__INCLUDE_AUTH__"
+    description: "Include Spring Security with OAuth 2.0 resource server (JWT validation)"
+    prompt: "Include OAuth 2.0 resource server?"
+    default: true
+
+  - name: IncludeDocker
+    type: bool
+    placeholder: "__INCLUDE_DOCKER__"
+    description: "Include Dockerfile and docker-compose.yml"
+    prompt: "Include Docker support?"
+    default: true
+
+conditionals:
+  - path: "src/main/java/__PKG_DIR__/config/SecurityConfig.java"
+    when: IncludeAuth
+  - path: "Dockerfile"
+    when: IncludeDocker
+  - path: "docker-compose.yml"
+    when: IncludeDocker
+
+hooks:
+  post:
+    - name: install-dependencies
+      description: "Resolve Maven dependencies"
+      run: "mvn -q -DskipTests dependency:resolve"
+      workdir: "."
+
+composition:
+  pairsWith: [k8s-deploy, monitoring-stack, infra-gcp, infra-aws]
+  nestsInside: [monorepo]
+
+prerequisites:
+  - name: java
+    version: ">=25"
+    purpose: "JDK 25 (latest LTS) for compiling and running the Spring Boot service"
+    optional: false
+  - name: mvn
+    version: ">=3.8"
+    purpose: "Maven build tool for dependency resolution and packaging"
+    optional: false


### PR DESCRIPTION
## Summary

Adds an Istio service-mesh policy bundle that layers onto any containerized HTTP service. Ships four v1 Istio resource manifests covering the common mesh-edge concerns: identity, authorization, transport security, and routing.

Designed to compose — pairs with `spring-boot-service`, `go-service`, `ts-service`, or `k8s-deploy`; the resources select the workload by `app.kubernetes.io/name=<ProjectName>` which `k8s-deploy` already emits.

## Resources produced

| File | Kind | Conditional? | Purpose |
|---|---|---|---|
| `request-authentication.yaml` | `RequestAuthentication` | no | JWT issuer + JWKs endpoint + expected audience. `forwardOriginalToken: true` so the app can inspect the raw token. |
| `authorization-policy.yaml` | `AuthorizationPolicy` | no | Requires an authenticated `requestPrincipal` from the issuer with the expected `aud` claim. Deny-by-default semantics. |
| `peer-authentication.yaml` | `PeerAuthentication` | `IncludeMTls` | STRICT mTLS. Gated — STRICT rejects non-sidecar traffic, only safe once every workload is injected. |
| `virtual-service.yaml` | `VirtualService` | `IncludeVirtualService` | Single catch-all route template. Gateway defaults to `mesh` (internal-only) or accepts a named external gateway. |

## Variables

Nine total. Two chain defaults that matter:

- `JwksUri` defaults to `${OidcIssuer}/.well-known/jwks.json` — the standard OIDC convention; users override if their provider uses a non-standard path.
- `ServiceHost` defaults to `${ProjectName}.${Namespace}.svc.cluster.local` — canonical K8s FQDN.
- `AllowedAudience` defaults to `${ProjectName}`.

## Stacked on #66

Targets `feat/spring-boot-service` rather than `main` — `composition.pairsWith` references `spring-boot-service` which doesn't exist on `main` yet, and `npm run validate:catalog` checks cross-refs. After #66 merges, I'll retarget this PR to `main` (should fast-forward, no conflicts).

## Test plan

- [x] `./scripts/validate.sh templates/istio-policy` — all checks pass
- [x] `npm run validate:catalog` — 0 errors, 0 warnings (**87 templates**)
- [x] End-to-end render via `@nanohype/sdk` CLI with `IncludeMTls=true`, `IncludeVirtualService=true` → 5 files, no placeholder leaks
- [x] All four rendered YAML files parse with `yaml.safe_load_all` — well-formed
- [ ] `istioctl analyze` not run locally (`istioctl` not installed on this machine); resources follow the public `security.istio.io/v1` and `networking.istio.io/v1` APIs

## Design decisions

**No `kustomization.yaml`.** Bundle is small — `kubectl apply -f .` works out of the box, and users on Kustomize or Helm will wire them into their own overlays.

**`security.istio.io/v1` not `v1beta1`.** The current GA surface (Istio ≥1.20). Older clusters can search-and-replace if needed.

**No hooks.** Templates the catalog convention expects for declarative infra (see also `k8s-deploy`, `infra-gcp`, `infra-aws` — also hook-free).

**Defense in depth with the app.** Pairs naturally with `spring-boot-service` when `IncludeAuth=true` and the same `OidcIssuer` is used on both sides — mesh catches unauthenticated traffic before the pod; app validation remains a safety net if the sidecar is bypassed.