### PR TITLE
fix(docs): markdownlint errors in .github/ISSUE_DRAFTS/

### DIFF
--- a/.github/ISSUE_DRAFTS/catalog-quality-audit.md
+++ b/.github/ISSUE_DRAFTS/catalog-quality-audit.md
@@ -1,4 +1,4 @@
-## Catalog Quality Audit — 2026-04-05
+# Catalog Quality Audit — 2026-04-05
 
 Comprehensive quality check across build health, SDK correctness, security, architecture, systems thinking, and design pattern consistency. All findings verified with file:line evidence.
 
@@ -24,6 +24,7 @@ Comprehensive quality check across build health, SDK correctness, security, arch
 Only `api-gateway` uses `AbortController` with timeout on `fetch()`. Every other template's external calls can hang indefinitely — circuit breakers don't help because a hung connection never errors (the CB never sees a failure to count).
 
 Affected (non-exhaustive):
+
 - `module-knowledge-base-ts/.../providers/{notion,confluence,coda,google-docs}.ts`
 - `module-search-ts/.../providers/{algolia,meilisearch,typesense}.ts`
 - `module-analytics-ts/.../providers/{mixpanel,amplitude,posthog,segment}.ts`

--- a/.github/ISSUE_DRAFTS/llm-wiki.md
+++ b/.github/ISSUE_DRAFTS/llm-wiki.md
@@ -1,3 +1,5 @@
+# llm-wiki — Multi-tenant LLM-maintained knowledge base
+
 ## Overview
 
 Add an `llm-wiki` template to the AI Systems category. Scaffolds a multi-tenant, LLM-maintained knowledge base where agents incrementally build structured markdown wikis from raw sources — knowledge compounds over time rather than being re-derived per query.
@@ -18,7 +20,7 @@ RAG re-derives understanding on every query. The wiki pattern front-loads the wo
 
 Three-layer design per tenant, plus a shared control plane:
 
-```
+```text
 ┌─────────────────────────────────────────────────┐
 │                  Control Plane                   │
 │  tenant registry · schema registry · auth/authz  │
@@ -102,6 +104,7 @@ llm:
 Three operations, matching the original pattern:
 
 **Ingest** — Process a new source, extract structured knowledge, create/update wiki pages:
+
 1. Hash source content, skip if already ingested (idempotent)
 2. LLM reads source against current wiki state
 3. Creates new pages or updates existing ones (type-checked against schema)
@@ -111,12 +114,14 @@ Three operations, matching the original pattern:
 7. Commits changes (git storage) or writes transaction (sqlite)
 
 **Query** — Search the wiki, synthesize an answer, optionally file discoveries back:
+
 1. Search wiki pages (FTS or git-grep depending on storage)
 2. LLM synthesizes answer from relevant pages
 3. Returns answer with source citations (page → original source chain)
 4. Optionally creates a new "discovery" page if the synthesis reveals new structure
 
 **Lint** — Health check for wiki consistency:
+
 1. Find orphaned pages (no inbound links)
 2. Detect contradictions across pages
 3. Flag stale claims (source age > threshold)
@@ -127,16 +132,19 @@ Three operations, matching the original pattern:
 ### Multi-Tenancy
 
 **Tenant isolation:**
+
 - Each tenant gets its own source store, wiki directory, and schema
 - Tenant registry in control plane (YAML or SQLite)
 - No cross-tenant data access by default
 
 **Access control:**
+
 - Role-based: `admin` (manage tenants, schemas), `editor` (ingest, lint), `reader` (query only)
 - Per-tenant role assignments
 - API key or JWT auth at the control plane
 
 **Operation queue:**
+
 - Ingest and lint operations are queued per tenant
 - Prevents concurrent wiki mutations within a tenant
 - Cross-tenant operations run in parallel
@@ -156,7 +164,7 @@ Three operations, matching the original pattern:
 
 ## Skeleton Structure
 
-```
+```text
 src/
 ├── index.ts                    # entry point — CLI + API bootstrap
 ├── config.ts                   # Zod-validated config from env
@@ -263,12 +271,13 @@ composition:
 
 The three operations map to a natural workflow pattern:
 
-```
+```text
 [Input: sources] → [Scaffold: llm-wiki] → [Agent: ingest] → [Agent: lint] → [Gate: review] → [Output: wiki]
 ```
 
 For ongoing use, a recurring workflow:
-```
+
+```text
 [Input: new sources] → [Agent: ingest] → [Condition: lint score < threshold] → [Agent: lint-fix] → [Output: updated wiki]
 ```
 


### PR DESCRIPTION
Two issue-draft markdown files were swept into commit `6962283` by a \`git add -A\` in #75. The repo-wide markdownlint-cli2 config globs \`**/*.md\`, so the drafts fall under lint scope and \`Lint Documentation\` went red on main.

Minimal mechanical fixes — content unchanged.

## catalog-quality-audit.md

- Promote the leading \`## Catalog Quality Audit\` to a top-level \`#\` (MD041 first-line-heading)
- Add a blank line before the *"Affected (non-exhaustive)"* bullet list (MD032 blanks-around-lists)

## llm-wiki.md

- Add a top-level \`# llm-wiki — ...\` heading above the existing \`## Overview\` (MD041)
- Add a blank line before each of six lists that immediately followed bold-prefix paragraphs — *"**Ingest** — ..."*, *"**Query** — ..."*, *"**Lint** — ..."*, *"**Tenant isolation:**"*, *"**Access control:**"*, *"**Operation queue:**"* (MD032)
- Tag three fenced code blocks (ASCII architecture diagram, skeleton tree, workflow pseudocode) with \`text\` (MD040 fenced-code-language)
- Add a missing blank line before the second workshop workflow fence (MD031 blanks-around-fences)

## Test plan

- [x] Ran \`npx markdownlint-cli2 .github/ISSUE_DRAFTS/catalog-quality-audit.md .github/ISSUE_DRAFTS/llm-wiki.md\` locally — zero errors for these two files (unrelated errors remain for \`sdk/node_modules/**\` which is a pre-existing glob issue, not in scope here)
- [ ] \`Lint Documentation\` workflow goes green on this PR

## Root cause + follow-up

The drafts landed in the repo via an overly broad \`git add -A\` in PR #75. Going forward I'll use explicit path-scoped staging (\`git add <path>/\`) to avoid catching incidental files.

Separately, worth considering: add \`!.github/ISSUE_DRAFTS/**\` to \`.markdownlint-cli2.jsonc\` if you'd rather these drafts stay outside lint scope. Not doing that in this PR — keeping the fix surgical.