### PR TITLE
fix(ts-service): zero tsc errors, bump deps to latest majors, drop dead jose

### DIFF
--- a/templates/ts-service/skeleton/.prettierignore
+++ b/templates/ts-service/skeleton/.prettierignore
@@ -1,0 +1,4 @@
+# Markdown files in the skeleton contain __PLACEHOLDER__ tokens that
+# prettier would rewrite as **bold** (double underscore is markdown
+# emphasis syntax). Keep markdown out of prettier's reach.
+*.md

--- a/templates/ts-service/skeleton/package.json
+++ b/templates/ts-service/skeleton/package.json
@@ -15,26 +15,25 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "hono": "^4.7.0",
-    "@hono/node-server": "^1.13.0",
+    "hono": "^4.12.0",
+    "@hono/node-server": "^2.0.0",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/sdk-node": "^0.57.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.56.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
-    "jose": "^6.0.0",
-    "zod": "^3.24.0",
-    "dotenv": "^16.4.0"
+    "@opentelemetry/sdk-node": "^0.215.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.73.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.215.0",
+    "zod": "^4.3.0",
+    "dotenv": "^17.4.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@types/node": "^22.0.0",
-    "eslint": "^9.20.0",
-    "prettier": "^3.5.0",
-    "tsx": "^4.19.0",
-    "typescript": "^5.8.0",
-    "typescript-eslint": "^8.25.0",
-    "vitest": "^3.1.0"
+    "@eslint/js": "^10.0.0",
+    "@types/node": "^25.6.0",
+    "eslint": "^10.2.0",
+    "prettier": "^3.8.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.0",
+    "typescript-eslint": "^8.59.0",
+    "vitest": "^4.1.0"
   },
   "engines": {
     "node": ">=22"

--- a/templates/ts-service/skeleton/src/__tests__/errors.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { json } from "./helpers.js";
 import { Hono } from "hono";
 import {
   AppError,
@@ -80,7 +81,7 @@ describe("errorHandler with domain errors", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(400);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("VALIDATION_ERROR");
     expect(body.error.message).toBe("Name is required");
     expect(body.error.statusCode).toBe(400);
@@ -95,7 +96,7 @@ describe("errorHandler with domain errors", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(404);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("NOT_FOUND");
     expect(body.error.message).toBe("Item not found");
     expect(body.error.statusCode).toBe(404);
@@ -110,7 +111,7 @@ describe("errorHandler with domain errors", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(409);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("CONFLICT");
     expect(body.error.message).toBe("Duplicate entry");
     expect(body.error.statusCode).toBe(409);
@@ -125,7 +126,7 @@ describe("errorHandler with domain errors", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(408);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("TIMEOUT");
     expect(body.error.message).toBe("Upstream timed out");
     expect(body.error.statusCode).toBe(408);
@@ -140,7 +141,7 @@ describe("errorHandler with domain errors", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(500);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("INTERNAL_ERROR");
     expect(body.error.message).toBe("Internal Server Error");
     expect(body.error.statusCode).toBe(500);
@@ -161,7 +162,7 @@ describe("errorHandler with domain errors", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(400);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("VALIDATION_ERROR");
     expect(body.error.issues).toHaveLength(2);
     expect(body.error.issues[0]).toEqual({
@@ -183,7 +184,7 @@ describe("errorHandler with domain errors", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(400);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("VALIDATION_ERROR");
     expect(body.error).not.toHaveProperty("issues");
   });

--- a/templates/ts-service/skeleton/src/__tests__/health.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/health.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { json } from "./helpers.js";
 import { app } from "../app.js";
 
 describe("GET /health", () => {
@@ -6,7 +7,7 @@ describe("GET /health", () => {
     const res = await app.request("/health");
     expect(res.status).toBe(200);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("status", "ok");
     expect(body).toHaveProperty("service", "__PROJECT_NAME__");
     expect(body).toHaveProperty("timestamp");
@@ -15,7 +16,7 @@ describe("GET /health", () => {
 
   it("returns exactly three fields", async () => {
     const res = await app.request("/health");
-    const body = await res.json();
+    const body = await json(res);
     expect(Object.keys(body)).toHaveLength(3);
     expect(Object.keys(body).sort()).toEqual(["service", "status", "timestamp"]);
   });

--- a/templates/ts-service/skeleton/src/__tests__/helpers.ts
+++ b/templates/ts-service/skeleton/src/__tests__/helpers.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Tests check arbitrary JSON response shapes that don't merit full
+// typing per call site. `json(res)` centralizes the assertion so the
+// rest of the file stays focused on what's being verified.
+export async function json<T = any>(res: Response): Promise<T> {
+  return (await res.json()) as T;
+}

--- a/templates/ts-service/skeleton/src/__tests__/idempotency.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/idempotency.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { json } from "./helpers.js";
 import { Hono } from "hono";
 import { idempotency } from "../middleware/idempotency.js";
 
@@ -25,11 +26,7 @@ function buildApp(options?: { ttlMs?: number }) {
   return app;
 }
 
-function post(
-  app: Hono,
-  body: unknown,
-  headers?: Record<string, string>
-) {
+function post(app: Hono, body: unknown, headers?: Record<string, string>) {
   return app.request("/items", {
     method: "POST",
     headers: {
@@ -40,12 +37,7 @@ function post(
   });
 }
 
-function put(
-  app: Hono,
-  id: string,
-  body: unknown,
-  headers?: Record<string, string>
-) {
+function put(app: Hono, id: string, body: unknown, headers?: Record<string, string>) {
   return app.request(`/items/${id}`, {
     method: "PUT",
     headers: {
@@ -61,13 +53,17 @@ function put(
 describe("idempotency middleware", () => {
   it("first POST with key returns 201", async () => {
     const app = buildApp();
-    const res = await post(app, { name: "Widget" }, {
-      "Idempotency-Key": "key-001",
-    });
+    const res = await post(
+      app,
+      { name: "Widget" },
+      {
+        "Idempotency-Key": "key-001",
+      }
+    );
 
     expect(res.status).toBe(201);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("id", "abc-123");
     expect(body).toHaveProperty("name", "Widget");
   });
@@ -81,7 +77,7 @@ describe("idempotency middleware", () => {
       "Idempotency-Key": "key-002",
     });
     expect(res1.status).toBe(201);
-    const body1 = await res1.json();
+    const body1 = await json(res1);
 
     // Second request — same key, same body
     const res2 = await post(app, payload, {
@@ -89,7 +85,7 @@ describe("idempotency middleware", () => {
     });
     expect(res2.status).toBe(201);
 
-    const body2 = await res2.json();
+    const body2 = await json(res2);
     expect(body2).toEqual(body1);
 
     // Verify replayed header
@@ -100,18 +96,26 @@ describe("idempotency middleware", () => {
     const app = buildApp();
 
     // First request
-    const res1 = await post(app, { name: "Widget" }, {
-      "Idempotency-Key": "key-003",
-    });
+    const res1 = await post(
+      app,
+      { name: "Widget" },
+      {
+        "Idempotency-Key": "key-003",
+      }
+    );
     expect(res1.status).toBe(201);
 
     // Second request — same key, different body
-    const res2 = await post(app, { name: "Gadget" }, {
-      "Idempotency-Key": "key-003",
-    });
+    const res2 = await post(
+      app,
+      { name: "Gadget" },
+      {
+        "Idempotency-Key": "key-003",
+      }
+    );
     expect(res2.status).toBe(409);
 
-    const body = await res2.json();
+    const body = await json(res2);
     expect(body.error.code).toBe("IDEMPOTENCY_CONFLICT");
   });
 
@@ -125,7 +129,7 @@ describe("idempotency middleware", () => {
 
     expect(res.status).toBe(200);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("items");
 
     // No replayed header on GET
@@ -178,7 +182,7 @@ describe("idempotency middleware", () => {
     const res = await post(app, { name: "NoKey" });
     expect(res.status).toBe(201);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("name", "NoKey");
   });
 });

--- a/templates/ts-service/skeleton/src/__tests__/integration.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { json } from "./helpers.js";
 import { app } from "../app.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -26,7 +27,7 @@ describe("POST /api/items", () => {
 
     expect(res.status).toBe(201);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("id");
     expect(body).toHaveProperty("name", "Test Widget");
     expect(body).toHaveProperty("description", "A test item");
@@ -39,7 +40,7 @@ describe("POST /api/items", () => {
 
     expect(res.status).toBe(201);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("name", "Minimal Item");
   });
 
@@ -48,7 +49,7 @@ describe("POST /api/items", () => {
 
     expect(res.status).toBe(400);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Validation failed");
     expect(body.issues).toBeInstanceOf(Array);
     expect(body.issues.length).toBeGreaterThan(0);
@@ -59,7 +60,7 @@ describe("POST /api/items", () => {
 
     expect(res.status).toBe(400);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Validation failed");
   });
 
@@ -72,7 +73,7 @@ describe("POST /api/items", () => {
 
     expect(res.status).toBe(400);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Invalid JSON");
   });
 });
@@ -81,13 +82,13 @@ describe("GET /api/items/:id", () => {
   it("returns 200 for an existing item", async () => {
     // Create an item first
     const createRes = await post("/api/items", { name: "Fetchable Item" });
-    const created = await createRes.json();
+    const created = await json(createRes);
 
     const res = await app.request(`/api/items/${created.id}`);
 
     expect(res.status).toBe(200);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("id", created.id);
     expect(body).toHaveProperty("name", "Fetchable Item");
   });
@@ -98,7 +99,7 @@ describe("GET /api/items/:id", () => {
 
     expect(res.status).toBe(404);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.code).toBe("NOT_FOUND");
     expect(body.error.statusCode).toBe(404);
   });
@@ -110,7 +111,7 @@ describe("GET /health", () => {
 
     expect(res.status).toBe(200);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("status", "ok");
     expect(body).toHaveProperty("service");
     expect(body).toHaveProperty("timestamp");
@@ -125,7 +126,7 @@ describe("GET /readyz", () => {
     // Default state is not ready (503) unless markReady was called
     // by another test or the bootstrap. Both 200 and 503 are valid
     // depending on test ordering, but we verify the response shape.
-    const body = await res.json();
+    const body = await json(res);
 
     if (res.status === 503) {
       expect(body).toHaveProperty("status", "not_ready");

--- a/templates/ts-service/skeleton/src/__tests__/middleware.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/middleware.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { json } from "./helpers.js";
 import { Hono } from "hono";
 import { errorHandler } from "../middleware/error-handler.js";
 
@@ -13,7 +14,7 @@ describe("errorHandler", () => {
     const res = await app.request("/fail");
     expect(res.status).toBe(500);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.message).toBe("Internal Server Error");
   });
 
@@ -29,7 +30,7 @@ describe("errorHandler", () => {
     const res = await app.request("/not-found");
     expect(res.status).toBe(404);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.message).toBe("Not Found");
   });
 
@@ -45,7 +46,7 @@ describe("errorHandler", () => {
     const res = await app.request("/bad");
     expect(res.status).toBe(400);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.message).toBe("Invalid input");
   });
 
@@ -63,7 +64,7 @@ describe("errorHandler", () => {
     const res = await app.request("/crash");
     expect(res.status).toBe(502);
 
-    const body = await res.json();
+    const body = await json(res);
     expect(body.error.message).toBe("Internal Server Error");
     expect(JSON.stringify(body)).not.toContain("secret");
   });

--- a/templates/ts-service/skeleton/src/__tests__/validate.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/validate.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { json } from "./helpers.js";
 import { Hono } from "hono";
 import { z } from "zod";
 import { validate } from "../middleware/validate.js";
@@ -37,7 +38,7 @@ describe("validate middleware", () => {
     const res = await post(app, { name: "widget", count: 5 });
 
     expect(res.status).toBe(201);
-    const body = await res.json();
+    const body = await json(res);
     expect(body.received).toEqual({ name: "widget", count: 5 });
   });
 
@@ -46,7 +47,7 @@ describe("validate middleware", () => {
     const res = await post(app, { name: "widget" });
 
     expect(res.status).toBe(201);
-    const body = await res.json();
+    const body = await json(res);
     expect(body.received).toEqual({ name: "widget" });
   });
 
@@ -55,7 +56,7 @@ describe("validate middleware", () => {
     const res = await post(app, { count: 3 });
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Validation failed");
     expect(body.issues).toBeInstanceOf(Array);
     expect(body.issues.length).toBeGreaterThan(0);
@@ -66,7 +67,7 @@ describe("validate middleware", () => {
     const res = await post(app, { name: "widget", count: "not-a-number" });
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Validation failed");
     expect(body.issues.some((i: { path: string }) => i.path === "count")).toBe(true);
   });
@@ -76,7 +77,7 @@ describe("validate middleware", () => {
     const res = await post(app, { name: "" });
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Validation failed");
     expect(body.issues.some((i: { message: string }) => i.message === "Name is required")).toBe(
       true
@@ -92,7 +93,7 @@ describe("validate middleware", () => {
     });
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Invalid JSON");
   });
 
@@ -101,7 +102,7 @@ describe("validate middleware", () => {
     const res = await post(app, { name: 123 });
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await json(res);
     expect(body.issues.some((i: { path: string }) => i.path === "name")).toBe(true);
   });
 
@@ -119,7 +120,7 @@ describe("validate middleware", () => {
     });
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await json(res);
     expect(body).toHaveProperty("error", "Validation failed");
   });
 });

--- a/templates/ts-service/skeleton/src/bootstrap.ts
+++ b/templates/ts-service/skeleton/src/bootstrap.ts
@@ -24,7 +24,7 @@ export function validateBootstrap(): void {
         `\n  Unresolved placeholder in ${label}: ${value}\n\n` +
           "  This project was scaffolded from a nanohype template but\n" +
           "  some variables were not replaced. Re-run the scaffolding\n" +
-          "  tool or replace placeholders manually.\n",
+          "  tool or replace placeholders manually.\n"
       );
       process.exit(1);
     }

--- a/templates/ts-service/skeleton/src/config.ts
+++ b/templates/ts-service/skeleton/src/config.ts
@@ -8,15 +8,9 @@ import { z } from "zod";
 //
 
 const configSchema = z.object({
-  PORT: z
-    .string()
-    .default("3000")
-    .transform(Number)
-    .pipe(z.number().int().min(1).max(65535)),
+  PORT: z.string().default("3000").transform(Number).pipe(z.number().int().min(1).max(65535)),
 
-  LOG_LEVEL: z
-    .enum(["trace", "debug", "info", "warn", "error", "fatal"])
-    .default("info"),
+  LOG_LEVEL: z.enum(["trace", "debug", "info", "warn", "error", "fatal"]).default("info"),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/templates/ts-service/skeleton/src/domain/errors.ts
+++ b/templates/ts-service/skeleton/src/domain/errors.ts
@@ -20,10 +20,7 @@ export class AppError extends Error {
 export class ValidationError extends AppError {
   readonly issues: Array<{ path: string; message: string }>;
 
-  constructor(
-    message: string,
-    issues: Array<{ path: string; message: string }> = []
-  ) {
+  constructor(message: string, issues: Array<{ path: string; message: string }> = []) {
     super(message, 400, "VALIDATION_ERROR");
     this.issues = issues;
   }

--- a/templates/ts-service/skeleton/src/metrics.ts
+++ b/templates/ts-service/skeleton/src/metrics.ts
@@ -16,10 +16,7 @@ export const httpRequestTotal = meter.createCounter("http_request_total", {
 });
 
 /** HTTP request duration in milliseconds, labeled by method, path, and status. */
-export const httpRequestDuration = meter.createHistogram(
-  "http_request_duration_ms",
-  {
-    description: "HTTP request latency in milliseconds",
-    unit: "ms",
-  },
-);
+export const httpRequestDuration = meter.createHistogram("http_request_duration_ms", {
+  description: "HTTP request latency in milliseconds",
+  unit: "ms",
+});

--- a/templates/ts-service/skeleton/src/middleware/error-handler.ts
+++ b/templates/ts-service/skeleton/src/middleware/error-handler.ts
@@ -43,9 +43,7 @@ export function errorHandler(err: Error, c: Context): Response {
   // internal detail doesn't leak.
   const rawStatus = (err as Error & { status?: unknown }).status;
   const status =
-    typeof rawStatus === "number" && rawStatus >= 400 && rawStatus < 600
-      ? rawStatus
-      : 500;
+    typeof rawStatus === "number" && rawStatus >= 400 && rawStatus < 600 ? rawStatus : 500;
 
   return c.json(
     {
@@ -55,6 +53,6 @@ export function errorHandler(err: Error, c: Context): Response {
         statusCode: status,
       },
     },
-    status as any,
+    status as any
   );
 }

--- a/templates/ts-service/skeleton/src/middleware/idempotency.ts
+++ b/templates/ts-service/skeleton/src/middleware/idempotency.ts
@@ -95,8 +95,7 @@ export function idempotency(options?: IdempotencyOptions) {
             {
               error: {
                 code: "IDEMPOTENCY_CONFLICT",
-                message:
-                  "Idempotency-Key has already been used with a different request body",
+                message: "Idempotency-Key has already been used with a different request body",
                 statusCode: 409,
               },
             },
@@ -143,8 +142,7 @@ export function idempotency(options?: IdempotencyOptions) {
 
       const res = c.res;
       const responseBody = await res.clone().text();
-      const contentType =
-        res.headers.get("Content-Type") ?? "application/json";
+      const contentType = res.headers.get("Content-Type") ?? "application/json";
 
       // Replace the sentinel with the real cached response
       store.set(idempotencyKey, {

--- a/templates/ts-service/skeleton/src/middleware/mask.ts
+++ b/templates/ts-service/skeleton/src/middleware/mask.ts
@@ -54,9 +54,7 @@ function isSensitiveHeader(name: string): boolean {
  * `***`. Authorization headers that start with "Bearer" preserve the
  * scheme prefix for debuggability: `Bearer ***`.
  */
-export function maskHeaders(
-  headers: Record<string, string>,
-): Record<string, string> {
+export function maskHeaders(headers: Record<string, string>): Record<string, string> {
   const result: Record<string, string> = {};
 
   for (const [name, value] of Object.entries(headers)) {

--- a/templates/ts-service/skeleton/src/middleware/metrics.ts
+++ b/templates/ts-service/skeleton/src/middleware/metrics.ts
@@ -9,10 +9,7 @@ import { httpRequestTotal, httpRequestDuration } from "../metrics.js";
 // silently discard data when no provider is registered.
 //
 
-export async function metricsMiddleware(
-  c: Context,
-  next: Next,
-): Promise<void> {
+export async function metricsMiddleware(c: Context, next: Next): Promise<void> {
   const start = performance.now();
 
   await next();

--- a/templates/ts-service/skeleton/src/middleware/request-id.ts
+++ b/templates/ts-service/skeleton/src/middleware/request-id.ts
@@ -8,10 +8,7 @@ import type { Context, Next } from "hono";
 // handlers and echoed back in the response header.
 //
 
-export async function requestId(
-  c: Context,
-  next: Next
-): Promise<void> {
+export async function requestId(c: Context, next: Next): Promise<void> {
   const requestId = c.req.header("X-Request-Id") ?? crypto.randomUUID();
   c.set("requestId", requestId);
   c.header("X-Request-Id", requestId);

--- a/templates/ts-service/skeleton/src/openapi.ts
+++ b/templates/ts-service/skeleton/src/openapi.ts
@@ -12,31 +12,28 @@ import { z, type ZodTypeAny, type ZodObject, type ZodRawShape } from "zod";
 
 // ── Zod-to-JSON-Schema Conversion ──────────────────────────────────
 
-// NOTE: This function accesses Zod's internal `_def` property to unwrap
-// optionals, defaults, effects, pipelines, and arrays. These internals are
-// not part of Zod's public API and may change in Zod v4. If upgrading Zod,
-// verify that `_def.innerType`, `_def.schema`, `_def.out`, and `_def.type`
-// still exist on the respective Zod class instances.
+// Walks a Zod schema via the internal `_def` property. Zod v4 exposes
+// the same shape through `_def.innerType` / `_def.in` / `_def.out` / etc.;
+// verify these still exist before bumping major.
 function zodTypeToJsonSchema(schema: ZodTypeAny): Record<string, unknown> {
-  // Unwrap optionals, defaults, and effects
+  // Unwrap optionals and defaults.
   if (schema instanceof z.ZodOptional || schema instanceof z.ZodDefault) {
     return zodTypeToJsonSchema((schema as any)._def.innerType);
   }
 
-  if (schema instanceof z.ZodEffects) {
-    // .transform() — we cannot introspect the output type at the schema
-    // level, so fall back to a generic string type. Callers who need a
+  // Zod v4 unified `.transform()` and `.pipe()` under two classes —
+  // `ZodTransform` for `.transform()` and `ZodPipe` for `.pipe()`.
+  if (schema instanceof z.ZodTransform) {
+    // `.transform()` — output type cannot be introspected at the schema
+    // level. Fall back to a generic string type; callers who need a
     // precise output type should use .pipe() instead.
     return { type: "string" };
   }
 
-  if (schema instanceof z.ZodPipeline) {
-    // For .pipe() chains, expose the output schema (e.g. z.coerce.number()
-    // piped through z.number() should appear as "integer" in the spec).
+  if (schema instanceof z.ZodPipe) {
+    // For `.pipe()` chains, expose the output schema (e.g.
+    // z.coerce.number().pipe(z.number().int()) appears as "integer").
     const out = zodTypeToJsonSchema((schema as any)._def.out);
-    // Promote "number" to "integer" for query params that pipe through
-    // z.number().int() or z.coerce.number() — the common pattern for
-    // integer query parameters.
     if (out.type === "number") {
       return { ...out, type: "integer" };
     }
@@ -70,9 +67,7 @@ function zodTypeToJsonSchema(schema: ZodTypeAny): Record<string, unknown> {
   return {};
 }
 
-function zodObjectToJsonSchema(
-  schema: ZodObject<ZodRawShape>
-): Record<string, unknown> {
+function zodObjectToJsonSchema(schema: ZodObject<ZodRawShape>): Record<string, unknown> {
   const shape = schema.shape;
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
@@ -82,9 +77,7 @@ function zodObjectToJsonSchema(
     properties[key] = zodTypeToJsonSchema(fieldSchema);
 
     // A field is required unless it's ZodOptional or ZodDefault
-    const isOptional =
-      fieldSchema instanceof z.ZodOptional ||
-      fieldSchema instanceof z.ZodDefault;
+    const isOptional = fieldSchema instanceof z.ZodOptional || fieldSchema instanceof z.ZodDefault;
     if (!isOptional) {
       required.push(key);
     }
@@ -122,10 +115,7 @@ interface RouteDefinition {
 }
 
 // Import schemas for route definitions
-import {
-  CreateItemSchema,
-  UpdateItemSchema,
-} from "./schemas/example.js";
+import { CreateItemSchema, UpdateItemSchema } from "./schemas/example.js";
 
 const routes: RouteDefinition[] = [
   {

--- a/templates/ts-service/skeleton/src/routes/example.ts
+++ b/templates/ts-service/skeleton/src/routes/example.ts
@@ -1,10 +1,11 @@
 import { Hono } from "hono";
+import type { z } from "zod";
 import { validate } from "../middleware/validate.js";
 import { CreateItemSchema, UpdateItemSchema } from "../schemas/example.js";
-import {
-  ExampleService,
-  InMemoryItemRepository,
-} from "../services/example.js";
+import { ExampleService, InMemoryItemRepository } from "../services/example.js";
+
+type CreateItemInput = z.infer<typeof CreateItemSchema>;
+type UpdateItemInput = z.infer<typeof UpdateItemSchema>;
 
 // ── Example CRUD Routes ──────────────────────────────────────────────
 //
@@ -28,14 +29,14 @@ exampleRoutes.get("/items", async (c) => {
 // ── Get by ID ────────────────────────────────────────────────────────
 
 exampleRoutes.get("/items/:id", async (c) => {
-  const item = await service.getItem(c.req.param("id"));
+  const item = await service.getItem(c.req.param("id")!);
   return c.json(item);
 });
 
 // ── Create ───────────────────────────────────────────────────────────
 
 exampleRoutes.post("/items", validate(CreateItemSchema), async (c) => {
-  const body = c.get("validatedBody");
+  const body = c.get("validatedBody") as CreateItemInput;
   const item = await service.createItem(body);
   return c.json(item, 201);
 });
@@ -43,14 +44,14 @@ exampleRoutes.post("/items", validate(CreateItemSchema), async (c) => {
 // ── Update ───────────────────────────────────────────────────────────
 
 exampleRoutes.patch("/items/:id", validate(UpdateItemSchema), async (c) => {
-  const body = c.get("validatedBody");
-  const item = await service.updateItem(c.req.param("id"), body);
+  const body = c.get("validatedBody") as UpdateItemInput;
+  const item = await service.updateItem(c.req.param("id")!, body);
   return c.json(item);
 });
 
 // ── Delete ───────────────────────────────────────────────────────────
 
 exampleRoutes.delete("/items/:id", async (c) => {
-  await service.deleteItem(c.req.param("id"));
+  await service.deleteItem(c.req.param("id")!);
   return c.json({ deleted: true });
 });

--- a/templates/ts-service/skeleton/src/schemas/example.ts
+++ b/templates/ts-service/skeleton/src/schemas/example.ts
@@ -21,16 +21,8 @@ export const ItemIdSchema = z.object({
 });
 
 export const QueryItemSchema = z.object({
-  limit: z
-    .string()
-    .transform(Number)
-    .pipe(z.number().int().min(1).max(100))
-    .optional(),
-  offset: z
-    .string()
-    .transform(Number)
-    .pipe(z.number().int().min(0))
-    .optional(),
+  limit: z.string().transform(Number).pipe(z.number().int().min(1).max(100)).optional(),
+  offset: z.string().transform(Number).pipe(z.number().int().min(0)).optional(),
 });
 
 export type CreateItemInput = z.infer<typeof CreateItemSchema>;

--- a/templates/ts-service/skeleton/src/telemetry/index.ts
+++ b/templates/ts-service/skeleton/src/telemetry/index.ts
@@ -49,7 +49,5 @@ export function initTelemetry(): void {
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
-  console.log(
-    `[telemetry] Initialized (exporter: ${otlpEndpoint ? "otlp" : "console"})`
-  );
+  console.log(`[telemetry] Initialized (exporter: ${otlpEndpoint ? "otlp" : "console"})`);
 }

--- a/templates/ts-service/skeleton/src/types/hono.d.ts
+++ b/templates/ts-service/skeleton/src/types/hono.d.ts
@@ -1,0 +1,16 @@
+// Module augmentation so Hono's `c.get(...)` / `c.set(...)` are typed
+// for the context variables this service installs through middleware.
+//
+// - requestId   set by middleware/request-id.ts
+// - validatedBody set by middleware/validate.ts; typed as unknown at
+//   the framework boundary, narrowed per route by casting to the
+//   schema's inferred output.
+
+import "hono";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    requestId: string;
+    validatedBody: unknown;
+  }
+}


### PR DESCRIPTION
## Summary

First fix PR surfaced by the template-doctor tool (#85). Targets the findings on `ts-service`:

- **49 → 0 tsc errors** (accumulated typing debt)
- **1 dead dep** dropped (`jose`, leftover from #77's inline auth-stub removal)
- **12 major-version bumps** applied (Hono 1→2, zod 3→4, vitest 3→4, typescript 5→6, eslint 9→10, dotenv 16→17, @types/node 22→25, the @opentelemetry/* family 0.57→0.215)

After this lands, `ts-service` is a clean slate: no typecheck debt, every direct dep on latest stable major, zero unused declarations.

## tsc 49 → 0

Two root causes:

1. **Hono's `ContextVariableMap` defaults to `never`**, so `c.get("validatedBody")` and `c.get("requestId")` never typechecked. Added `src/types/hono.d.ts` with a module augmentation — one ambient declaration, every call site just works.
2. **Test files treated `await res.json()` as structured data**; recent `@types/node` returns `unknown` from `Response.json()`. Added `src/__tests__/helpers.ts` exporting `json<T = any>(res)` that casts at the response boundary. Six test files switched to `const body = await json(res);`.

Also fixed in `routes/example.ts`: `c.req.param("id")` returns `string | undefined` for path segments — non-null assertion matches the `/items/:id` contract. Added typed `CreateItemInput` / `UpdateItemInput` aliases via `z.infer<>` and cast `validatedBody` at the handler level.

## Dep bumps

| Dep | Current | Latest |
|---|---|---|
| hono | 4.7 | 4.12 |
| @hono/node-server | 1.19 | 2.0 |
| zod | 3.24 | 4.3 |
| dotenv | 16.4 | 17.4 |
| @opentelemetry/sdk-node | 0.57 | 0.215 |
| @opentelemetry/auto-instrumentations-node | 0.56 | 0.73 |
| @opentelemetry/exporter-trace-otlp-http | 0.57 | 0.215 |
| @opentelemetry/exporter-metrics-otlp-http | 0.57 | 0.215 |
| typescript (dev) | 5.8 | 6.0 |
| @types/node (dev) | 22 | 25.6 |
| eslint (dev) | 9.20 | 10.2 |
| @eslint/js (dev) | 9.20 | 10.0 |
| vitest (dev) | 3.1 | 4.1 |
| prettier, tsx (dev) | stable minor bumps |

**Zod 4 break:** `openapi.ts` used `ZodEffects` / `ZodPipeline` — Zod v4 renamed them to `ZodTransform` / `ZodPipe`. Updated the two `instanceof` checks; the rest of the `_def`-walking logic is unchanged.

## Dropped dead dep

Removed `jose` — the inline auth stub that used it was deleted in #77.

## Prettier hazard

`npm run format` rewrote README placeholders `__PROJECT_NAME__` → `**PROJECT_NAME**` (double underscore is markdown emphasis; prettier normalizes). Added `.prettierignore` that excludes `*.md`. Reverted the damaged README to its source.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors (was 49)
- [x] `npm test` — 44/44 pass
- [x] `npm run lint` — 15 pre-existing warnings, 0 errors
- [x] `npm run format:check` — clean (markdown now excluded)
- [x] `npm run validate:catalog` — 0 errors, 0 warnings
- [x] `npm run lint:docs` — 0 errors, 111 files

## Follow-up

The other 46 TS templates + 3 Go + 1 Java + 1 Python need the same treatment. The template-doctor workflow from #85 posts a weekly catalog health report; each ecosystem batch fix becomes its own PR as drift accumulates.