### PR TITLE
feat(templates): add k8s-app-tenant — primary scaffold for nanohype-org apps

### DIFF
--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -1,0 +1,76 @@
+# k8s-app-tenant
+
+Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm chart, ArgoCD ApplicationSet entry, and Platform CR — the three artifacts that make an app a Platform tenant on the `eks-agent-platform` operator.
+
+## What you get
+
+- **Helm chart** in `chart/` with `Chart.yaml`, `values.yaml`, per-env deltas (`values-dev.yaml`, `values-staging.yaml`, `values-production.yaml`), and templates for Deployment, Service, ServiceAccount (IRSA-annotated by the Platform reconciler), and NetworkPolicy (default-deny + explicit egress allow-list)
+- **ApplicationSet entry** in `gitops/applicationset-entry.yaml` ready to copy into `nanohype/eks-gitops/applicationsets/` (or aks-gitops)
+- **Platform CR** in `platform.yaml` (`agents.stxkxs.io/v1alpha1`) declaring the tenant boundary — the operator reconciles Namespace, ResourceQuota, default-deny NetworkPolicy, ArgoCD AppProject, IRSA role, KMS grants, and S3 bucket policy from this CR
+- **Skeleton README** documenting how to apply the Platform CR, register the ApplicationSet entry, and roll out new versions
+
+## Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `AppName` | string | (required) | Kebab-case app name — used as chart name, namespace, Platform CR name, service account name |
+| `Description` | string | `k8s-native Platform tenant` | Short description for Chart.yaml + README |
+| `Tenant` | string | (required) | Owning team (drives namespace prefix `tenants-<team>`, AppProject, quotas) |
+| `Image` | string | (required) | Container image base (no tag) |
+| `Port` | string | `8080` | Container port |
+| `GitopsRepo` | string | `nanohype/eks-gitops` | Target gitops repo for the ApplicationSet entry |
+| `SyncWave` | string | `100` | ArgoCD sync wave (apps land after addons which use waves 0–52) |
+
+## Project layout
+
+```
+<app>/
+  chart/
+    Chart.yaml
+    values.yaml                    # base values for all environments
+    values-dev.yaml                # dev delta only
+    values-staging.yaml            # staging delta only
+    values-production.yaml         # prod delta only
+    templates/
+      deployment.yaml
+      service.yaml
+      serviceaccount.yaml          # eks.amazonaws.com/role-arn filled by Platform reconciler
+      networkpolicy.yaml           # default-deny + egress allow-list
+      _helpers.tpl
+  gitops/
+    applicationset-entry.yaml      # copy into nanohype/eks-gitops/applicationsets/
+  platform.yaml                    # Platform CR (apply once during tenant setup)
+  README.md                        # how to deploy + iterate
+```
+
+## Pairs with
+
+Compose with any of the application templates that produce a container-shipped service:
+
+- `ts-service` / `go-service` — backend services
+- `next-app` — frontend
+- `mcp-server-ts` / `mcp-server-python` — MCP gateways
+- `agentic-loop` — agent-driven workloads (also use `agent-fleet` for the AgentFleet CR)
+
+## Nests inside
+
+- `monorepo` — drop the rendered tree at `apps/<app-name>/` or wherever the monorepo's app layout calls for
+
+## Renders against
+
+Designed to work with these repos already in place on the target cluster:
+
+- `nanohype/landing-zone` — provisions the EKS/AKS cluster, ArgoCD, base IAM, KMS keys
+- `nanohype/eks-gitops` (or `aks-gitops`) — supplies cluster addons (cert-manager, external-secrets, ingress-nginx, observability, Kyverno policies) and the ApplicationSet that picks up `gitops/applicationset-entry.yaml`
+- `nanohype/eks-agent-platform` — runs the operator that reconciles your `platform.yaml`
+
+If any of these are missing on the target cluster, the rendered app's `platform.yaml` won't reconcile and the ApplicationSet entry won't have a parent to register against.
+
+## How to roll out
+
+1. Render: `helm template chart/ -f chart/values-dev.yaml` (sanity)
+2. Apply Platform CR: `kubectl apply -f platform.yaml`
+3. Wait for `Platform.status.phase = Ready`
+4. Copy `gitops/applicationset-entry.yaml` into the gitops repo as a new entry in the appropriate ApplicationSet
+5. ArgoCD picks up the entry on next sync and rolls out the chart
+6. For new image tags: update `values-{env}.yaml` `image.tag`, commit, ArgoCD reconciles

