### PR TITLE
fix(agentic-loop): replace Function constructor with arithmetic parser (#61)

### DIFF
--- a/templates/agentic-loop/skeleton/src/__tests__/example-tool.test.ts
+++ b/templates/agentic-loop/skeleton/src/__tests__/example-tool.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { evaluateArithmetic, calculatorTool } from "../tools/example.js";
+
+describe("evaluateArithmetic", () => {
+  it("evaluates simple addition", () => {
+    expect(evaluateArithmetic("2 + 3")).toBe(5);
+  });
+
+  it("evaluates simple subtraction", () => {
+    expect(evaluateArithmetic("10 - 4")).toBe(6);
+  });
+
+  it("evaluates simple multiplication", () => {
+    expect(evaluateArithmetic("6 * 7")).toBe(42);
+  });
+
+  it("evaluates simple division", () => {
+    expect(evaluateArithmetic("20 / 4")).toBe(5);
+  });
+
+  it("respects operator precedence", () => {
+    expect(evaluateArithmetic("2 + 3 * 4")).toBe(14);
+    expect(evaluateArithmetic("10 - 6 / 2")).toBe(7);
+  });
+
+  it("evaluates parenthesized sub-expressions", () => {
+    expect(evaluateArithmetic("(2 + 3) * 4")).toBe(20);
+    expect(evaluateArithmetic("2 * (3 + (4 - 1))")).toBe(12);
+  });
+
+  it("handles unary minus and plus", () => {
+    expect(evaluateArithmetic("-5")).toBe(-5);
+    expect(evaluateArithmetic("+5")).toBe(5);
+    expect(evaluateArithmetic("3 + -2")).toBe(1);
+    expect(evaluateArithmetic("-(2 + 3)")).toBe(-5);
+  });
+
+  it("handles decimal numbers", () => {
+    expect(evaluateArithmetic("1.5 + 2.25")).toBe(3.75);
+    expect(evaluateArithmetic("0.1 * 10")).toBeCloseTo(1);
+  });
+
+  it("ignores whitespace", () => {
+    expect(evaluateArithmetic("   2   +   3   ")).toBe(5);
+  });
+
+  it("produces Infinity for division by zero", () => {
+    expect(evaluateArithmetic("1 / 0")).toBe(Infinity);
+  });
+
+  it("rejects unmatched parentheses", () => {
+    expect(() => evaluateArithmetic("(1 + 2")).toThrow(/Unmatched/);
+  });
+
+  it("rejects trailing garbage", () => {
+    expect(() => evaluateArithmetic("1 + 2 x")).toThrow(/Unexpected character/);
+  });
+
+  it("rejects empty expressions", () => {
+    expect(() => evaluateArithmetic("")).toThrow(/Expected a number/);
+  });
+
+  it("rejects identifiers — no access to globals", () => {
+    expect(() => evaluateArithmetic("process")).toThrow();
+    expect(() => evaluateArithmetic("globalThis")).toThrow();
+  });
+});
+
+describe("calculatorTool", () => {
+  it("returns the computed result as a string", async () => {
+    const result = await calculatorTool.execute({ expression: "(2 + 3) * 4" });
+    expect(result).toBe("20");
+  });
+
+  it("throws on non-finite results", async () => {
+    await expect(
+      calculatorTool.execute({ expression: "0 / 0" }),
+    ).rejects.toThrow(/did not evaluate to a finite number/);
+  });
+
+  it("rejects malformed expressions", async () => {
+    await expect(
+      calculatorTool.execute({ expression: "1 +" }),
+    ).rejects.toThrow();
+  });
+});

--- a/templates/agentic-loop/skeleton/src/tools/example.ts
+++ b/templates/agentic-loop/skeleton/src/tools/example.ts
@@ -22,18 +22,9 @@ async function execute(
 ): Promise<string> {
   const { expression } = input;
 
-  // Only allow safe arithmetic characters
-  if (!/^[\d+\-*/.() ]+$/.test(expression)) {
-    throw new Error(
-      "Expression contains invalid characters. Only digits, +, -, *, /, ., (, ) are allowed.",
-    );
-  }
+  const result = evaluateArithmetic(expression);
 
-  // Evaluate the expression safely via Function constructor
-  // (restricted to arithmetic by the regex above)
-  const result = new Function(`"use strict"; return (${expression});`)() as number;
-
-  if (typeof result !== "number" || !Number.isFinite(result)) {
+  if (!Number.isFinite(result)) {
     throw new Error(`Expression did not evaluate to a finite number: ${expression}`);
   }
 
@@ -47,3 +38,121 @@ export const calculatorTool: Tool<typeof inputSchema> = {
   inputSchema,
   execute,
 };
+
+/**
+ * Evaluate an arithmetic expression using a recursive descent parser.
+ *
+ * Grammar:
+ *   expr   = term (('+' | '-') term)*
+ *   term   = factor (('*' | '/') factor)*
+ *   factor = number | '(' expr ')' | ('+' | '-') factor
+ *
+ * Avoids `eval` / `Function` entirely — the parser only understands
+ * numbers and the four basic operators, so arbitrary code cannot run
+ * even if a caller bypasses upstream validation.
+ */
+export function evaluateArithmetic(expression: string): number {
+  const parser = new ArithmeticParser(expression);
+  const value = parser.parseExpression();
+  parser.expectEnd();
+  return value;
+}
+
+class ArithmeticParser {
+  private readonly input: string;
+  private pos = 0;
+
+  constructor(input: string) {
+    this.input = input;
+  }
+
+  parseExpression(): number {
+    let value = this.parseTerm();
+    for (;;) {
+      this.skipWhitespace();
+      const op = this.peek();
+      if (op !== "+" && op !== "-") return value;
+      this.pos++;
+      const rhs = this.parseTerm();
+      value = op === "+" ? value + rhs : value - rhs;
+    }
+  }
+
+  private parseTerm(): number {
+    let value = this.parseFactor();
+    for (;;) {
+      this.skipWhitespace();
+      const op = this.peek();
+      if (op !== "*" && op !== "/") return value;
+      this.pos++;
+      const rhs = this.parseFactor();
+      value = op === "*" ? value * rhs : value / rhs;
+    }
+  }
+
+  private parseFactor(): number {
+    this.skipWhitespace();
+    const ch = this.peek();
+
+    if (ch === "+" || ch === "-") {
+      this.pos++;
+      const value = this.parseFactor();
+      return ch === "-" ? -value : value;
+    }
+
+    if (ch === "(") {
+      this.pos++;
+      const value = this.parseExpression();
+      this.skipWhitespace();
+      if (this.peek() !== ")") {
+        throw new Error(`Unmatched '(' at position ${this.pos}`);
+      }
+      this.pos++;
+      return value;
+    }
+
+    return this.parseNumber();
+  }
+
+  private parseNumber(): number {
+    this.skipWhitespace();
+    const start = this.pos;
+    while (this.pos < this.input.length && /[0-9]/.test(this.input[this.pos]!)) {
+      this.pos++;
+    }
+    if (this.input[this.pos] === ".") {
+      this.pos++;
+      while (this.pos < this.input.length && /[0-9]/.test(this.input[this.pos]!)) {
+        this.pos++;
+      }
+    }
+    if (this.pos === start) {
+      throw new Error(`Expected a number at position ${this.pos}`);
+    }
+    const literal = this.input.slice(start, this.pos);
+    const value = Number(literal);
+    if (!Number.isFinite(value)) {
+      throw new Error(`Invalid number literal: "${literal}"`);
+    }
+    return value;
+  }
+
+  expectEnd(): void {
+    this.skipWhitespace();
+    if (this.pos !== this.input.length) {
+      throw new Error(
+        `Unexpected character '${this.input[this.pos]}' at position ${this.pos}`,
+      );
+    }
+  }
+
+  private skipWhitespace(): void {
+    while (this.pos < this.input.length && this.input[this.pos] === " ") {
+      this.pos++;
+    }
+  }
+
+  private peek(): string | undefined {
+    return this.input[this.pos];
+  }
+}


### PR DESCRIPTION
## Summary

Closes #61.

The example calculator tool in `agentic-loop` used `new Function("return (" + expression + ")")()` to evaluate arithmetic. A strict regex whitelist made it non-exploitable in practice, but it is an eval-family construct in a template others model themselves on.

## Changes

- **`templates/agentic-loop/skeleton/src/tools/example.ts`** — replace the `Function` path with a recursive-descent parser. Grammar supports `+`, `-`, `*`, `/`, parentheses, unary sign, decimals, and whitespace. No identifier or call syntax, so arbitrary code cannot run even if upstream validation is bypassed. The character-class regex guard is dropped — the parser itself throws on unexpected characters.
- **`templates/agentic-loop/skeleton/src/__tests__/example-tool.test.ts`** — 17 new test cases covering operator precedence, parens, unary sign, whitespace, decimals, divide-by-zero, unmatched parens, empty input, trailing garbage, and identifier rejection (confirming globals like `process`/`globalThis` are not reachable).

## Test plan

- [x] `npm test` in the skeleton — 38/38 pass (was 21, +17 new)
- [x] `npm run validate:catalog` — 0 errors, 0 warnings
- [x] No behavioral change for valid inputs — same results for `2 + 3 * 4`, `(2 + 3) * 4`, decimals, etc.