### PR TITLE
chore: migrate CR templates + tenant contract to *.nanohype.dev groups

### DIFF
--- a/.plans/k8s-templates.md
+++ b/.plans/k8s-templates.md
@@ -38,7 +38,7 @@ Variables:
 - `ScaleTrigger` — `sqs` | `cpu` | `cron`
 - `Compute` — accelerator class (`none` | `nvidia-l40s` | `nvidia-h100` | `neuron`)
 
-Reference: `eks-agent-platform/ARCHITECTURE.md` AgentFleet CRD field shape; `agents.stxkxs.io/v1alpha1` API group.
+Reference: `eks-agent-platform/ARCHITECTURE.md` AgentFleet CRD field shape; `agents.nanohype.dev/v1alpha1` API group.
 
 ### `templates/landing-zone-component/`
 

--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/catalog.schema.json",
   "kind": "nanohype/catalog",
   "version": "1",
-  "generated_at": "2026-05-18T03:17:13.000Z",
+  "generated_at": "2026-05-30T01:48:51.000Z",
   "templates": [
     {
       "name": "a2a-agent",
@@ -46,7 +46,7 @@
     {
       "name": "agent-fleet",
       "displayName": "Agent Fleet (kagent + AgentFleet CR)",
-      "description": "Scaffolds the AI-workload composite on top of a Platform tenant. Produces an AgentFleet CR (agents.stxkxs.io/v1alpha1) composing kagent Agent + ModelConfig + KEDA scaler + optional DRA accelerator, plus a ModelGateway CR declaring the agentgateway route with Bedrock model resolution and Guardrails. Pairs with k8s-app-tenant — the Platform CR there owns the tenant boundary; this composes the AI pieces inside that boundary.",
+      "description": "Scaffolds the AI-workload composite on top of a Platform tenant. Produces an AgentFleet CR (agents.nanohype.dev/v1alpha1) composing kagent Agent + ModelConfig + KEDA scaler + optional DRA accelerator, plus a ModelGateway CR declaring the agentgateway route with Bedrock model resolution and Guardrails. Pairs with k8s-app-tenant — the Platform CR there owns the tenant boundary; this composes the AI pieces inside that boundary.",
       "version": "0.1.0",
       "category": "ai-systems",
       "persona": [
@@ -804,7 +804,7 @@
     {
       "name": "k8s-app-tenant",
       "displayName": "K8s App as Platform Tenant",
-      "description": "Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm chart with per-environment values, an ArgoCD ApplicationSet entry ready to register against nanohype/eks-gitops or nanohype/aks-gitops, and a Platform CR (agents.stxkxs.io/v1alpha1) declaring the tenant boundary for the eks-agent-platform operator to reconcile. Use this for every k8s-native deliverable unless an explicit escape hatch (aws-lambda, fly, vercel, cloudflare) is justified.",
+      "description": "Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm chart with per-environment values, an ArgoCD ApplicationSet entry ready to register against nanohype/eks-gitops or nanohype/aks-gitops, and a Platform CR (platform.nanohype.dev/v1alpha1) declaring the tenant boundary for the eks-agent-platform operator to reconcile. Use this for every k8s-native deliverable unless an explicit escape hatch (aws-lambda, fly, vercel, cloudflare) is justified.",
       "version": "0.1.0",
       "category": "infrastructure",
       "persona": [

--- a/standards/platform-tenant-contract.json
+++ b/standards/platform-tenant-contract.json
@@ -48,7 +48,7 @@
       }
     ],
     "platform_cr_shape": {
-      "apiVersion": "agents.stxkxs.io/v1alpha1",
+      "apiVersion": "platform.nanohype.dev/v1alpha1",
       "kind": "Platform",
       "metadata": {
         "name": "<app-name>",

--- a/templates/agent-fleet/README.md
+++ b/templates/agent-fleet/README.md
@@ -4,7 +4,7 @@ The AI-workload composite scaffolding for nanohype-org apps. Produces an `AgentF
 
 ## What you get
 
-- **`agentfleet.yaml`** — `AgentFleet` (`agents.stxkxs.io/v1alpha1`) composing kagent `Agent` + `ModelConfig` + KEDA `ScaledObject`, with optional DRA accelerator class for NVIDIA/Neuron workloads
+- **`agentfleet.yaml`** — `AgentFleet` (`agents.nanohype.dev/v1alpha1`) composing kagent `Agent` + `ModelConfig` + KEDA `ScaledObject`, with optional DRA accelerator class for NVIDIA/Neuron workloads
 - **`modelgateway.yaml`** — `ModelGateway` declaring the agentgateway `Route`, Bedrock model ID resolution, Bedrock Guardrails attachment point, and per-route rate limits
 - **`README.md`** documenting the apply order (Platform first, then ModelGateway, then AgentFleet) and the OTel attributes the AI workload must emit
 

--- a/templates/agent-fleet/skeleton/agentfleet.yaml
+++ b/templates/agent-fleet/skeleton/agentfleet.yaml
@@ -9,7 +9,7 @@
 #   - tenant ServiceAccount annotated for IRSA (Platform reconciler owns the role-arn)
 #   - optional ResourceClaimTemplate for DRA accelerators (when spec.compute != none)
 
-apiVersion: agents.stxkxs.io/v1alpha1
+apiVersion: agents.nanohype.dev/v1alpha1
 kind: AgentFleet
 metadata:
   name: __FLEET_NAME__

--- a/templates/agent-fleet/skeleton/modelgateway.yaml
+++ b/templates/agent-fleet/skeleton/modelgateway.yaml
@@ -1,7 +1,7 @@
 # ModelGateway — declares the agentgateway route + Bedrock model resolution.
 # Apply BEFORE AgentFleet (AgentFleet.spec.modelRoute references this).
 
-apiVersion: agents.stxkxs.io/v1alpha1
+apiVersion: agents.nanohype.dev/v1alpha1
 kind: ModelGateway
 metadata:
   name: __APP_NAME__-gateway

--- a/templates/agent-fleet/template.yaml
+++ b/templates/agent-fleet/template.yaml
@@ -4,7 +4,7 @@ name: agent-fleet
 displayName: "Agent Fleet (kagent + AgentFleet CR)"
 description: >
   Scaffolds the AI-workload composite on top of a Platform tenant.
-  Produces an AgentFleet CR (agents.stxkxs.io/v1alpha1) composing
+  Produces an AgentFleet CR (agents.nanohype.dev/v1alpha1) composing
   kagent Agent + ModelConfig + KEDA scaler + optional DRA accelerator,
   plus a ModelGateway CR declaring the agentgateway route with Bedrock
   model resolution and Guardrails. Pairs with k8s-app-tenant — the

--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -6,7 +6,7 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
 
 - **Helm chart** in `chart/` with `Chart.yaml`, `values.yaml`, per-env deltas (`values-dev.yaml`, `values-staging.yaml`, `values-production.yaml`), and templates for Deployment, Service, ServiceAccount (IRSA-annotated by the Platform reconciler), and NetworkPolicy (default-deny + explicit egress allow-list)
 - **ApplicationSet entry** in `gitops/applicationset-entry.yaml` ready to copy into `nanohype/eks-gitops/applicationsets/` (or aks-gitops)
-- **Platform CR** in `platform.yaml` (`agents.stxkxs.io/v1alpha1`) declaring the tenant boundary — the operator reconciles Namespace, ResourceQuota, default-deny NetworkPolicy, ArgoCD AppProject, IRSA role, KMS grants, and S3 bucket policy from this CR
+- **Platform CR** in `platform.yaml` (`platform.nanohype.dev/v1alpha1`) declaring the tenant boundary — the operator reconciles Namespace, ResourceQuota, default-deny NetworkPolicy, ArgoCD AppProject, IRSA role, KMS grants, and S3 bucket policy from this CR
 - **Skeleton README** documenting how to apply the Platform CR, register the ApplicationSet entry, and roll out new versions
 
 ## Variables

--- a/templates/k8s-app-tenant/skeleton/chart/templates/_helpers.tpl
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/_helpers.tpl
@@ -31,8 +31,8 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | 
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-agents.stxkxs.io/tenant: {{ .Values.otel.resourceAttributes "agents.tenant" | default "unknown" | quote }}
-agents.stxkxs.io/platform: {{ .Values.otel.resourceAttributes "agents.platform" | default .Chart.Name | quote }}
+agents.nanohype.dev/tenant: {{ .Values.otel.resourceAttributes "agents.tenant" | default "unknown" | quote }}
+agents.nanohype.dev/platform: {{ .Values.otel.resourceAttributes "agents.platform" | default .Chart.Name | quote }}
 {{- end -}}
 
 {{/*

--- a/templates/k8s-app-tenant/skeleton/platform.yaml
+++ b/templates/k8s-app-tenant/skeleton/platform.yaml
@@ -11,7 +11,7 @@
 # After this is Ready (Platform.status.phase), the chart's ApplicationSet
 # entry in __GITOPS_REPO__ takes over.
 
-apiVersion: agents.stxkxs.io/v1alpha1
+apiVersion: platform.nanohype.dev/v1alpha1
 kind: Platform
 metadata:
   name: __APP_NAME__

--- a/templates/k8s-app-tenant/template.yaml
+++ b/templates/k8s-app-tenant/template.yaml
@@ -6,7 +6,7 @@ description: >
   Primary scaffolding for a nanohype-org k8s-native application. Produces
   a Helm chart with per-environment values, an ArgoCD ApplicationSet entry
   ready to register against nanohype/eks-gitops or nanohype/aks-gitops,
-  and a Platform CR (agents.stxkxs.io/v1alpha1) declaring the tenant
+  and a Platform CR (platform.nanohype.dev/v1alpha1) declaring the tenant
   boundary for the eks-agent-platform operator to reconcile. Use this for
   every k8s-native deliverable unless an explicit escape hatch
   (aws-lambda, fly, vercel, cloudflare) is justified.


### PR DESCRIPTION
Moves every Custom Resource the catalog scaffolds — and the Platform tenant contract documenting the canonical shape — off the legacy `agents.stxkxs.io` group onto the per-kind `nanohype.dev` groups the eks-agent-platform operator now serves. Domain only; `v1alpha1` is unchanged.

## Per-kind group mapping
| Kind | New apiVersion |
|---|---|
| Platform | `platform.nanohype.dev/v1alpha1` |
| AgentFleet | `agents.nanohype.dev/v1alpha1` |
| ModelGateway | `agents.nanohype.dev/v1alpha1` |

## What changed
- **standards/platform-tenant-contract.json** — canonical Platform CR shape `apiVersion` -> `platform.nanohype.dev/v1alpha1`.
- **templates/k8s-app-tenant/skeleton/platform.yaml** — Platform CR -> `platform.nanohype.dev/v1alpha1`.
- **templates/agent-fleet/skeleton/agentfleet.yaml** — AgentFleet -> `agents.nanohype.dev/v1alpha1`.
- **templates/agent-fleet/skeleton/modelgateway.yaml** — ModelGateway -> `agents.nanohype.dev/v1alpha1`.
- **templates/k8s-app-tenant/skeleton/chart/templates/_helpers.tpl** — common-label keys `agents.stxkxs.io/{tenant,platform}` -> `agents.nanohype.dev/{tenant,platform}` (label-key swap `stxkxs.io/<x>` -> `nanohype.dev/<x>`). OTel resource-attribute keys `agents.tenant` / `agents.platform` left untouched — they are OTel attrs, not stxkxs.io label keys.
- **Prose** — k8s-app-tenant + agent-fleet `template.yaml`/`README.md` and `.plans/k8s-templates.md` group references updated.
- **catalog.json** — regenerated from the template manifests; agent-fleet and k8s-app-tenant entries pick up the new group references.

## Verification
- `validate:schema` — all template manifests valid
- `validate:standards` — platform-tenant-contract.json valid
- `validate:manifest` — catalog.json valid
- `verify:catalog` — generator output in sync with sources
- `validate.sh templates/k8s-app-tenant` and `templates/agent-fleet` — all checks pass

Scope is limited to this repo; eks-agent-platform is handled separately.