--- a/templates/k8s-app-tenant/skeleton/.gitignore
+++ b/templates/k8s-app-tenant/skeleton/.gitignore
@@ -1,0 +1,13 @@
+# Helm
+chart/charts/
+chart/Chart.lock
+
+# Rendered output (if you ever run helm template > rendered/)
+rendered/
+
+# Editor + OS noise
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/templates/k8s-app-tenant/skeleton/README.md
+++ b/templates/k8s-app-tenant/skeleton/README.md
@@ -1,0 +1,57 @@
+# __APP_NAME__
+
+__DESCRIPTION__
+
+A Platform tenant on the [`nanohype/eks-agent-platform`](https://github.com/nanohype/eks-agent-platform) operator. Owned by team `__TENANT__`.
+
+## Layout
+
+```
+chart/
+  Chart.yaml
+  values.yaml                    # base values (all environments)
+  values-dev.yaml                # dev delta
+  values-staging.yaml            # staging delta
+  values-production.yaml         # prod delta
+  templates/                     # deployment, service, serviceaccount, networkpolicy
+gitops/
+  applicationset-entry.yaml      # register with __GITOPS_REPO__
+platform.yaml                    # Platform CR — apply once
+```
+
+## Initial setup (per cluster, one-time)
+
+1. **Apply the Platform CR**:
+   ```sh
+   kubectl apply -f platform.yaml
+   ```
+2. **Wait for reconciliation**:
+   ```sh
+   kubectl wait --for=jsonpath='{.status.phase}'=Ready \
+     platform/__APP_NAME__ -n tenants-__TENANT__ --timeout=60s
+   ```
+3. **Register the ApplicationSet entry** — copy `gitops/applicationset-entry.yaml` into [`__GITOPS_REPO__/applicationsets/`](https://github.com/__GITOPS_REPO__/tree/main/applicationsets), commit, push. ArgoCD picks it up on next reconcile.
+
+## Iterating
+
+- **Code change** → bump image tag in `values-<env>.yaml` → commit → ArgoCD reconciles.
+- **Chart change** → edit `chart/templates/*.yaml` → render locally with `helm template chart/ -f chart/values-dev.yaml` → commit.
+- **New egress** → add entry to `chart/values.yaml` `networkPolicy.egress` → render → commit.
+- **New IRSA policy** → edit `platform.yaml` `spec.irsa.policies` → reapply → operator reconciles the role.
+
+## What lives where (don't put it in the wrong place)
+
+- **Cloud substrate** (KMS keys, VPC endpoints, IAM patterns) → [`nanohype/landing-zone`](https://github.com/nanohype/landing-zone), NOT this chart.
+- **Cluster addons** (ingress controller, cert-manager, External Secrets, observability) → `__GITOPS_REPO__`, NOT this chart.
+- **App config** → this chart's `values.yaml` + per-env deltas.
+- **Per-tenant IAM** → `platform.yaml` `spec.irsa.policies`. The reconciler creates the role.
+
+## Local development
+
+Run against [`nanohype/kx`](https://github.com/nanohype/kx) (local kind cluster mirroring eks-gitops):
+
+```sh
+cd ~/codes/kx && task up
+kubectl apply -f platform.yaml
+helm install __APP_NAME__ chart/ -f chart/values-dev.yaml
+```

--- a/templates/k8s-app-tenant/skeleton/chart/Chart.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: __APP_NAME__
+description: __DESCRIPTION__
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+maintainers:
+  - name: __TENANT__

--- a/templates/k8s-app-tenant/skeleton/chart/templates/_helpers.tpl
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "app.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+agents.stxkxs.io/tenant: {{ .Values.otel.resourceAttributes "agents.tenant" | default "unknown" | quote }}
+agents.stxkxs.io/platform: {{ .Values.otel.resourceAttributes "agents.platform" | default .Chart.Name | quote }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Service account name.
+*/}}
+{{- define "app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/templates/k8s-app-tenant/skeleton/chart/templates/deployment.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.labels" . | nindent 8 }}
+      annotations:
+        {{- range $k, $v := .Values.otel.resourceAttributes }}
+        resource.opentelemetry.io/{{ $k }}: {{ $v | quote }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- range $k, $v := .Values.otel.resourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES_{{ $k | upper | replace "." "_" | replace "-" "_" }}
+              value: {{ $v | quote }}
+            {{- end }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector.observability.svc.cluster.local:4317"
+          livenessProbe:
+            {{- toYaml .Values.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.probes.readiness | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/templates/k8s-app-tenant/skeleton/chart/templates/networkpolicy.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from same namespace + cluster-level ingress controller.
+    # Adjust to match the actual caller pattern for this app.
+    - from:
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+{{- end }}

--- a/templates/k8s-app-tenant/skeleton/chart/templates/service.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/templates/k8s-app-tenant/skeleton/chart/templates/serviceaccount.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  # The Platform reconciler (eks-agent-platform) fills in
+  # `eks.amazonaws.com/role-arn` here based on platform.yaml's spec.irsa.policies.
+  # Do NOT scaffold this annotation manually — the reconciler owns it.
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/k8s-app-tenant/skeleton/chart/values-dev.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-dev.yaml
@@ -1,0 +1,10 @@
+# Dev delta — only differences from values.yaml.
+image:
+  tag: dev
+
+replicaCount: 1
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi

--- a/templates/k8s-app-tenant/skeleton/chart/values-production.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-production.yaml
@@ -1,0 +1,13 @@
+# Production delta — only differences from values.yaml.
+image:
+  tag: production
+
+replicaCount: 3
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi

--- a/templates/k8s-app-tenant/skeleton/chart/values-staging.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-staging.yaml
@@ -1,0 +1,5 @@
+# Staging delta — only differences from values.yaml.
+image:
+  tag: staging
+
+replicaCount: 2

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -1,0 +1,91 @@
+# Base values for __APP_NAME__. Per-environment deltas live in values-{dev,staging,production}.yaml.
+
+image:
+  repository: __IMAGE__
+  tag: ""           # pinned per-environment in values-{env}.yaml
+  pullPolicy: IfNotPresent
+
+replicaCount: 2
+
+service:
+  type: ClusterIP
+  port: __PORT__
+  targetPort: __PORT__
+
+serviceAccount:
+  create: true
+  # `eks.amazonaws.com/role-arn` annotation is filled by the Platform reconciler.
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: __PORT__
+    initialDelaySeconds: 10
+    periodSeconds: 30
+  readiness:
+    httpGet:
+      path: /readyz
+      port: __PORT__
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+# Default-deny + egress allow-list. Add entries per the app's actual needs.
+networkPolicy:
+  enabled: true
+  egress:
+    # DNS to kube-system CoreDNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        - podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+    # HTTPS egress to the internet (Bedrock, GitHub, etc.)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.0.0/16   # link-local / IMDS — must NOT be reachable from pods
+      ports:
+        - protocol: TCP
+          port: 443
+
+# OTel resource attrs propagate through traces/logs/metrics. The cluster-level
+# OTel Collector tags downstream exporters using these.
+otel:
+  enabled: true
+  resourceAttributes:
+    agents.tenant: __TENANT__
+    agents.platform: __APP_NAME__
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/templates/k8s-app-tenant/skeleton/gitops/applicationset-entry.yaml
+++ b/templates/k8s-app-tenant/skeleton/gitops/applicationset-entry.yaml
@@ -1,0 +1,53 @@
+# Copy this entry into the appropriate ApplicationSet in __GITOPS_REPO__.
+# Match the existing ApplicationSet matrix-generator shape — typically
+# `applicationsets/apps-tenants.yaml` (or create one if it doesn't exist yet).
+#
+# Reference: the ApplicationSet template uses the cluster secret labels
+# (environment, provider) and per-app overrides (chart path, sync wave).
+
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tenant-__APP_NAME__
+  namespace: argocd
+spec:
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  argocd.argoproj.io/secret-type: cluster
+          - list:
+              elements:
+                - name: __APP_NAME__
+                  path: apps/__APP_NAME__/chart
+                  syncWave: "__SYNC_WAVE__"
+  template:
+    metadata:
+      name: '{{ "{{name}}" }}-{{ "{{ index .metadata.labels \"environment\" }}" }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{ "{{syncWave}}" }}'
+    spec:
+      project: tenant-__TENANT__
+      sources:
+        - repoURL: https://github.com/__GITOPS_REPO__.git
+          targetRevision: main
+          path: '{{ "{{path}}" }}'
+          helm:
+            valueFiles:
+              - $values/{{ "{{path}}" }}/values.yaml
+              - $values/{{ "{{path}}" }}/values-{{ "{{ index .metadata.labels \"environment\" }}" }}.yaml
+        - repoURL: https://github.com/__GITOPS_REPO__.git
+          targetRevision: main
+          ref: values
+      destination:
+        server: '{{ "{{server}}" }}'
+        namespace: tenants-__TENANT__
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false   # Platform reconciler owns the Namespace
+          - ServerSideApply=true

--- a/templates/k8s-app-tenant/skeleton/platform.yaml
+++ b/templates/k8s-app-tenant/skeleton/platform.yaml
@@ -1,0 +1,35 @@
+# Platform CR — declares the tenant boundary. Apply this ONCE during initial
+# tenant setup. The eks-agent-platform operator reconciles:
+#   - Namespace (with Pod Security Standards baseline label)
+#   - ResourceQuota + LimitRange
+#   - Default-deny NetworkPolicy
+#   - ArgoCD AppProject scoped to this Platform
+#   - Per-Platform IRSA role with the policies named in spec.irsa.policies
+#   - KMS grants on the data CMK + log CMK
+#   - S3 bucket policy on spec.storage.bucket
+#
+# After this is Ready (Platform.status.phase), the chart's ApplicationSet
+# entry in __GITOPS_REPO__ takes over.
+
+apiVersion: agents.stxkxs.io/v1alpha1
+kind: Platform
+metadata:
+  name: __APP_NAME__
+  namespace: tenants-__TENANT__
+spec:
+  tenant: __TENANT__
+
+  irsa:
+    serviceAccount: __APP_NAME__
+    # Add the AWS managed-or-inline policy ARNs this app's pod needs to assume
+    # via IRSA. Common patterns: bedrock-invoke, secretsmanager-read, s3-rw,
+    # dynamodb-rw, sqs-rw. The operator applies + grants accordingly.
+    policies: []
+
+  resourceQuota:
+    cpu: "2"
+    memory: 4Gi
+
+  storage:
+    bucket: __APP_NAME__-artifacts
+    kmsKey: cmk-data

--- a/templates/k8s-app-tenant/template.yaml
+++ b/templates/k8s-app-tenant/template.yaml
@@ -1,0 +1,98 @@
+apiVersion: nanohype/v1
+
+name: k8s-app-tenant
+displayName: "K8s App as Platform Tenant"
+description: >
+  Primary scaffolding for a nanohype-org k8s-native application. Produces
+  a Helm chart with per-environment values, an ArgoCD ApplicationSet entry
+  ready to register against nanohype/eks-gitops or nanohype/aks-gitops,
+  and a Platform CR (agents.stxkxs.io/v1alpha1) declaring the tenant
+  boundary for the eks-agent-platform operator to reconcile. Use this for
+  every k8s-native deliverable unless an explicit escape hatch
+  (aws-lambda, fly, vercel, cloudflare) is justified.
+version: "0.1.0"
+license: Apache-2.0
+persona: [engineering]
+category: infrastructure
+tags: [kubernetes, k8s, helm, argocd, platform, nanohype]
+
+variables:
+  - name: AppName
+    type: string
+    placeholder: "__APP_NAME__"
+    description: "Kebab-case app name. Used as chart name, namespace, Platform CR name, and service account name."
+    prompt: "App name"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be lowercase kebab-case starting with a letter"
+
+  - name: Description
+    type: string
+    placeholder: "__DESCRIPTION__"
+    description: "Short app description for Chart.yaml and README."
+    prompt: "Description"
+    default: "k8s-native Platform tenant"
+
+  - name: Tenant
+    type: string
+    placeholder: "__TENANT__"
+    description: "Owning team. Drives the namespace prefix (tenants-<team>), ArgoCD AppProject, and per-tenant resource quotas."
+    prompt: "Owning team"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be lowercase kebab-case"
+
+  - name: Image
+    type: string
+    placeholder: "__IMAGE__"
+    description: "Container image base (no tag — tag pinned per-env in values-{env}.yaml)."
+    prompt: "Container image"
+    required: true
+
+  - name: Port
+    type: string
+    placeholder: "__PORT__"
+    description: "Container port the app listens on."
+    prompt: "Container port"
+    default: "8080"
+
+  - name: GitopsRepo
+    type: string
+    placeholder: "__GITOPS_REPO__"
+    description: "Target gitops repo for the ApplicationSet entry."
+    prompt: "Gitops repo (org/repo)"
+    default: "nanohype/eks-gitops"
+    validation:
+      pattern: "^[a-z0-9-]+/[a-z0-9-]+$"
+      message: "Must be org/repo (e.g., nanohype/eks-gitops)"
+
+  - name: SyncWave
+    type: string
+    placeholder: "__SYNC_WAVE__"
+    description: "ArgoCD sync wave for this app's ApplicationSet entry. Apps typically deploy after addons (wave >= 100)."
+    prompt: "Sync wave"
+    default: "100"
+
+conditionals: []
+
+composition:
+  pairsWith: [ts-service, go-service, next-app, mcp-server-ts, mcp-server-python, agentic-loop]
+  nestsInside: [monorepo]
+
+prerequisites:
+  - name: helm
+    version: ">=3.0"
+    purpose: "Render and lint the chart locally before pushing"
+    optional: false
+  - name: kubectl
+    version: ">=1.28"
+    purpose: "Apply the Platform CR during initial tenant setup (before ArgoCD takes over via the ApplicationSet)"
+    optional: false
+  - name: kustomize
+    version: ">=5.0"
+    purpose: "Build per-env overlays consumed by the ApplicationSet entry"
+    optional: false
+
+hooks: {}


### PR DESCRIPTION
## Summary

Adds the canonical template every nanohype-org k8s-native application should scaffold from. Produces the three artifacts that make an app a Platform tenant on the [`nanohype/eks-agent-platform`](https://github.com/nanohype/eks-agent-platform) operator:

1. A Helm chart in `chart/` (with the eks-gitops base+delta values pattern)
2. An ArgoCD ApplicationSet entry in `gitops/applicationset-entry.yaml`
3. A `Platform` CR in `platform.yaml`

This is the template `spastic`'s factory now defaults to per `IAC_BY_TARGET` / `PLATFORM_TENANT_CONTRACT` (landed in `nanohype/spastic#2`).

## Variables

`AppName`, `Description`, `Tenant`, `Image`, `Port`, `GitopsRepo` (default `nanohype/eks-gitops`), `SyncWave` (default `100`).

## Conventions adopted

- [`nanohype/eks-gitops`](https://github.com/nanohype/eks-gitops) Helm values pattern: base `values.yaml` + delta-only `values-{env}.yaml` files
- [`nanohype/eks-agent-platform`](https://github.com/nanohype/eks-agent-platform) Platform CR shape per `ARCHITECTURE.md`
- Pod Security Standards baseline (Namespace labeled by operator)
- OTel resource attributes (`agents.tenant`, `agents.platform`) propagated as both pod annotations and container env vars
- ServiceAccount template explicitly defers IRSA annotation to the Platform reconciler — apps do NOT scaffold IAM roles inline

## Test plan

- [x] `./scripts/validate.sh templates/k8s-app-tenant` — passes (template.yaml schema valid, skeleton non-empty, all placeholders used)
- [x] `npm run validate:catalog` — 0 errors, 0 warnings across the full catalog
- [ ] After merge: render against sample variables and `helm lint chart/` to confirm chart validity post-substitution

## Follow-ups (next phases)

- Phase 2.3 continued: `agent-fleet`, `landing-zone-component`, `eks-addon` templates
- Phase 2.4: `infra-aws` README rewrite (Lambda-only escape hatch); decide `k8s-deploy` fate
- Phase 2.5: `nanohype/CLAUDE.md` updates to reflect new template catalog