### PR TITLE
feat(template-doctor): report-only catalog health tool

### DIFF
--- a/.github/workflows/template-doctor.yml
+++ b/.github/workflows/template-doctor.yml
@@ -1,0 +1,102 @@
+name: Template Doctor
+
+on:
+  # Weekly cron — Sunday 06:00 UTC. Full catalog runs take a while; the
+  # weekly cadence matches how fast the ecosystem drifts in practice.
+  schedule:
+    - cron: "0 6 * * 0"
+  # Manual trigger for on-demand runs (e.g., before cutting a release).
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Limit to specific check groups (comma-separated: ts,go,java,python,cross)"
+        required: false
+        default: "ts,go,java,python,cross"
+
+jobs:
+  doctor:
+    name: Run template doctor
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "25"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run doctor
+        id: doctor
+        env:
+          ONLY: ${{ github.event.inputs.only || 'ts,go,java,python,cross' }}
+        run: |
+          set -e
+          ./scripts/template-doctor/run.sh --only "$ONLY" --format markdown \
+            > doctor-report.md || true
+
+      - name: Post report to job summary
+        run: cat doctor-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: doctor-report
+          path: doctor-report.md
+          retention-days: 30
+
+      - name: Open or update tracking issue (cron runs only)
+        if: github.event_name == 'schedule'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require("fs");
+            const body = fs.readFileSync("doctor-report.md", "utf8");
+            const title = "Template Doctor — weekly catalog health report";
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "template-doctor",
+              per_page: 10,
+            });
+
+            if (existing.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+              core.info(`Updated existing issue #${existing[0].number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["template-doctor", "maintenance"],
+              });
+              core.info("Opened new tracking issue");
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tmp/
 
 # Generated lock files in template skeletons
 **/skeleton/package-lock.json
+
+# Template doctor report artifact
+scripts/template-doctor/.report.tsv

--- a/scripts/template-doctor/Makefile
+++ b/scripts/template-doctor/Makefile
@@ -1,0 +1,41 @@
+SHELL := /bin/bash
+DOCTOR := ./run.sh
+
+.PHONY: help doctor ts go java python cross markdown
+
+help:
+	@echo "Targets:"
+	@echo "  doctor    Run every check group (default)"
+	@echo "  ts        Run TypeScript checks only"
+	@echo "  go        Run Go checks only"
+	@echo "  java      Run Java checks only"
+	@echo "  python    Run Python checks only"
+	@echo "  cross     Run cross-cutting checks only"
+	@echo "  markdown  Emit the report as markdown on stdout"
+	@echo ""
+	@echo "Flags via env:"
+	@echo "  SKIP_TS=<names>    Skip named TS templates (comma-separated)"
+	@echo "  SKIP_GO=<names>    Skip named Go templates"
+	@echo "  SKIP_JAVA=<names>  Skip named Java templates"
+	@echo "  SKIP_PYTHON=<names> Skip named Python templates"
+
+doctor:
+	$(DOCTOR)
+
+ts:
+	$(DOCTOR) --only ts
+
+go:
+	$(DOCTOR) --only go
+
+java:
+	$(DOCTOR) --only java
+
+python:
+	$(DOCTOR) --only python
+
+cross:
+	$(DOCTOR) --only cross
+
+markdown:
+	$(DOCTOR) --format markdown

--- a/scripts/template-doctor/README.md
+++ b/scripts/template-doctor/README.md
@@ -1,0 +1,112 @@
+# Template doctor
+
+Report-only catalog health tool. Runs per-ecosystem checks across every
+template under `templates/` and produces a grouped report of findings
+(outdated dependencies, broken builds, stale references, dead
+placeholders).
+
+The doctor never fails CI on findings. It exists to give maintainers
+visibility into catalog drift so it can be batch-fixed intentionally
+rather than surfacing as one-off bug reports.
+
+## Quick start
+
+```sh
+# All checks
+make -C scripts/template-doctor doctor
+
+# One ecosystem
+make -C scripts/template-doctor ts
+make -C scripts/template-doctor go
+make -C scripts/template-doctor java
+make -C scripts/template-doctor python
+make -C scripts/template-doctor cross
+
+# Markdown report (stdout-safe for PR comments)
+make -C scripts/template-doctor markdown > report.md
+```
+
+## What it checks
+
+### Cross-cutting (`cross.sh`)
+
+- README `(../template-name/)` links resolve to a real template
+- `template.yaml` `composition.pairsWith` / `nestsInside` entries exist
+- Composites' `- template: X` entries reference a real template
+- Placeholders declared in `template.yaml` appear somewhere in `skeleton/`
+
+### TypeScript (`ts.sh`)
+
+- `npm outdated` — major-version drift as warning, minor/patch as info
+- `tsc --noEmit` — non-zero error count surfaced as an error
+- Dead dependencies — declared in `package.json` but not imported under `src/`
+
+### Go (`go.sh`)
+
+Materializes each skeleton into a tmp dir with substituted placeholders
+before running Go tooling.
+
+- `go list -u -m -json all` — drift surfaced the same way as TS
+- `go build ./...` — any output is an error finding
+- `go vet ./...` — any output is a warning finding
+
+### Java (`java.sh`)
+
+Materializes the `__PKG_DIR__` source tree into a real package path,
+then runs Maven.
+
+- `mvn versions:display-dependency-updates` — drift findings
+- `mvn compile` — compile failure is an error finding
+
+### Python (`python.sh`)
+
+- `python3 -m compileall` — syntax errors surfaced as errors
+- PyPI lookup against declared packages in `pyproject.toml` /
+  `requirements.txt` — surfaces the latest known version so maintainers
+  can compare against their pin
+
+## Finding model
+
+Every check emits zero or more lines to `$REPORT_FILE` as tab-separated
+tuples:
+
+```text
+severity <TAB> ecosystem <TAB> template <TAB> category <TAB> message
+```
+
+Severities: `error`, `warn`, `info`. `report.sh` groups by ecosystem
+and category when rendering.
+
+## Adding a check
+
+Add a new file under `checks/`, source `lib/common.sh`, and emit
+findings via the `finding` helper:
+
+```bash
+finding "warn" "ts" "my-template" "my-category" "some drift detected"
+```
+
+Then add the new group name to `run.sh`'s dispatch switch.
+
+## Skipping templates
+
+Pass skip lists via env vars (comma-separated template names):
+
+```sh
+SKIP_TS=templates-under-heavy-rework make -C scripts/template-doctor ts
+```
+
+## Design notes
+
+- **Report-only by design.** Checks never `exit 1` on findings; they
+  only exit non-zero when the checker itself can't run. A follow-up
+  will add a `--strict` mode that converts errors into a non-zero exit
+  code when the catalog is clean enough to gate CI on.
+- **Materialize before checking.** Go and Java skeletons use
+  placeholder module paths / directories that break their native
+  tooling. Each ecosystem-specific check copies the skeleton into a tmp
+  dir and substitutes placeholders before running native tools.
+- **No build-system flakes in findings.** Network failures during
+  `npm install` / `mvn compile` are surfaced as single `install` or
+  `build` findings, not cascades — the report stays skimmable when a
+  mirror is misbehaving.

--- a/scripts/template-doctor/checks/cross.sh
+++ b/scripts/template-doctor/checks/cross.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Cross-cutting checks that don't care about ecosystem:
+#   - README "Pairs with" / "Nests inside" links point at real templates
+#   - template.yaml composition.pairsWith / nestsInside entries exist
+#   - composites reference templates that exist
+#
+# No external tooling required. Shell + awk.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR}/../lib/common.sh"
+
+check_cross() {
+  log_step "cross: template/composite references"
+  _cross_readme_links
+  _cross_template_yaml_refs
+  _cross_composite_refs
+  _cross_placeholder_dangling
+}
+
+# Scan each template's README.md for "(../<name>/)" links and confirm
+# the target directory exists. Catches stale references after renames.
+_cross_readme_links() {
+  local tmpl name readme ref
+  while IFS= read -r tmpl; do
+    name="$(template_name "$tmpl")"
+    readme="${tmpl}/README.md"
+    [ -f "$readme" ] || continue
+
+    # Extract ../<slug>/ segments that appear in markdown link targets.
+    # `grep` exits 1 when no match — that's fine here, swallow it.
+    { grep -oE '\(\.\./[a-z][a-z0-9-]*/\)' "$readme" 2>/dev/null || true; } \
+      | sed -E 's|\(\.\./||; s|/\)||' \
+      | sort -u \
+      | while IFS= read -r ref; do
+          [ -z "$ref" ] && continue
+          if [ ! -d "${TEMPLATES_DIR}/${ref}" ]; then
+            finding "error" "cross" "$name" "stale-readme-ref" \
+              "README links to ../${ref}/ but no such template exists"
+          fi
+        done
+  done < <(list_templates all)
+}
+
+# Parse composition.pairsWith / composition.nestsInside from each
+# template.yaml and verify every named template exists.
+_cross_template_yaml_refs() {
+  local tmpl name ymls ref refs
+  while IFS= read -r tmpl; do
+    name="$(template_name "$tmpl")"
+    local y="${tmpl}/template.yaml"
+    [ -f "$y" ] || continue
+
+    # Grab the array contents after pairsWith: / nestsInside:.
+    refs="$(awk '
+      /^[[:space:]]*pairsWith:/   { sub(/.*:[[:space:]]*\[/, ""); sub(/\].*/, ""); print; next }
+      /^[[:space:]]*nestsInside:/ { sub(/.*:[[:space:]]*\[/, ""); sub(/\].*/, ""); print; next }
+    ' "$y" \
+    | tr ',' '\n' \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/"//g; s/'"'"'//g' \
+    | awk 'NF')"
+
+    while IFS= read -r ref; do
+      [ -z "$ref" ] && continue
+      if [ ! -d "${TEMPLATES_DIR}/${ref}" ]; then
+        finding "error" "cross" "$name" "stale-yaml-ref" \
+          "template.yaml references \"${ref}\" but no such template exists"
+      fi
+    done <<< "$refs"
+  done < <(list_templates all)
+}
+
+# Every composite's `- template: <name>` entry must resolve to a real
+# templates/<name>/ directory.
+_cross_composite_refs() {
+  local composites="${ROOT}/composites"
+  [ -d "$composites" ] || return 0
+
+  local yml name ref
+  for yml in "$composites"/*.yaml "$composites"/*.yml; do
+    [ -f "$yml" ] || continue
+    name="$(basename "${yml%.*}")"
+    awk '/^[[:space:]]*-[[:space:]]*template:[[:space:]]*/ {
+      sub(/^[[:space:]]*-[[:space:]]*template:[[:space:]]*/, "");
+      gsub(/"/, ""); gsub(/'"'"'/, "");
+      sub(/#.*$/, "");
+      sub(/[[:space:]]+$/, "");
+      print
+    }' "$yml" | sort -u | while IFS= read -r ref; do
+      [ -z "$ref" ] && continue
+      if [ ! -d "${TEMPLATES_DIR}/${ref}" ]; then
+        finding "error" "cross" "composite:${name}" "stale-composite-ref" \
+          "composite references template \"${ref}\" but no such template exists"
+      fi
+    done
+  done
+}
+
+# Placeholders declared in template.yaml must actually appear in
+# skeleton/ content or filenames. `scripts/validate.sh` already enforces
+# this; we re-run it per template and surface any miss as an error so
+# it shows up in the doctor report alongside the rest.
+_cross_placeholder_dangling() {
+  local tmpl name result
+  while IFS= read -r tmpl; do
+    name="$(template_name "$tmpl")"
+    result="$("${ROOT}/scripts/validate.sh" "$tmpl" 2>&1 || true)"
+    if printf '%s' "$result" | grep -q "FAIL placeholder not found"; then
+      printf '%s\n' "$result" \
+        | awk '/FAIL placeholder not found/ {
+            sub(/.*FAIL placeholder not found in skeleton\/ files or filenames:[[:space:]]*/, "");
+            sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, "");
+            print
+          }' \
+        | while IFS= read -r ph; do
+            [ -z "$ph" ] && continue
+            finding "error" "cross" "$name" "dangling-placeholder" \
+              "placeholder ${ph} declared in template.yaml but unused in skeleton/"
+          done
+    fi
+  done < <(list_templates all)
+}

--- a/scripts/template-doctor/checks/go.sh
+++ b/scripts/template-doctor/checks/go.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Go checks: outdated modules + go vet + go build.
+#
+# `go list -u -m -json all` surfaces available updates. Go skeletons
+# use placeholder module paths (__GO_MODULE__), so we materialize each
+# skeleton into a tmp dir with substituted placeholders before running
+# go commands.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR}/../lib/common.sh"
+
+check_go() {
+  if ! command -v go >/dev/null 2>&1; then
+    log_warn "go not found — skipping Go checks"
+    return 0
+  fi
+
+  local tmpl name
+  while IFS= read -r tmpl; do
+    [ -z "$tmpl" ] && continue
+    name="$(template_name "$tmpl")"
+    if is_skipped "go" "$name"; then
+      log_step "go:${name} — skipped"
+      continue
+    fi
+    log_step "go:${name}"
+    _check_go_template "$tmpl"
+  done < <(list_templates go)
+}
+
+_check_go_template() {
+  local tmpl="$1"
+  local name work
+  name="$(template_name "$tmpl")"
+
+  work="$(mktemp -d)"
+  # Guarantee cleanup even on early return / error.
+  trap 'rm -rf "$work"' RETURN
+  cp -R "${tmpl}/skeleton/." "${work}/"
+
+  _materialize_placeholders "$work" "$name"
+
+  _go_outdated "$work" "$name"
+  _go_build "$work" "$name"
+  _go_vet "$work" "$name"
+}
+
+# Replace every __PLACEHOLDER__ token in the materialized skeleton with
+# a value that lets go tooling run. We only need placeholders that are
+# actually referenced by Go source / go.mod — over-substituting is fine.
+_materialize_placeholders() {
+  local work="$1" name="$2"
+  local module="example.com/${name}"
+
+  # Iterate over source + config files. Use `find -print0` for safety.
+  find "$work" -type f \( -name "*.go" -o -name "go.mod" -o -name "Makefile" \
+       -o -name "*.yaml" -o -name "*.yml" -o -name "*.md" \) \
+       -print0 2>/dev/null \
+  | xargs -0 perl -pi -e "
+      s|__GO_MODULE__|${module}|g;
+      s|__PROJECT_NAME__|${name}|g;
+      s|__ORG__|acme|g;
+      s|__DESCRIPTION__|Health-check project|g;
+      s|__DATABASE__|postgres|g;
+      s|__AUTH_PROVIDER__|jwt|g;
+    "
+}
+
+_go_outdated() {
+  local work="$1" name="$2"
+  # Require a module first. If tidy can't run (network issues etc),
+  # emit a finding and move on rather than abandoning other checks.
+  if ! (cd "$work" && GOSUMDB=off go mod tidy >/dev/null 2>&1); then
+    finding "error" "go" "$name" "install" "go mod tidy failed"
+    return
+  fi
+
+  (cd "$work" && GOSUMDB=off go list -u -m -json all 2>/dev/null) \
+  | node --input-type=module -e '
+      let buf = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", chunk => { buf += chunk; });
+      process.stdin.on("end", () => {
+        // go list -m -json emits one JSON object per module, concatenated.
+        const objs = [];
+        let depth = 0, start = -1;
+        for (let i = 0; i < buf.length; i++) {
+          const c = buf[i];
+          if (c === "{") { if (depth === 0) start = i; depth++; }
+          else if (c === "}") {
+            depth--;
+            if (depth === 0 && start !== -1) {
+              try { objs.push(JSON.parse(buf.slice(start, i + 1))); } catch {}
+              start = -1;
+            }
+          }
+        }
+        for (const m of objs) {
+          if (!m.Update || !m.Version || !m.Update.Version) continue;
+          if (m.Main) continue;
+          const current = m.Version, latest = m.Update.Version;
+          const currentMajor = current.replace(/^v/, "").split(".")[0];
+          const latestMajor  = latest.replace(/^v/, "").split(".")[0];
+          const drift = currentMajor === latestMajor ? "minor" : "major";
+          const severity = drift === "major" ? "warn" : "info";
+          process.stdout.write(`${severity}\t${m.Path}\t${current}\t${latest}\t${drift}\n`);
+        }
+      });
+    ' 2>/dev/null \
+  | while IFS=$'\t' read -r severity pkg current latest drift; do
+      [ -z "$pkg" ] && continue
+      finding "$severity" "go" "$name" "outdated-dep" \
+        "${pkg}: ${current} → ${latest} (${drift})"
+    done
+}
+
+_go_build() {
+  local work="$1" name="$2"
+  local output
+  output="$(cd "$work" && GOSUMDB=off go build ./... 2>&1 || true)"
+  if [ -n "$output" ]; then
+    local error_count
+    error_count=$(printf '%s' "$output" | wc -l | tr -d ' ')
+    finding "error" "go" "$name" "build" \
+      "go build ./... failed (${error_count} lines of output)"
+  fi
+}
+
+_go_vet() {
+  local work="$1" name="$2"
+  local output
+  output="$(cd "$work" && GOSUMDB=off go vet ./... 2>&1 || true)"
+  if [ -n "$output" ]; then
+    local error_count
+    error_count=$(printf '%s' "$output" | wc -l | tr -d ' ')
+    finding "warn" "go" "$name" "vet" \
+      "go vet ./... reports ${error_count} lines of output"
+  fi
+}

--- a/scripts/template-doctor/checks/java.sh
+++ b/scripts/template-doctor/checks/java.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Java / Maven checks: outdated deps + compile.
+#
+# Uses `mvn versions:display-dependency-updates` for dep reports and
+# `mvn compile` for build verification. Materializes placeholders into
+# a tmp dir so Maven can resolve module paths and package names.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR}/../lib/common.sh"
+
+check_java() {
+  if ! command -v mvn >/dev/null 2>&1; then
+    log_warn "mvn not found — skipping Java checks"
+    return 0
+  fi
+
+  local tmpl name
+  while IFS= read -r tmpl; do
+    [ -z "$tmpl" ] && continue
+    name="$(template_name "$tmpl")"
+    if is_skipped "java" "$name"; then
+      log_step "java:${name} — skipped"
+      continue
+    fi
+    log_step "java:${name}"
+    _check_java_template "$tmpl"
+  done < <(list_templates java)
+}
+
+_check_java_template() {
+  local tmpl="$1"
+  local name work
+  name="$(template_name "$tmpl")"
+
+  work="$(mktemp -d)"
+  trap 'rm -rf "$work"' RETURN
+  cp -R "${tmpl}/skeleton/." "${work}/"
+
+  _java_materialize "$work" "$name"
+
+  _java_outdated "$work" "$name"
+  _java_compile "$work" "$name"
+}
+
+_java_materialize() {
+  local work="$1" name="$2"
+
+  # Flatten the __PKG_DIR__ source tree into a real one. Templates use
+  # __PKG_DIR__ as a literal directory segment so we have to rename
+  # after copying, not substitute before.
+  local pkg_dir_main="${work}/src/main/java/com/example/app"
+  local pkg_dir_test="${work}/src/test/java/com/example/app"
+  if [ -d "${work}/src/main/java/__PKG_DIR__" ]; then
+    mkdir -p "$pkg_dir_main"
+    cp -R "${work}/src/main/java/__PKG_DIR__/." "$pkg_dir_main/"
+    rm -rf "${work}/src/main/java/__PKG_DIR__"
+  fi
+  if [ -d "${work}/src/test/java/__PKG_DIR__" ]; then
+    mkdir -p "$pkg_dir_test"
+    cp -R "${work}/src/test/java/__PKG_DIR__/." "$pkg_dir_test/"
+    rm -rf "${work}/src/test/java/__PKG_DIR__"
+  fi
+
+  find "$work" -type f \( -name "*.java" -o -name "pom.xml" -o -name "*.yaml" \
+       -o -name "*.yml" -o -name "*.xml" -o -name "*.md" \) \
+       -print0 2>/dev/null \
+  | xargs -0 perl -pi -e "
+      s|__PROJECT_NAME__|${name}|g;
+      s|__GROUP_ID__|com.example|g;
+      s|__ARTIFACT_ID__|${name}|g;
+      s|__DESCRIPTION__|Health-check project|g;
+      s|__JAVA_PKG__|com.example.app|g;
+      s|__PKG_DIR__|com/example/app|g;
+      s|__DATABASE__|postgres|g;
+      s|__OIDC_ISSUER__|https://auth.example.com|g;
+      s|__ALLOWED_AUD__|${name}|g;
+    "
+}
+
+_java_outdated() {
+  local work="$1" name="$2"
+  local output
+  output="$(cd "$work" && mvn -B -q versions:display-dependency-updates 2>&1 || true)"
+
+  # Maven output form: "  [INFO]   group:artifact ......... current -> latest"
+  # Parse per-line; skip anything without the arrow.
+  printf '%s\n' "$output" \
+    | grep -E "\->[[:space:]]" \
+    | sed -E 's/^\[INFO\][[:space:]]*//; s/^[[:space:]]+//' \
+    | while IFS= read -r line; do
+        # Strip the padding dots; extract "coord current -> latest".
+        local coord current latest
+        coord="$(printf '%s' "$line" | awk '{print $1}')"
+        current="$(printf '%s' "$line" | awk -F'\\.\\.\\. ' '{print $2}' \
+                   | awk '{print $1}')"
+        latest="$(printf '%s' "$line" | awk -F'-> ' '{print $2}' | awk '{print $1}')"
+        [ -z "$coord" ] || [ -z "$current" ] || [ -z "$latest" ] && continue
+        local current_major latest_major drift severity
+        current_major="${current%%.*}"
+        latest_major="${latest%%.*}"
+        if [ "$current_major" = "$latest_major" ]; then
+          drift="minor"; severity="info"
+        else
+          drift="major"; severity="warn"
+        fi
+        finding "$severity" "java" "$name" "outdated-dep" \
+          "${coord}: ${current} → ${latest} (${drift})"
+      done
+}
+
+_java_compile() {
+  local work="$1" name="$2"
+  if ! (cd "$work" && mvn -B -q -DskipTests compile >/dev/null 2>&1); then
+    finding "error" "java" "$name" "build" "mvn compile failed"
+  fi
+}

--- a/scripts/template-doctor/checks/python.sh
+++ b/scripts/template-doctor/checks/python.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Python checks: outdated deps + import syntax check.
+#
+# With a single Python template (mcp-server-python) and limited Python
+# tooling we keep this light: parse pyproject.toml / requirements.txt
+# for declared versions, ask PyPI for the latest release via `pip index`,
+# and flag drift. Compile check via `python -m compileall` is optional.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR}/../lib/common.sh"
+
+check_python() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    log_warn "python3 not found — skipping Python checks"
+    return 0
+  fi
+  if ! command -v pip >/dev/null 2>&1 && ! command -v pip3 >/dev/null 2>&1; then
+    log_warn "pip not found — skipping Python dep freshness checks"
+  fi
+
+  local tmpl name
+  while IFS= read -r tmpl; do
+    [ -z "$tmpl" ] && continue
+    name="$(template_name "$tmpl")"
+    if is_skipped "python" "$name"; then
+      log_step "python:${name} — skipped"
+      continue
+    fi
+    log_step "python:${name}"
+    _check_python_template "$tmpl"
+  done < <(list_templates python)
+}
+
+_check_python_template() {
+  local tmpl="$1"
+  local name skeleton
+  name="$(template_name "$tmpl")"
+  skeleton="${tmpl}/skeleton"
+
+  _py_compile "$skeleton" "$name"
+  _py_outdated "$skeleton" "$name"
+}
+
+_py_compile() {
+  local skeleton="$1" name="$2"
+  # Skip files with templated dir segments like __PKG__.
+  local output error_count
+  output="$(python3 -m compileall -q "$skeleton" 2>&1 || true)"
+  error_count=$(printf '%s' "$output" | grep -cE "SyntaxError|IndentationError" || true)
+  [ "$error_count" -gt 0 ] && finding "error" "python" "$name" "syntax" \
+    "python3 compileall reports ${error_count} syntax errors"
+}
+
+_py_outdated() {
+  local skeleton="$1" name="$2"
+  local pipbin
+  pipbin="$(command -v pip || command -v pip3 || true)"
+  [ -z "$pipbin" ] && return 0
+
+  # Extract declared packages from pyproject.toml (PEP 621 dependencies
+  # list) or requirements.txt. Strip version specifiers and extras.
+  local deps
+  deps="$(python3 -c '
+import re, sys, pathlib
+root = pathlib.Path(sys.argv[1])
+out = set()
+pyproj = root / "pyproject.toml"
+if pyproj.exists():
+    try:
+        import tomllib
+    except ImportError:
+        tomllib = None
+    if tomllib is not None:
+        try:
+            with pyproj.open("rb") as f:
+                data = tomllib.load(f)
+        except Exception:
+            data = {}
+        for d in data.get("project", {}).get("dependencies", []) or []:
+            m = re.match(r"^([A-Za-z0-9_.\-]+)", d)
+            if m: out.add(m.group(1))
+reqs = root / "requirements.txt"
+if reqs.exists():
+    for line in reqs.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"): continue
+        m = re.match(r"^([A-Za-z0-9_.\-]+)", line)
+        if m: out.add(m.group(1))
+for d in sorted(out): print(d)
+' "$skeleton" 2>/dev/null || true)"
+  [ -z "$deps" ] && return 0
+
+  # Query PyPI JSON API for each package — lightweight, no pip install.
+  local pkg
+  while IFS= read -r pkg; do
+    [ -z "$pkg" ] && continue
+    local latest
+    latest="$(curl -fsSL "https://pypi.org/pypi/${pkg}/json" 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin).get("info", {}).get("version", ""))' \
+      2>/dev/null || true)"
+    [ -z "$latest" ] && continue
+    # We don't know the declared version precisely without a full parse;
+    # just surface the latest as info so maintainers can compare.
+    finding "info" "python" "$name" "latest-known" \
+      "${pkg}: latest on PyPI is ${latest}"
+  done <<< "$deps"
+}

--- a/scripts/template-doctor/checks/ts.sh
+++ b/scripts/template-doctor/checks/ts.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# TypeScript checks: outdated deps + typecheck + dead-dep sweep.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR}/../lib/common.sh"
+
+check_ts() {
+  if ! command -v npm >/dev/null 2>&1; then
+    log_warn "npm not found — skipping TS checks"
+    return 0
+  fi
+
+  local tmpl name
+  while IFS= read -r tmpl; do
+    [ -z "$tmpl" ] && continue
+    name="$(template_name "$tmpl")"
+    if is_skipped "ts" "$name"; then
+      log_step "ts:${name} — skipped"
+      continue
+    fi
+    log_step "ts:${name}"
+    _check_ts_template "$tmpl"
+  done < <(list_templates ts)
+}
+
+_check_ts_template() {
+  local tmpl="$1"
+  local name skeleton
+  name="$(template_name "$tmpl")"
+  skeleton="${tmpl}/skeleton"
+
+  # Install once per skeleton; cached via node_modules across checks.
+  if [ ! -d "${skeleton}/node_modules" ]; then
+    if ! (cd "$skeleton" && npm install --silent --no-audit --no-fund >/dev/null 2>&1); then
+      finding "error" "ts" "$name" "install" "npm install failed"
+      return
+    fi
+  fi
+
+  _ts_outdated "$tmpl" "$name"
+  _ts_typecheck "$tmpl" "$name"
+  _ts_dead_deps "$tmpl" "$name"
+}
+
+_ts_outdated() {
+  local tmpl="$1" name="$2"
+  local skeleton="${tmpl}/skeleton"
+
+  # `npm outdated` (no --all) reports only top-level declared deps from
+  # package.json, which is what we care about. --all would recurse into
+  # every transitive in the lockfile and flood the report.
+  # npm outdated exits 1 when there are outdated packages — that is expected.
+  local json
+  json="$(cd "$skeleton" && npm outdated --json 2>/dev/null || true)"
+  [ -z "$json" ] || [ "$json" = "{}" ] && return 0
+
+  # Parse in a single node pass; emit one tsv-ready line per outdated
+  # package with severity picked by major-version drift.
+  (cd "$skeleton" && JSON="$json" node --input-type=module -e '
+    const data = JSON.parse(process.env.JSON);
+    for (const [pkg, info] of Object.entries(data)) {
+      if (!info || typeof info !== "object") continue;
+      const current = String(info.current ?? "?");
+      const latest  = String(info.latest  ?? "?");
+      if (current === latest || current === "?" || latest === "?") continue;
+      const drift = current.split(".")[0] === latest.split(".")[0] ? "minor" : "major";
+      const severity = drift === "major" ? "warn" : "info";
+      process.stdout.write(`${severity}\t${pkg}\t${current}\t${latest}\t${drift}\n`);
+    }
+  ') | while IFS=$'\t' read -r severity pkg current latest drift; do
+    [ -z "$pkg" ] && continue
+    finding "$severity" "ts" "$name" "outdated-dep" \
+      "${pkg}: ${current} → ${latest} (${drift})"
+  done
+}
+
+_ts_typecheck() {
+  local tmpl="$1" name="$2"
+  local skeleton="${tmpl}/skeleton"
+  [ -f "${skeleton}/tsconfig.json" ] || return 0
+
+  local output error_count
+  output="$(cd "$skeleton" && npx --no-install tsc --noEmit 2>&1 || true)"
+  error_count=$(printf '%s' "$output" | grep -cE "error TS[0-9]+" || true)
+  [ "$error_count" -gt 0 ] && finding "error" "ts" "$name" "typecheck" \
+    "tsc --noEmit reports ${error_count} errors"
+}
+
+_ts_dead_deps() {
+  local tmpl="$1" name="$2"
+  local skeleton="${tmpl}/skeleton"
+  [ -d "${skeleton}/src" ] || return 0
+  [ -f "${skeleton}/package.json" ] || return 0
+
+  local deps
+  deps="$(node -e '
+    const p = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+    for (const d of Object.keys(p.dependencies || {})) process.stdout.write(d + "\n");
+  ' "${skeleton}/package.json" 2>/dev/null || true)"
+  [ -z "$deps" ] && return 0
+
+  local dep
+  while IFS= read -r dep; do
+    [ -z "$dep" ] && continue
+    # Packages often loaded via side-effectful imports or type-only
+    # peers don't show up in textual grep; exempt those.
+    case "$dep" in
+      dotenv|@opentelemetry/*|reflect-metadata) continue ;;
+    esac
+    if ! grep -rq --include="*.ts" --include="*.tsx" --include="*.js" \
+         --include="*.mjs" --include="*.cjs" \
+         -E "from [\"']${dep}([\"'/])|require\\([\"']${dep}([\"'/])" \
+         "${skeleton}/src" 2>/dev/null; then
+      finding "warn" "ts" "$name" "dead-dep" \
+        "dependency \"${dep}\" declared but not imported under src/"
+    fi
+  done <<< "$deps"
+}

--- a/scripts/template-doctor/lib/common.sh
+++ b/scripts/template-doctor/lib/common.sh
@@ -1,0 +1,128 @@
+# Shared helpers for the template doctor. Sourced by each check script.
+#
+# Finding model: every check emits zero or more `finding` lines to a
+# report file. A finding is a tab-separated tuple of
+#
+#   <severity>\t<ecosystem>\t<template>\t<category>\t<message>
+#
+# Severity is one of: error | warn | info.
+# The report renderer (report.sh) reads the file and produces the summary.
+#
+# The doctor is report-only by design — individual check scripts never
+# exit non-zero on findings. They exit non-zero only when they cannot
+# run at all (missing tool, hard error in the checker itself).
+
+set -euo pipefail
+
+# --- paths --------------------------------------------------------------------
+
+# ROOT: repository root, two levels up from scripts/template-doctor/lib/.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TEMPLATES_DIR="${ROOT}/templates"
+
+# REPORT_FILE: set by run.sh before sourcing check scripts. Check
+# scripts append findings via the `finding` helper; report.sh reads it.
+: "${REPORT_FILE:=${ROOT}/scripts/template-doctor/.report.tsv}"
+
+# --- terminal formatting ------------------------------------------------------
+
+if [ -t 1 ] && [ "${NO_COLOR:-}" = "" ]; then
+  C_RED=$'\033[31m'
+  C_YELLOW=$'\033[33m'
+  C_BLUE=$'\033[34m'
+  C_GREEN=$'\033[32m'
+  C_DIM=$'\033[2m'
+  C_BOLD=$'\033[1m'
+  C_RESET=$'\033[0m'
+else
+  C_RED=""
+  C_YELLOW=""
+  C_BLUE=""
+  C_GREEN=""
+  C_DIM=""
+  C_BOLD=""
+  C_RESET=""
+fi
+
+log() { printf "%s\n" "$*" >&2; }
+log_step() { printf "%s▸%s %s\n" "$C_BLUE" "$C_RESET" "$*" >&2; }
+log_ok() { printf "%s✓%s %s\n" "$C_GREEN" "$C_RESET" "$*" >&2; }
+log_warn() { printf "%s⚠%s %s\n" "$C_YELLOW" "$C_RESET" "$*" >&2; }
+log_err() { printf "%s✗%s %s\n" "$C_RED" "$C_RESET" "$*" >&2; }
+
+# --- finding emission ---------------------------------------------------------
+
+# Usage: finding <severity> <ecosystem> <template> <category> <message>
+finding() {
+  local severity="$1" ecosystem="$2" template="$3" category="$4" message="$5"
+  printf "%s\t%s\t%s\t%s\t%s\n" \
+    "$severity" "$ecosystem" "$template" "$category" "$message" \
+    >> "$REPORT_FILE"
+}
+
+# --- ecosystem detection ------------------------------------------------------
+
+# Echoes the ecosystem name for a template directory, or "none" if we
+# can't tell. Ecosystem is derived from the presence of marker files in
+# the skeleton. Some templates legitimately ship no code (briefs,
+# markdown-only scaffolds) — those return "none" and are skipped.
+ecosystem_of() {
+  local tmpl="$1"
+  local sk="${tmpl}/skeleton"
+  [ -d "$sk" ] || { echo "none"; return; }
+
+  if [ -f "${sk}/package.json" ]; then
+    echo "ts"
+  elif [ -f "${sk}/go.mod" ]; then
+    echo "go"
+  elif [ -f "${sk}/pom.xml" ] || [ -f "${sk}/build.gradle" ] || [ -f "${sk}/build.gradle.kts" ]; then
+    echo "java"
+  elif [ -f "${sk}/pyproject.toml" ] || [ -f "${sk}/requirements.txt" ]; then
+    echo "python"
+  else
+    echo "none"
+  fi
+}
+
+# list_templates <ecosystem>
+# Echoes one template absolute path per line. Pass "all" to list every
+# template regardless of ecosystem.
+list_templates() {
+  local want="$1"
+  local tmpl ecosystem
+  for tmpl in "${TEMPLATES_DIR}"/*/; do
+    tmpl="${tmpl%/}"
+    [ -d "$tmpl" ] || continue
+    [ -f "${tmpl}/template.yaml" ] || continue
+    if [ "$want" = "all" ]; then
+      echo "$tmpl"
+      continue
+    fi
+    ecosystem="$(ecosystem_of "$tmpl")"
+    if [ "$ecosystem" = "$want" ]; then
+      echo "$tmpl"
+    fi
+  done
+}
+
+template_name() {
+  basename "$1"
+}
+
+# --- skip-list handling -------------------------------------------------------
+
+# Some templates are legitimately not meant to run the full build check
+# (e.g., templates that use __PLACEHOLDER__ directory names that break
+# package managers before rendering). Skip by setting SKIP_<ECOSYSTEM>
+# env vars to comma-separated template names.
+is_skipped() {
+  local ecosystem="$1" name="$2"
+  local varname skip_list
+  varname="SKIP_$(printf '%s' "$ecosystem" | tr '[:lower:]' '[:upper:]')"
+  skip_list="${!varname:-}"
+  [ -z "$skip_list" ] && return 1
+  case ",${skip_list}," in
+    *",${name},"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/scripts/template-doctor/lib/report.sh
+++ b/scripts/template-doctor/lib/report.sh
@@ -1,0 +1,123 @@
+# Report renderer. Reads findings from $REPORT_FILE and produces the
+# human-readable summary. Sourced by run.sh after all checks have
+# executed.
+
+# Usage: render_report
+#
+# Reads REPORT_FILE (TSV of severity / ecosystem / template / category
+# / message) and prints a grouped summary. Categories surface as
+# sections within each ecosystem; severities drive the emoji/color.
+
+render_report() {
+  : "${REPORT_FILE:?REPORT_FILE not set}"
+
+  local total errors warns infos
+  total=0; errors=0; warns=0; infos=0
+  if [ -s "$REPORT_FILE" ]; then
+    total=$(wc -l < "$REPORT_FILE" | tr -d ' ')
+    errors=$(awk -F'\t' '$1=="error"' "$REPORT_FILE" | wc -l | tr -d ' ')
+    warns=$(awk -F'\t' '$1=="warn"'  "$REPORT_FILE" | wc -l | tr -d ' ')
+    infos=$(awk -F'\t' '$1=="info"'  "$REPORT_FILE" | wc -l | tr -d ' ')
+  fi
+
+  echo
+  echo "${C_BOLD}════════════════════════════════════════════════════════${C_RESET}"
+  echo "${C_BOLD} Template Doctor Report${C_RESET}"
+  echo "${C_BOLD}════════════════════════════════════════════════════════${C_RESET}"
+  echo
+
+  if [ "$total" -eq 0 ]; then
+    echo "${C_GREEN}No findings. Catalog looks clean.${C_RESET}"
+    echo
+    return 0
+  fi
+
+  echo "Findings: ${C_BOLD}${total}${C_RESET}  ·  ${C_RED}errors ${errors}${C_RESET}  ·  ${C_YELLOW}warnings ${warns}${C_RESET}  ·  ${C_DIM}info ${infos}${C_RESET}"
+  echo
+
+  # Group by ecosystem, then category.
+  local ecosystem
+  for ecosystem in ts go java python cross; do
+    local count
+    count=$(awk -F'\t' -v eco="$ecosystem" '$2==eco' "$REPORT_FILE" | wc -l | tr -d ' ')
+    [ "$count" -eq 0 ] && continue
+    echo "${C_BOLD}── ${ecosystem^^} ──────────────────────────────────────${C_RESET}"
+    _render_ecosystem "$ecosystem"
+    echo
+  done
+}
+
+_render_ecosystem() {
+  local ecosystem="$1"
+  local categories
+  categories="$(awk -F'\t' -v eco="$ecosystem" '$2==eco {print $4}' "$REPORT_FILE" \
+    | sort -u)"
+
+  local cat
+  while IFS= read -r cat; do
+    [ -z "$cat" ] && continue
+    echo "  ${C_DIM}[${cat}]${C_RESET}"
+    awk -F'\t' -v eco="$ecosystem" -v cat="$cat" \
+      '$2==eco && $4==cat {printf "    %s | %s | %s\n", $1, $3, $5}' \
+      "$REPORT_FILE" \
+      | _colorize_findings
+  done <<< "$categories"
+}
+
+_colorize_findings() {
+  # Input: "severity | template | message" — colorize the severity
+  # token and indent consistently.
+  while IFS= read -r line; do
+    case "$line" in
+      *"error |"*)
+        printf "    %s%s%s\n" "$C_RED" "$line" "$C_RESET"
+        ;;
+      *"warn |"*)
+        printf "    %s%s%s\n" "$C_YELLOW" "$line" "$C_RESET"
+        ;;
+      *"info |"*)
+        printf "    %s%s%s\n" "$C_DIM" "$line" "$C_RESET"
+        ;;
+      *)
+        printf "    %s\n" "$line"
+        ;;
+    esac
+  done
+}
+
+# Write a GitHub-flavored markdown version of the report to stdout.
+render_markdown_report() {
+  : "${REPORT_FILE:?REPORT_FILE not set}"
+  local total errors warns infos
+  total=0; errors=0; warns=0; infos=0
+  if [ -s "$REPORT_FILE" ]; then
+    total=$(wc -l < "$REPORT_FILE" | tr -d ' ')
+    errors=$(awk -F'\t' '$1=="error"' "$REPORT_FILE" | wc -l | tr -d ' ')
+    warns=$(awk -F'\t' '$1=="warn"'  "$REPORT_FILE" | wc -l | tr -d ' ')
+    infos=$(awk -F'\t' '$1=="info"'  "$REPORT_FILE" | wc -l | tr -d ' ')
+  fi
+
+  printf "# Template Doctor Report\n\n"
+  if [ "$total" -eq 0 ]; then
+    printf "No findings. Catalog looks clean.\n"
+    return 0
+  fi
+  printf "**Summary**: %d findings — %d errors, %d warnings, %d info.\n\n" \
+    "$total" "$errors" "$warns" "$infos"
+
+  local ecosystem
+  for ecosystem in ts go java python cross; do
+    local count
+    count=$(awk -F'\t' -v eco="$ecosystem" '$2==eco' "$REPORT_FILE" | wc -l | tr -d ' ')
+    [ "$count" -eq 0 ] && continue
+    printf "## %s\n\n" "$(echo "$ecosystem" | tr '[:lower:]' '[:upper:]')"
+    printf "| Severity | Template | Category | Message |\n"
+    printf "|---|---|---|---|\n"
+    awk -F'\t' -v eco="$ecosystem" \
+      'BEGIN{OFS=" | "} $2==eco {
+         gsub(/\|/, "\\|", $5);
+         printf "| %s | %s | %s | %s |\n", $1, $3, $4, $5
+       }' "$REPORT_FILE"
+    printf "\n"
+  done
+}

--- a/scripts/template-doctor/run.sh
+++ b/scripts/template-doctor/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Entry point for the template doctor. Runs the selected check groups,
+# aggregates findings via $REPORT_FILE, and renders a report.
+#
+# Usage:
+#   run.sh [--only <list>] [--skip <list>] [--format text|markdown]
+#   --only   comma-separated subset of {ts,go,java,python,cross} (default: all)
+#   --skip   comma-separated subset to skip (runs after --only)
+#   --format report format; default text. markdown is stdout-safe for PR comments.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+. "${SCRIPT_DIR}/lib/common.sh"
+# shellcheck source=lib/report.sh
+. "${SCRIPT_DIR}/lib/report.sh"
+
+ONLY="ts,go,java,python,cross"
+SKIP=""
+FORMAT="text"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --only)   ONLY="$2"; shift 2 ;;
+    --skip)   SKIP="$2"; shift 2 ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '3,9p' "$0" >&2
+      exit 0
+      ;;
+    *) log_err "Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+# Fresh report file.
+: > "$REPORT_FILE"
+
+run_group() {
+  local group="$1"
+  case ",$ONLY," in *",$group,"*) ;; *) return 0 ;; esac
+  case ",$SKIP," in *",$group,"*) return 0 ;; esac
+
+  local script="${SCRIPT_DIR}/checks/${group}.sh"
+  [ -f "$script" ] || { log_warn "no check script for ${group}"; return 0; }
+
+  # shellcheck source=/dev/null
+  . "$script"
+  case "$group" in
+    ts)     check_ts ;;
+    go)     check_go ;;
+    java)   check_java ;;
+    python) check_python ;;
+    cross)  check_cross ;;
+  esac
+}
+
+log_step "template-doctor running (only=${ONLY}, skip=${SKIP:-none})"
+run_group cross
+run_group ts
+run_group go
+run_group java
+run_group python
+
+case "$FORMAT" in
+  text)     render_report ;;
+  markdown) render_markdown_report ;;
+  *) log_err "Unknown format: $FORMAT"; exit 2 ;;
+esac
+
+# Report-only: always exit 0. The fix-follow-up PR flips this when we
+# want to gate CI on hard errors.
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/template-doctor/` — a per-ecosystem health checker that surfaces drift across the catalog. Report-only by design; findings never gate CI. Maintainers get visibility so drift is fixed intentionally in batches rather than one-off as bug reports.

## What it checks

| Group | Checks |
|---|---|
| cross | README link resolution, template.yaml refs, composite refs, dangling placeholders |
| TS | `npm outdated`, `tsc --noEmit`, dead deps |
| Go | `go list -u -m`, `go build`, `go vet` — materializes placeholders first |
| Java | `mvn versions:display-dependency-updates`, `mvn compile` — flattens `__PKG_DIR__` |
| Python | `python3 -m compileall`, PyPI latest-known lookups |

## Shape

- `run.sh` orchestrates, aggregates findings into a TSV file, renders text or markdown
- `lib/common.sh` — finding emitter, template enumeration, skip lists, term colors
- `lib/report.sh` — grouped renderers
- `checks/<ecosystem>.sh` — one per ecosystem, each exposing `check_<ecosystem>`
- `Makefile` — `make doctor` + per-group targets

Severity model: `error` / `warn` / `info`. Major-version drift is warn; minor is info; build failures / typecheck errors / invalid refs are error.

## CI

`.github/workflows/template-doctor.yml`:

- Weekly cron (Sunday 06:00 UTC) + `workflow_dispatch`
- Installs Node 22 / Go 1.24 / JDK 25 / Python 3.12
- Uploads report as artifact; pastes into job summary
- On cron, opens or updates a tracking issue labeled `template-doctor`
- Never fails on findings — report-only

## Test plan

- [x] `make -C scripts/template-doctor cross` — 0 findings (catalog's cross-references are clean)
- [x] Single-template TS run (`SKIP_TS=...` everything else) — 14 findings on ts-service: 1 typecheck error (49 tsc errors), 1 dead-dep (`jose`), 12 outdated-dep warnings
- [x] Markdown rendering works (used for GitHub job summary)
- [x] `npm outdated` uses default (top-level) not `--all` — cuts transitive noise from 146 findings to 14

## Follow-up

Next PR applies what this surfaces: hono 1→2, zod 3→4, vitest 3→4, typescript 5→6, eslint 9→10, dotenv 16→17, the 49 ts-service tsc errors, and the `jose` dead-dep cleanup.