### PR TITLE
fix(module-rate-limit-ts): widen TTL test window to avoid CI race (#81)

### DIFF
--- a/templates/module-rate-limit-ts/skeleton/src/rate-limit/__tests__/memory-store.test.ts
+++ b/templates/module-rate-limit-ts/skeleton/src/rate-limit/__tests__/memory-store.test.ts
@@ -99,15 +99,14 @@ describe("in-memory rate limit store", () => {
   });
 
   it("expires keys after TTL", async () => {
-    // Set with a very short TTL
-    await store.set("ephemeral", "value", 1);
+    // TTL is in milliseconds. Use a window wide enough to survive an
+    // awaited get() without racing against expiry on a slow runner.
+    await store.set("ephemeral", "value", 50);
 
-    // Should still exist immediately
     const immediate = await store.get("ephemeral");
     expect(immediate).toBe("value");
 
-    // Wait for TTL to expire
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise((resolve) => setTimeout(resolve, 75));
 
     const expired = await store.get("ephemeral");
     expect(expired).toBeNull();


### PR DESCRIPTION
## Summary

Closes #81.

The "expires keys after TTL" test used `ttl=1` — and the store's TTL is in milliseconds, so the value was scheduled to expire 1ms after `set()`. The immediate `get()` that followed goes through an `await`, and on a slow runner the key had already expired by the time `get()` executed, failing with "expected null to be 'value'".

Widens TTL from 1 to 50ms and the post-set wait from 10 to 75ms. Test still runs in under 100ms; the timing now survives any reasonable event-loop tick. Also replaces the misleading "very short TTL" comment with a note clarifying that TTL is milliseconds.

## Test plan

- [x] `npm test` in the skeleton — 27/27 pass