### PR TITLE
Phase 3 — application templates to the production bar (ts-service, slack-bot, rag-pipeline, data-pipeline)

### DIFF
--- a/templates/data-pipeline/skeleton/.dockerignore
+++ b/templates/data-pipeline/skeleton/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+coverage
+.git
+.github
+.env
+.env.*
+*.test.ts
+src/**/__tests__
+output
+npm-debug.log*
+.DS_Store

--- a/templates/data-pipeline/skeleton/.env.example
+++ b/templates/data-pipeline/skeleton/.env.example
@@ -1,12 +1,18 @@
-# ──── Embedding Provider ────
-# Provider: openai
+# ──── Embedding Provider (AWS Bedrock — default) ────
+# Bedrock authenticates via the AWS credential chain (IRSA on-cluster, your local
+# AWS profile in dev) — NO API keys. Set the region where Titan is enabled.
+AWS_REGION=us-west-2
+EMBED_REQUEST_TIMEOUT_MS=30000
+
+# Provider: bedrock (default, Titan v2) | openai
 EMBEDDING_PROVIDER=__EMBEDDING_PROVIDER__
-EMBEDDING_MODEL=text-embedding-3-small
-EMBEDDING_DIMENSIONS=1536
+EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+EMBEDDING_DIMENSIONS=1024
 EMBEDDING_BATCH_SIZE=128
 
-# OpenAI API key (required for openai embeddings)
-OPENAI_API_KEY=sk-your-openai-api-key
+# OpenAI alternate — only when EMBEDDING_PROVIDER=openai (with
+# EMBEDDING_MODEL=text-embedding-3-small, EMBEDDING_DIMENSIONS=1536):
+# OPENAI_API_KEY=sk-your-openai-api-key
 
 # ──── Chunking ────
 CHUNK_STRATEGY=__CHUNK_STRATEGY__

--- a/templates/data-pipeline/skeleton/.github/workflows/ci.yml
+++ b/templates/data-pipeline/skeleton/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [24]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test (with coverage)
+        run: npm run test:coverage
+
+      - name: Audit (production dependencies)
+        run: npm audit --audit-level=high --omit=dev

--- a/templates/data-pipeline/skeleton/Dockerfile
+++ b/templates/data-pipeline/skeleton/Dockerfile
@@ -1,0 +1,31 @@
+# ── Build Stage ───────────────────────────────────────────────────────
+
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN npm run build
+
+# ── Production Stage ──────────────────────────────────────────────────
+
+FROM node:24-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+USER node
+
+# Batch ETL entry. In-cluster this typically runs as a CronJob/Job.
+CMD ["node", "dist/pipeline/index.js"]

--- a/templates/data-pipeline/skeleton/eslint.config.js
+++ b/templates/data-pipeline/skeleton/eslint.config.js
@@ -4,5 +4,19 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    rules: {
+      // Honor the `_`-prefix convention for intentionally-unused params/vars
+      // (e.g. provider methods that ignore some arguments).
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
   { ignores: ["dist/", "node_modules/"] },
 );

--- a/templates/data-pipeline/skeleton/package.json
+++ b/templates/data-pipeline/skeleton/package.json
@@ -8,31 +8,36 @@
     "run": "tsx src/pipeline/index.ts",
     "build": "tsc",
     "lint": "eslint src/",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "audit:prod": "npm audit --audit-level=high --omit=dev"
   },
   "dependencies": {
-    "openai": "^4.85.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+    "openai": "^6.34.0",
     "pdf-parse": "^1.1.1",
-    "cheerio": "^1.0.0",
-    "@opentelemetry/api": "^1.9.0",
-    "zod": "^3.24.0",
-    "dotenv": "^16.4.0"
+    "cheerio": "^1.2.0",
+    "@opentelemetry/api": "^1.9.1",
+    "zod": "^4.3.6",
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@types/node": "^22.0.0",
+    "@eslint/js": "^10.0.1",
+    "@types/node": "^24.12.2",
     "@types/pdf-parse": "^1.1.4",
-    "eslint": "^9.20.0",
-    "prettier": "^3.5.0",
-    "tsx": "^4.19.0",
-    "typescript": "^5.8.0",
-    "typescript-eslint": "^8.25.0",
-    "vitest": "^3.1.0"
+    "eslint": "^10.2.0",
+    "prettier": "^3.8.2",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.58.2",
+    "vitest": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.4"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/templates/data-pipeline/skeleton/src/pipeline/__tests__/orchestrator.test.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/__tests__/orchestrator.test.ts
@@ -6,7 +6,7 @@
  * and that per-document error handling works as expected.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { runPipeline } from "../orchestrator.js";
 import type { IngestSource } from "../ingest/types.js";
 import type { ChunkStrategy } from "../transform/types.js";

--- a/templates/data-pipeline/skeleton/src/pipeline/embed/bedrock.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/embed/bedrock.ts
@@ -1,0 +1,72 @@
+/**
+ * AWS Bedrock embedding provider (Titan Text v2) — the org default.
+ *
+ * Auth is the AWS credential chain (IRSA on-cluster), never API keys. Every call
+ * carries an AbortSignal timeout so a hung Bedrock socket trips the circuit
+ * breaker, and the Titan response is schema-validated before use rather than
+ * trusting raw model output.
+ *
+ * Registers itself as the "bedrock" embedding provider on import.
+ */
+
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { z } from "zod";
+import type { EmbeddingProvider } from "./types.js";
+import { registerEmbeddingProvider } from "./registry.js";
+import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
+
+const REQUEST_TIMEOUT_MS = Number(process.env.EMBED_REQUEST_TIMEOUT_MS ?? 30_000);
+const titanResponseSchema = z.object({ embedding: z.array(z.number()) });
+
+class BedrockEmbedder implements EmbeddingProvider {
+  readonly name = "bedrock";
+
+  private readonly client = new BedrockRuntimeClient({
+    region: process.env.AWS_REGION ?? "us-west-2",
+  });
+  private readonly cb = createCircuitBreaker();
+  private readonly model: string;
+  private readonly dims: number;
+
+  constructor(model = "amazon.titan-embed-text-v2:0", dims = 1024) {
+    this.model = model;
+    this.dims = dims;
+  }
+
+  get dimensions(): number {
+    return this.dims;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const response = await this.cb.execute(() =>
+      this.client.send(
+        new InvokeModelCommand({
+          modelId: this.model,
+          contentType: "application/json",
+          accept: "application/json",
+          body: JSON.stringify({ inputText: text, dimensions: this.dims, normalize: true }),
+        }),
+        { abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+      ),
+    );
+    const parsed = titanResponseSchema.parse(
+      JSON.parse(new TextDecoder().decode(response.body)),
+    );
+    return parsed.embedding;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    // Titan embeds a single input per call; sequential keeps it within quota.
+    const out: number[][] = [];
+    for (const t of texts) {
+      out.push(await this.embed(t));
+    }
+    return out;
+  }
+}
+
+registerEmbeddingProvider(
+  "bedrock",
+  (model?: unknown, dims?: unknown) =>
+    new BedrockEmbedder(model as string, dims as number),
+);

--- a/templates/data-pipeline/skeleton/src/pipeline/embed/index.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/embed/index.ts
@@ -13,6 +13,8 @@ export {
   listEmbeddingProviders,
 } from "./registry.js";
 
-// Import provider modules to trigger registration
+// Import provider modules to trigger registration. Bedrock (Titan v2) is the
+// org default; openai is an alternate.
+import "./bedrock.js";
 import "./openai.js";
 import "./mock.js";

--- a/templates/data-pipeline/skeleton/src/pipeline/embed/openai.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/embed/openai.ts
@@ -12,6 +12,8 @@ import type { EmbeddingProvider } from "./types.js";
 import { registerEmbeddingProvider } from "./registry.js";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 
+const REQUEST_TIMEOUT_MS = Number(process.env.EMBED_REQUEST_TIMEOUT_MS ?? 30_000);
+
 class OpenAIEmbedder implements EmbeddingProvider {
   readonly name = "openai";
 
@@ -42,7 +44,7 @@ class OpenAIEmbedder implements EmbeddingProvider {
   private async getClient(): Promise<InstanceType<typeof import("openai").default>> {
     if (!this.client) {
       const OpenAI = (await import("openai")).default;
-      this.client = new OpenAI({ apiKey: this.apiKey });
+      this.client = new OpenAI({ apiKey: this.apiKey, timeout: REQUEST_TIMEOUT_MS, maxRetries: 1 });
     }
     return this.client;
   }

--- a/templates/data-pipeline/skeleton/src/pipeline/ingest/file.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/ingest/file.ts
@@ -66,7 +66,7 @@ class FileSource implements IngestSource {
 
   private async loadSingleFile(filePath: string): Promise<Document | null> {
     const ext = extname(filePath).toLowerCase();
-    let content: string | null = null;
+    let content: string | null;
 
     if (TEXT_EXTENSIONS.has(ext) || DATA_EXTENSIONS.has(ext)) {
       content = await loadTextFile(filePath);

--- a/templates/data-pipeline/skeleton/src/pipeline/ingest/url-guard.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/ingest/url-guard.ts
@@ -1,0 +1,80 @@
+/**
+ * SSRF guard for the web ingest source.
+ *
+ * Rejects URLs that would let an operator-supplied source pivot into internal
+ * services (cloud metadata at 169.254.169.254, RFC1918 subnets, loopback,
+ * link-local). Run before every outbound fetch on operator-controlled URLs. The
+ * hostname is resolved once here so the address we gate on is the one fetched;
+ * DNS-rebinding remains a theoretical residual risk.
+ */
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+export interface UrlGuardOptions {
+  readonly allowedSchemes?: readonly string[];
+}
+
+const DEFAULT_SCHEMES = ["http:", "https:"] as const;
+
+export class UrlGuardError extends Error {
+  constructor(
+    public readonly reason: string,
+    public readonly url: string,
+  ) {
+    super(`URL guard rejected ${url}: ${reason}`);
+    this.name = "UrlGuardError";
+  }
+}
+
+export async function guardUrl(rawUrl: string, options: UrlGuardOptions = {}): Promise<URL> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new UrlGuardError("malformed URL", rawUrl);
+  }
+
+  const schemes = options.allowedSchemes ?? DEFAULT_SCHEMES;
+  if (!schemes.includes(parsed.protocol)) {
+    throw new UrlGuardError(`scheme ${parsed.protocol} not allowed`, rawUrl);
+  }
+
+  const host = parsed.hostname;
+  if (!host) {
+    throw new UrlGuardError("missing host", rawUrl);
+  }
+
+  // URL.hostname wraps IPv6 literals in brackets ([::1]); isIP wants the bare address.
+  const bareHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  const addresses = isIP(bareHost) ? [bareHost] : [(await lookup(bareHost)).address];
+  for (const addr of addresses) {
+    if (isBlockedAddress(addr)) {
+      throw new UrlGuardError(`resolves to blocked address ${addr}`, rawUrl);
+    }
+  }
+
+  return parsed;
+}
+
+function isBlockedAddress(addr: string): boolean {
+  // IPv4 private + loopback + link-local + cloud metadata.
+  if (isIP(addr) === 4) {
+    const parts = addr.split(".").map(Number);
+    const [a = 0, b = 0] = parts;
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 169 && b === 254) return true; // includes 169.254.169.254 cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 0) return true;
+    return false;
+  }
+
+  // IPv6: loopback, link-local (fe80::/10), unique-local (fc00::/7), unspecified.
+  const lower = addr.toLowerCase();
+  if (lower === "::1" || lower === "::") return true;
+  if (lower.startsWith("fe80:") || lower.startsWith("fe80::")) return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  return false;
+}

--- a/templates/data-pipeline/skeleton/src/pipeline/ingest/web.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/ingest/web.ts
@@ -11,6 +11,7 @@ import { createHash } from "node:crypto";
 import type { Document } from "../types.js";
 import type { IngestSource } from "./types.js";
 import { registerSource } from "./registry.js";
+import { guardUrl } from "./url-guard.js";
 import { logger } from "../logger.js";
 
 function contentHash(text: string): string {
@@ -22,6 +23,10 @@ class WebSource implements IngestSource {
 
   async load(url: string): Promise<Document[]> {
     try {
+      // SSRF guard — reject loopback / RFC1918 / link-local / cloud-metadata
+      // before the fetch. Throws UrlGuardError (handled by the catch below).
+      await guardUrl(url);
+
       const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
 
       if (!response.ok) {

--- a/templates/data-pipeline/skeleton/src/pipeline/metrics.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/metrics.ts
@@ -32,3 +32,12 @@ export const pipelineDuration = meter.createHistogram(
     unit: "ms",
   },
 );
+
+/** Terminal stage errors, labeled by stage (ingest/transform/embed/output) — the
+ *  "errors" of RED. Incremented when a stage fails after retries are exhausted. */
+export const pipelineErrorsTotal = meter.createCounter(
+  "pipeline_errors_total",
+  {
+    description: "Total terminal stage errors, labeled by stage",
+  },
+);

--- a/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
@@ -24,7 +24,12 @@ import type { ChunkStrategy } from "./transform/types.js";
 import type { EmbeddingProvider } from "./embed/types.js";
 import type { OutputAdapter } from "./output/types.js";
 import { logger } from "./logger.js";
-import { pipelineDocumentsProcessed, pipelineChunksCreated, pipelineDuration } from "./metrics.js";
+import {
+  pipelineDocumentsProcessed,
+  pipelineChunksCreated,
+  pipelineDuration,
+  pipelineErrorsTotal,
+} from "./metrics.js";
 
 export interface OrchestratorOptions {
   /** Ingest source for loading documents. */
@@ -70,6 +75,7 @@ export async function runPipeline(opts: OrchestratorOptions): Promise<PipelineRe
       itemId: config.sourcePath,
       message: String(err),
     });
+    pipelineErrorsTotal.add(1, { stage: "ingest" });
     logger.error("Ingest failed completely", { error: String(err) });
   }
 
@@ -102,6 +108,7 @@ export async function runPipeline(opts: OrchestratorOptions): Promise<PipelineRe
         itemId: doc.id,
         message: String(err),
       });
+      pipelineErrorsTotal.add(1, { stage: "transform" });
       logger.warn("Transform failed for document", { docId: doc.id, error: String(err) });
     }
   }
@@ -155,6 +162,7 @@ export async function runPipeline(opts: OrchestratorOptions): Promise<PipelineRe
           message: String(err),
         });
       }
+      pipelineErrorsTotal.add(batch.length, { stage: "embed" });
       logger.warn("Embed failed for batch", {
         batchIdx,
         batchSize: batch.length,
@@ -196,6 +204,7 @@ export async function runPipeline(opts: OrchestratorOptions): Promise<PipelineRe
             message: String(err),
           });
         }
+        pipelineErrorsTotal.add(batch.length, { stage: "index" });
         logger.warn("Index write failed for batch", { error: String(err) });
       }
     }
@@ -207,6 +216,7 @@ export async function runPipeline(opts: OrchestratorOptions): Promise<PipelineRe
       itemId: "adapter",
       message: String(err),
     });
+    pipelineErrorsTotal.add(1, { stage: "index" });
     logger.error("Index adapter error", { error: String(err) });
   }
 

--- a/templates/data-pipeline/skeleton/vitest.config.ts
+++ b/templates/data-pipeline/skeleton/vitest.config.ts
@@ -3,5 +3,35 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the pure transform algorithms + registries (focused unit tests).
+      // SDK-backed embedders, IO ingest/output adapters, the orchestrator glue,
+      // bootstrap, and the semantic chunker are exercised by integration / live
+      // SDKs, not unit-covered.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/pipeline/index.ts",
+        "src/pipeline/bootstrap.ts",
+        "src/pipeline/logger.ts",
+        "src/pipeline/metrics.ts",
+        "src/pipeline/orchestrator.ts",
+        "src/pipeline/ingest/**",
+        "src/pipeline/embed/**",
+        "src/pipeline/output/**",
+        "src/pipeline/transform/semantic.ts",
+      ],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        statements: 70,
+        branches: 70,
+      },
+    },
   },
 });

--- a/templates/data-pipeline/template.yaml
+++ b/templates/data-pipeline/template.yaml
@@ -7,9 +7,10 @@ description: >
   document ingestion from files and web pages, configurable chunking
   strategies (recursive, fixed-size, semantic), embedding generation,
   and output adapters for indexing. No LangChain — all components are
-  built from first principles using provider SDKs directly. Supports
-  multiple ingest sources (PDF, Markdown, plain text, JSON, CSV, web),
-  embedding providers (OpenAI), and output formats (JSONL, console).
+  built from first principles using provider SDKs directly. Defaults to
+  AWS Bedrock Titan v2 embeddings (on IRSA — no keys), with OpenAI as an
+  alternate. Supports multiple ingest sources (PDF, Markdown, plain text,
+  JSON, CSV, web — SSRF-guarded) and output formats (JSONL, console).
   Output is compatible with module-vector-store's VectorDocument shape.
 version: "0.1.0"
 license: Apache-2.0
@@ -38,9 +39,9 @@ variables:
   - name: EmbeddingProvider
     type: string
     placeholder: "__EMBEDDING_PROVIDER__"
-    description: "Provider for generating text embeddings (e.g. openai)"
+    description: "Provider for text embeddings — bedrock (Titan v2, default) or openai"
     prompt: "Embedding provider"
-    default: "openai"
+    default: "bedrock"
 
   - name: ChunkStrategy
     type: string
@@ -79,6 +80,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
+    version: ">=24"
     purpose: "Node.js runtime for TypeScript execution"
     optional: false

--- a/templates/rag-pipeline/skeleton/.dockerignore
+++ b/templates/rag-pipeline/skeleton/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+coverage
+.git
+.github
+.env
+.env.*
+*.test.ts
+src/__tests__
+chroma_data
+docs
+npm-debug.log*
+.DS_Store

--- a/templates/rag-pipeline/skeleton/.env.example
+++ b/templates/rag-pipeline/skeleton/.env.example
@@ -1,18 +1,28 @@
+# ──── LLM + Embeddings (AWS Bedrock — default) ────
+# Bedrock authenticates via the AWS credential chain (IRSA on-cluster, your
+# local AWS profile in dev) — NO API keys. Set the region where the models are
+# enabled.
+AWS_REGION=us-west-2
+LLM_REQUEST_TIMEOUT_MS=30000
+
+# ──── Generation (LLM) ────
+# Provider: bedrock (default) | anthropic | openai
+LLM_PROVIDER=__LLM_PROVIDER__
+LLM_MODEL=anthropic.claude-sonnet-4-6
+LLM_TEMPERATURE=0.1
+LLM_MAX_TOKENS=1024
+
 # ──── Embedding Provider ────
-# Provider: openai | cohere
+# Provider: bedrock (default, Titan v2) | openai | cohere
 EMBEDDING_PROVIDER=__EMBEDDING_PROVIDER__
-EMBEDDING_MODEL=text-embedding-3-small
-EMBEDDING_DIMENSIONS=1536
+EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+EMBEDDING_DIMENSIONS=1024
 EMBEDDING_BATCH_SIZE=128
 
-# Anthropic API key (required for anthropic generation)
-ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key
-
-# OpenAI API key (required for openai embeddings and/or openai generation)
-OPENAI_API_KEY=sk-your-openai-api-key
-
-# Cohere API key (required for cohere embeddings)
-# COHERE_API_KEY=your-cohere-api-key
+# Direct-API alternates — only when the provider is anthropic / openai / cohere:
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# COHERE_API_KEY=...
 
 # ──── Chunking ────
 CHUNK_STRATEGY=__CHUNK_STRATEGY__
@@ -20,30 +30,16 @@ CHUNK_SIZE=512
 CHUNK_OVERLAP=64
 
 # ──── Vector Store ────
-# Backend: chroma | pgvector | qdrant | pinecone
+# Backend: chroma | pgvector | qdrant | pinecone. pgvector is the durable
+# cluster default; chroma is convenient for local dev.
 VECTORSTORE_BACKEND=__VECTOR_STORE__
 VECTORSTORE_COLLECTION_NAME=documents
-
-# Chroma (local persistent storage)
 VECTORSTORE_CHROMA_PERSIST_DIR=./chroma_data
-
-# pgvector
 # VECTORSTORE_PG_CONNECTION_STRING=postgresql://user:password@localhost:5432/__PROJECT_NAME__
-
-# Qdrant
 # VECTORSTORE_QDRANT_URL=http://localhost:6333
 # VECTORSTORE_QDRANT_API_KEY=
-
-# Pinecone
-# VECTORSTORE_PINECONE_API_KEY=your-pinecone-api-key
+# VECTORSTORE_PINECONE_API_KEY=
 # VECTORSTORE_PINECONE_INDEX_NAME=__PROJECT_NAME__
-
-# ──── Generation (LLM) ────
-# Provider: anthropic | openai
-LLM_PROVIDER=__LLM_PROVIDER__
-LLM_MODEL=claude-sonnet-4-20250514
-LLM_TEMPERATURE=0.1
-LLM_MAX_TOKENS=1024
 
 # ──── Retrieval ────
 RETRIEVAL_TOP_K=5

--- a/templates/rag-pipeline/skeleton/.github/workflows/ci.yml
+++ b/templates/rag-pipeline/skeleton/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [24]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test (with coverage)
+        run: npm run test:coverage
+
+      - name: Audit (production dependencies)
+        run: npm audit --audit-level=high --omit=dev

--- a/templates/rag-pipeline/skeleton/Dockerfile
+++ b/templates/rag-pipeline/skeleton/Dockerfile
@@ -1,0 +1,32 @@
+# ── Build Stage ───────────────────────────────────────────────────────
+
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN npm run build
+
+# ── Production Stage ──────────────────────────────────────────────────
+
+FROM node:24-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+USER node
+
+# Default to the CLI entry (ingest/query subcommands). Override CMD to run a
+# specific subcommand or a long-lived service wrapper.
+CMD ["node", "dist/index.js"]

--- a/templates/rag-pipeline/skeleton/eslint.config.js
+++ b/templates/rag-pipeline/skeleton/eslint.config.js
@@ -4,5 +4,19 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    rules: {
+      // Honor the `_`-prefix convention for intentionally-unused params/vars
+      // (e.g. interface methods that ignore some arguments).
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
   { ignores: ["dist/", "node_modules/"] },
 );

--- a/templates/rag-pipeline/skeleton/package.json
+++ b/templates/rag-pipeline/skeleton/package.json
@@ -9,34 +9,39 @@
     "query": "tsx src/index.ts query",
     "build": "tsc",
     "lint": "eslint src/",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "audit:prod": "npm audit --audit-level=high --omit=dev"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
-    "openai": "^4.85.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+    "@anthropic-ai/sdk": "^0.89.0",
     "cohere-ai": "^7.0.0",
-    "chromadb": "^1.9.0",
     "pg": "^8.13.0",
     "@qdrant/js-client-rest": "^1.12.0",
     "@pinecone-database/pinecone": "^4.0.0",
-    "zod": "^3.24.0",
-    "dotenv": "^16.4.0"
+    "dotenv": "^17.4.2",
+    "openai": "^4.104.0",
+    "chromadb": "^1.10.5",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@types/node": "^22.0.0",
+    "@eslint/js": "^10.0.1",
+    "@types/node": "^24.12.2",
     "@types/pg": "^8.11.0",
-    "eslint": "^9.20.0",
-    "prettier": "^3.5.0",
-    "tsx": "^4.19.0",
-    "typescript": "^5.8.0",
-    "typescript-eslint": "^8.25.0",
-    "vitest": "^3.1.0"
+    "eslint": "^10.2.0",
+    "prettier": "^3.8.2",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.58.2",
+    "vitest": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.4"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/templates/rag-pipeline/skeleton/src/__tests__/pipeline.integration.test.ts
+++ b/templates/rag-pipeline/skeleton/src/__tests__/pipeline.integration.test.ts
@@ -326,7 +326,6 @@ describe("RAG pipeline integration", () => {
 
   it("uses different chunking strategies and produces valid pipeline output", async () => {
     const longText = Array(20).fill(DOCUMENT_A).join("\n\n");
-    const config = makeConfig();
 
     for (const strategy of ["fixed", "recursive"] as const) {
       const chunker = createChunker({ strategy, size: 50, overlap: 10 });

--- a/templates/rag-pipeline/skeleton/src/__tests__/registry.test.ts
+++ b/templates/rag-pipeline/skeleton/src/__tests__/registry.test.ts
@@ -5,7 +5,7 @@
  * LLM, embedding, and vector store.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerLlmProvider,
   getLlmProvider,

--- a/templates/rag-pipeline/skeleton/src/config.ts
+++ b/templates/rag-pipeline/skeleton/src/config.ts
@@ -18,8 +18,10 @@ const chunkingSchema = z.object({
 
 const embeddingSchema = z.object({
   provider: z.string().default("__EMBEDDING_PROVIDER__"),
-  model: z.string().default("text-embedding-3-small"),
-  dimensions: z.coerce.number().int().positive().default(1536),
+  // Defaults target Bedrock Titan Text v2 (1024-dim). For OpenAI, set
+  // EMBEDDING_MODEL=text-embedding-3-small and EMBEDDING_DIMENSIONS=1536.
+  model: z.string().default("amazon.titan-embed-text-v2:0"),
+  dimensions: z.coerce.number().int().positive().default(1024),
   batchSize: z.coerce.number().int().positive().default(128),
 });
 
@@ -38,7 +40,9 @@ const generationSchema = z.object({
   provider: z.string().default("__LLM_PROVIDER__"),
   anthropicApiKey: z.string().default(""),
   openaiApiKey: z.string().default(""),
-  model: z.string().default("claude-sonnet-4-20250514"),
+  // Bedrock model id (the org default). For the direct Anthropic API use
+  // "claude-sonnet-4-6"; for OpenAI use e.g. "gpt-4o".
+  model: z.string().default("anthropic.claude-sonnet-4-6"),
   temperature: z.coerce.number().min(0).max(2).default(0.1),
   maxTokens: z.coerce.number().int().positive().default(1024),
 });

--- a/templates/rag-pipeline/skeleton/src/providers/anthropic.ts
+++ b/templates/rag-pipeline/skeleton/src/providers/anthropic.ts
@@ -9,6 +9,8 @@ import type { LlmProvider } from "./types.js";
 import { registerLlmProvider } from "./registry.js";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 
+const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
+
 class AnthropicLlm implements LlmProvider {
   private readonly client: Anthropic;
   private readonly cb = createCircuitBreaker();
@@ -20,7 +22,7 @@ class AnthropicLlm implements LlmProvider {
         "ANTHROPIC_API_KEY environment variable is required when using the Anthropic provider",
       );
     }
-    this.client = new Anthropic({ apiKey: key });
+    this.client = new Anthropic({ apiKey: key, timeout: REQUEST_TIMEOUT_MS, maxRetries: 1 });
   }
 
   async generate(

--- a/templates/rag-pipeline/skeleton/src/providers/bedrock.ts
+++ b/templates/rag-pipeline/skeleton/src/providers/bedrock.ts
@@ -1,0 +1,125 @@
+/**
+ * AWS Bedrock providers — the org-default LLM (Converse + prompt caching) and
+ * embedding (Titan Text v2) path. Auth is the AWS credential chain (IRSA
+ * on-cluster), never API keys. Every call carries an AbortSignal timeout so a
+ * hung Bedrock socket trips the circuit breaker instead of hanging, and the
+ * Titan response is schema-validated before use (never trust raw model output).
+ *
+ * Registers itself as the "bedrock" LLM provider and the "bedrock" embedding
+ * provider on import.
+ */
+
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import { z } from "zod";
+import type { LlmProvider, EmbeddingProvider } from "./types.js";
+import { registerLlmProvider, registerEmbeddingProvider } from "./registry.js";
+import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
+
+const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
+
+function newClient(): BedrockRuntimeClient {
+  return new BedrockRuntimeClient({ region: process.env.AWS_REGION ?? "us-west-2" });
+}
+
+class BedrockLlm implements LlmProvider {
+  private readonly client = newClient();
+  private readonly cb = createCircuitBreaker();
+
+  async generate(
+    systemPrompt: string,
+    userMessage: string,
+    model: string,
+    temperature: number,
+    maxTokens: number,
+  ): Promise<{ answer: string; usage: Record<string, number> }> {
+    const response = await this.cb.execute(() =>
+      this.client.send(
+        new ConverseCommand({
+          modelId: model,
+          // cachePoint after the (stable) system prompt — the mandated
+          // prompt-caching pattern; cache tokens are reported in usage.
+          system: [{ text: systemPrompt }, { cachePoint: { type: "default" } }],
+          messages: [{ role: "user", content: [{ text: userMessage }] }],
+          inferenceConfig: { temperature, maxTokens },
+        }),
+        { abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+      ),
+    );
+
+    const blocks = response.output?.message?.content ?? [];
+    const answer = blocks
+      .map((b) => b.text ?? "")
+      .join("\n")
+      .trim();
+    const u = response.usage;
+    const usage: Record<string, number> = {
+      input_tokens: u?.inputTokens ?? 0,
+      output_tokens: u?.outputTokens ?? 0,
+      total_tokens: u?.totalTokens ?? 0,
+      cache_read_tokens: u?.cacheReadInputTokens ?? 0,
+      cache_write_tokens: u?.cacheWriteInputTokens ?? 0,
+    };
+    return { answer, usage };
+  }
+}
+
+const titanResponseSchema = z.object({ embedding: z.array(z.number()) });
+
+class BedrockEmbedder implements EmbeddingProvider {
+  private readonly client = newClient();
+  private readonly cb = createCircuitBreaker();
+  private readonly model: string;
+  private readonly dims: number;
+
+  constructor(model = "amazon.titan-embed-text-v2:0", dims = 1024) {
+    this.model = model;
+    this.dims = dims;
+  }
+
+  get dimensions(): number {
+    return this.dims;
+  }
+
+  private async embedOne(text: string): Promise<number[]> {
+    const response = await this.cb.execute(() =>
+      this.client.send(
+        new InvokeModelCommand({
+          modelId: this.model,
+          contentType: "application/json",
+          accept: "application/json",
+          body: JSON.stringify({ inputText: text, dimensions: this.dims, normalize: true }),
+        }),
+        { abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+      ),
+    );
+    const parsed = titanResponseSchema.parse(
+      JSON.parse(new TextDecoder().decode(response.body)),
+    );
+    return parsed.embedding;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    return this.embedOne(text);
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    // Titan embeds a single input per call; sequential keeps it simple and
+    // within per-account request quota.
+    const out: number[][] = [];
+    for (const t of texts) {
+      out.push(await this.embedOne(t));
+    }
+    return out;
+  }
+}
+
+registerLlmProvider("bedrock", () => new BedrockLlm());
+registerEmbeddingProvider(
+  "bedrock",
+  (model?: unknown, dims?: unknown) =>
+    new BedrockEmbedder(model as string, dims as number),
+);

--- a/templates/rag-pipeline/skeleton/src/providers/index.ts
+++ b/templates/rag-pipeline/skeleton/src/providers/index.ts
@@ -25,7 +25,9 @@ export {
   listVectorStoreProviders,
 } from "./registry.js";
 
-// Import provider modules to trigger registration
+// Import provider modules to trigger registration. Bedrock is the org-default
+// for both LLM and embeddings; the others are alternates.
+import "./bedrock.js";
 import "./anthropic.js";
 import "./openai.js";
 import "./cohere.js";

--- a/templates/rag-pipeline/skeleton/src/providers/openai.ts
+++ b/templates/rag-pipeline/skeleton/src/providers/openai.ts
@@ -10,6 +10,8 @@ import type { LlmProvider, EmbeddingProvider } from "./types.js";
 import { registerLlmProvider, registerEmbeddingProvider } from "./registry.js";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 
+const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
+
 class OpenAILlm implements LlmProvider {
   private readonly client: OpenAI;
   private readonly cb = createCircuitBreaker();
@@ -21,7 +23,7 @@ class OpenAILlm implements LlmProvider {
         "OPENAI_API_KEY environment variable is required when using the OpenAI provider",
       );
     }
-    this.client = new OpenAI({ apiKey: key });
+    this.client = new OpenAI({ apiKey: key, timeout: REQUEST_TIMEOUT_MS, maxRetries: 1 });
   }
 
   async generate(
@@ -70,7 +72,7 @@ class OpenAIEmbedder implements EmbeddingProvider {
         "OPENAI_API_KEY environment variable is required for OpenAI embeddings",
       );
     }
-    this.client = new OpenAI({ apiKey: key });
+    this.client = new OpenAI({ apiKey: key, timeout: REQUEST_TIMEOUT_MS, maxRetries: 1 });
     this.model = model;
     this.dims = dims;
     this.batchSize = batchSize;

--- a/templates/rag-pipeline/skeleton/vitest.config.ts
+++ b/templates/rag-pipeline/skeleton/vitest.config.ts
@@ -3,5 +3,32 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the pure logic (chunking, retrieval). SDK-backed providers, the
+      // generation/ingest IO paths, bootstrap, and CLI entry are exercised by
+      // the integration test / live SDKs, not unit-covered.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/__tests__/**",
+        "src/index.ts",
+        "src/bootstrap.ts",
+        "src/ingest.ts",
+        "src/generation.ts",
+        "src/logger.ts",
+        "src/config.ts",
+        "src/providers/**",
+      ],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        statements: 70,
+        branches: 70,
+      },
+    },
   },
 });

--- a/templates/rag-pipeline/template.yaml
+++ b/templates/rag-pipeline/template.yaml
@@ -8,9 +8,11 @@ description: >
   embedding generation, vector storage, similarity retrieval, and
   LLM-powered answer generation with source citations. No LangChain —
   all components are built from first principles using the provider
-  SDKs directly. Supports multiple vector stores (pgvector, Chroma,
-  Qdrant, Pinecone), embedding providers (OpenAI, Cohere), and LLM
-  providers (Anthropic, OpenAI) for generation.
+  SDKs directly. Defaults to AWS Bedrock (Claude via Converse with prompt
+  caching for generation, Titan v2 for embeddings, on IRSA — no keys).
+  Supports multiple vector stores (pgvector, Chroma, Qdrant, Pinecone),
+  alternate embedding providers (OpenAI, Cohere), and alternate LLM
+  providers (Anthropic, OpenAI).
 version: "0.1.0"
 license: Apache-2.0
 persona: [engineering]
@@ -45,16 +47,16 @@ variables:
   - name: EmbeddingProvider
     type: string
     placeholder: "__EMBEDDING_PROVIDER__"
-    description: "Provider for generating text embeddings (e.g. openai, cohere)"
+    description: "Provider for text embeddings — bedrock (Titan v2, default), openai, or cohere"
     prompt: "Embedding provider"
-    default: "openai"
+    default: "bedrock"
 
   - name: LlmProvider
     type: string
     placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for answer generation (e.g. anthropic, openai)"
+    description: "LLM provider for answer generation — bedrock (default), anthropic, or openai"
     prompt: "LLM provider"
-    default: "anthropic"
+    default: "bedrock"
 
   - name: ChunkStrategy
     type: string
@@ -91,6 +93,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
+    version: ">=24"
     purpose: "Node.js runtime for TypeScript execution"
     optional: false

--- a/templates/slack-bot/skeleton/.dockerignore
+++ b/templates/slack-bot/skeleton/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+coverage
+.git
+.github
+.env
+.env.*
+*.test.ts
+src/**/__tests__
+npm-debug.log*
+.DS_Store

--- a/templates/slack-bot/skeleton/.env.example
+++ b/templates/slack-bot/skeleton/.env.example
@@ -8,16 +8,25 @@ SLACK_APP_TOKEN=xapp-your-app-token
 # Signing secret — required for HTTP mode request verification
 SLACK_SIGNING_SECRET=your-signing-secret
 
-# ── AI Provider ───────────────────────────────────────────────────────
-# At least one provider key is required. The SDKs read these
-# automatically when constructing their clients.
-ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key
-OPENAI_API_KEY=sk-your-openai-api-key
-
-# ── Application ──────────────────────────────────────────────────────
-# LLM provider to use (anthropic or openai)
+# ── LLM (AWS Bedrock — default) ────────────────────────────────────────
+# Bedrock authenticates via the AWS credential chain (IRSA on the cluster,
+# your local AWS profile in dev) — NO API keys. Set the region where the
+# model is enabled.
+AWS_REGION=us-west-2
+LLM_MODEL=anthropic.claude-sonnet-4-6
 LLM_PROVIDER=__LLM_PROVIDER__
 
+# Per-call LLM request timeout in milliseconds
+LLM_REQUEST_TIMEOUT_MS=30000
+
+# Alternate direct-API providers — only needed when LLM_PROVIDER=anthropic|openai.
+# Leave unset for the Bedrock default.
+# ANTHROPIC_API_KEY=sk-ant-...
+# ANTHROPIC_MODEL=claude-sonnet-4-6
+# OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o
+
+# ── Application ──────────────────────────────────────────────────────
 # Port for HTTP mode (ignored in Socket Mode)
 PORT=3000
 

--- a/templates/slack-bot/skeleton/.github/workflows/ci.yml
+++ b/templates/slack-bot/skeleton/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [24]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test (with coverage)
+        run: npm run test:coverage
+
+      - name: Audit (production dependencies)
+        run: npm audit --audit-level=high --omit=dev

--- a/templates/slack-bot/skeleton/Dockerfile
+++ b/templates/slack-bot/skeleton/Dockerfile
@@ -1,0 +1,39 @@
+# ── Build Stage ───────────────────────────────────────────────────────
+
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN npm run build
+
+# ── Production Stage ──────────────────────────────────────────────────
+
+FROM node:24-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# OTel auto-instrumentation — traces http/fetch/aws-sdk and wires a MeterProvider
+# before user code, exporting to the cluster collector. Requires
+# @opentelemetry/auto-instrumentations-node in production deps.
+ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
+ENV OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector.observability.svc.cluster.local:4318"
+ENV OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+USER node
+
+CMD ["node", "dist/index.js"]

--- a/templates/slack-bot/skeleton/package.json
+++ b/templates/slack-bot/skeleton/package.json
@@ -9,29 +9,36 @@
     "dev": "tsx --watch src/index.ts",
     "start": "node dist/index.js",
     "lint": "eslint src/",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "audit:prod": "npm audit --audit-level=high --omit=dev"
   },
   "dependencies": {
-    "@slack/bolt": "^4.1.0",
-    "@anthropic-ai/sdk": "^0.82.0",
-    "openai": "^4.85.0",
-    "zod": "^3.24.0",
-    "dotenv": "^16.4.0"
+    "@slack/bolt": "^4.7.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+    "@anthropic-ai/sdk": "^0.89.0",
+    "openai": "^6.34.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "^0.76.0",
+    "zod": "^4.3.6",
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@types/node": "^22.0.0",
-    "eslint": "^9.20.0",
-    "prettier": "^3.5.0",
-    "tsx": "^4.19.0",
-    "typescript": "^5.8.0",
-    "typescript-eslint": "^8.25.0",
-    "vitest": "^3.1.0"
+    "@eslint/js": "^10.0.1",
+    "@types/node": "^24.12.2",
+    "eslint": "^10.2.0",
+    "prettier": "^3.8.2",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.58.2",
+    "vitest": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.4"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/templates/slack-bot/skeleton/src/__tests__/message.test.ts
+++ b/templates/slack-bot/skeleton/src/__tests__/message.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { registerProvider, getProvider } from "../providers/registry.js";
 import type { LlmProvider, ChatMessage } from "../providers/types.js";
 
@@ -11,10 +11,10 @@ import type { LlmProvider, ChatMessage } from "../providers/types.js";
  */
 
 describe("provider registry", () => {
-  let mockChat: ReturnType<typeof vi.fn>;
+  let mockChat: Mock<LlmProvider["chat"]>;
 
   beforeEach(() => {
-    mockChat = vi.fn();
+    mockChat = vi.fn<LlmProvider["chat"]>();
 
     const mockProvider: LlmProvider = {
       chat: mockChat,

--- a/templates/slack-bot/skeleton/src/config.ts
+++ b/templates/slack-bot/skeleton/src/config.ts
@@ -24,6 +24,24 @@ const configSchema = z.object({
     .string()
     .default("__LLM_PROVIDER__"),
 
+  // Bedrock model id (Converse). Injectable so the model isn't hardcoded.
+  LLM_MODEL: z
+    .string()
+    .default("anthropic.claude-sonnet-4-6"),
+
+  // Region where the Bedrock model is enabled. Bedrock auth is the AWS
+  // credential chain (IRSA on-cluster) — no API keys.
+  AWS_REGION: z
+    .string()
+    .default("us-west-2"),
+
+  // Per-call LLM request timeout (ms) — a hung upstream trips the breaker.
+  LLM_REQUEST_TIMEOUT_MS: z
+    .string()
+    .default("30000")
+    .transform(Number)
+    .pipe(z.number().int().positive()),
+
   PORT: z
     .string()
     .default("3000")

--- a/templates/slack-bot/skeleton/src/metrics.ts
+++ b/templates/slack-bot/skeleton/src/metrics.ts
@@ -1,0 +1,51 @@
+import { metrics } from "@opentelemetry/api";
+
+// ── Application Metrics ────────────────────────────────────────────
+//
+// RED-style counters plus Bedrock token accounting via the OTel metrics API.
+// No-ops unless an OTel SDK is registered — the Dockerfile loads
+// @opentelemetry/auto-instrumentations-node via NODE_OPTIONS, which wires a
+// MeterProvider exporting to the cluster collector. The meter name matches the
+// project so dashboards can filter by service.
+
+const meter = metrics.getMeter("__PROJECT_NAME__");
+
+/** Total LLM chat requests, labeled by provider + model. */
+export const llmRequestsTotal = meter.createCounter("llm_requests_total", {
+  description: "Total LLM chat requests",
+});
+
+/** LLM chat requests that threw, labeled by provider + model. */
+export const llmErrorsTotal = meter.createCounter("llm_errors_total", {
+  description: "Total LLM chat requests that errored",
+});
+
+/** LLM call latency in milliseconds. */
+export const llmDuration = meter.createHistogram("llm_request_duration_ms", {
+  description: "LLM chat latency in milliseconds",
+  unit: "ms",
+});
+
+/** Token usage by kind (input/output/cache_read/cache_write). Cost is derived
+ *  downstream from these counts; cache_read/cache_write surface the prompt-cache
+ *  hit ratio the LLM policy requires. */
+export const llmTokensTotal = meter.createCounter("llm_tokens_total", {
+  description: "LLM token usage by kind",
+});
+
+export interface TokenUsage {
+  provider: string;
+  model: string;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+export function recordLlmTokens(u: TokenUsage): void {
+  const base = { provider: u.provider, model: u.model };
+  llmTokensTotal.add(u.input, { ...base, kind: "input" });
+  llmTokensTotal.add(u.output, { ...base, kind: "output" });
+  llmTokensTotal.add(u.cacheRead, { ...base, kind: "cache_read" });
+  llmTokensTotal.add(u.cacheWrite, { ...base, kind: "cache_write" });
+}

--- a/templates/slack-bot/skeleton/src/providers/anthropic.ts
+++ b/templates/slack-bot/skeleton/src/providers/anthropic.ts
@@ -3,14 +3,22 @@ import type { LlmProvider, ChatMessage } from "./types.js";
 import { registerProvider } from "./registry.js";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 
-const client = new Anthropic();
+// Direct Anthropic API — an alternate to the Bedrock default
+// (set LLM_PROVIDER=anthropic). Requires ANTHROPIC_API_KEY. The SDK client is
+// given an explicit per-request timeout so a hung socket trips the breaker
+// instead of hanging; the model id is injectable via ANTHROPIC_MODEL.
+
+const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
+const MODEL = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-6";
+
+const client = new Anthropic({ timeout: REQUEST_TIMEOUT_MS, maxRetries: 1 });
 const cb = createCircuitBreaker();
 
 class AnthropicProvider implements LlmProvider {
   async chat(systemPrompt: string, messages: ChatMessage[]): Promise<string> {
     const response = await cb.execute(() =>
       client.messages.create({
-        model: "claude-sonnet-4-20250514",
+        model: MODEL,
         max_tokens: 2048,
         system: systemPrompt,
         messages: messages.map((m) => ({

--- a/templates/slack-bot/skeleton/src/providers/bedrock.ts
+++ b/templates/slack-bot/skeleton/src/providers/bedrock.ts
@@ -1,0 +1,73 @@
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import type { LlmProvider, ChatMessage } from "./types.js";
+import { registerProvider } from "./registry.js";
+import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
+import { llmRequestsTotal, llmErrorsTotal, llmDuration, recordLlmTokens } from "../metrics.js";
+
+// Bedrock via the Converse API — the org-default LLM path. Auth is the AWS
+// credential chain (IRSA on the cluster), never API keys. A cachePoint after
+// the system prompt amortizes the (large, stable) prefix across turns — the
+// mandated prompt-caching pattern; cache_read/cache_write tokens are metered so
+// the hit ratio is observable. Every call has an explicit request timeout, so a
+// hung Bedrock socket trips the circuit breaker instead of hanging forever.
+
+const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
+const MODEL = process.env.LLM_MODEL ?? "anthropic.claude-sonnet-4-6";
+
+class BedrockProvider implements LlmProvider {
+  private readonly client = new BedrockRuntimeClient({
+    region: process.env.AWS_REGION ?? "us-west-2",
+  });
+  private readonly cb = createCircuitBreaker();
+
+  async chat(systemPrompt: string, messages: ChatMessage[]): Promise<string> {
+    const start = performance.now();
+    const labels = { provider: "bedrock", model: MODEL };
+    llmRequestsTotal.add(1, labels);
+    try {
+      const response = await this.cb.execute(() =>
+        this.client.send(
+          new ConverseCommand({
+            modelId: MODEL,
+            system: [{ text: systemPrompt }, { cachePoint: { type: "default" } }],
+            messages: messages.map((m) => ({
+              role: m.role,
+              content: [{ text: m.content }],
+            })),
+            inferenceConfig: { maxTokens: 2048 },
+          }),
+          // Per-request timeout — a hung Bedrock socket trips the breaker
+          // instead of hanging forever.
+          { abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+        ),
+      );
+
+      const usage = response.usage;
+      if (usage) {
+        recordLlmTokens({
+          ...labels,
+          input: usage.inputTokens ?? 0,
+          output: usage.outputTokens ?? 0,
+          cacheRead: usage.cacheReadInputTokens ?? 0,
+          cacheWrite: usage.cacheWriteInputTokens ?? 0,
+        });
+      }
+
+      const blocks = response.output?.message?.content ?? [];
+      return blocks
+        .map((b) => b.text ?? "")
+        .join("\n")
+        .trim();
+    } catch (err) {
+      llmErrorsTotal.add(1, labels);
+      throw err;
+    } finally {
+      llmDuration.record(performance.now() - start, labels);
+    }
+  }
+}
+
+registerProvider("bedrock", () => new BedrockProvider());

--- a/templates/slack-bot/skeleton/src/providers/index.ts
+++ b/templates/slack-bot/skeleton/src/providers/index.ts
@@ -7,7 +7,9 @@
  * environment variable (set via the __LLM_PROVIDER__ placeholder).
  */
 
-// Side-effect imports: each module calls registerProvider() at load time
+// Side-effect imports: each module calls registerProvider() at load time.
+// Bedrock is the org-default LLM path; anthropic/openai are alternates.
+import "./bedrock.js";
 import "./anthropic.js";
 import "./openai.js";
 import "./mock.js";

--- a/templates/slack-bot/skeleton/src/providers/openai.ts
+++ b/templates/slack-bot/skeleton/src/providers/openai.ts
@@ -3,14 +3,21 @@ import type { LlmProvider, ChatMessage } from "./types.js";
 import { registerProvider } from "./registry.js";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 
-const client = new OpenAI();
+// Direct OpenAI API — an alternate to the Bedrock default
+// (set LLM_PROVIDER=openai). Requires OPENAI_API_KEY. Explicit per-request
+// timeout so a hung socket trips the breaker; model id injectable via OPENAI_MODEL.
+
+const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
+const MODEL = process.env.OPENAI_MODEL ?? "gpt-4o";
+
+const client = new OpenAI({ timeout: REQUEST_TIMEOUT_MS, maxRetries: 1 });
 const cb = createCircuitBreaker();
 
 class OpenAIProvider implements LlmProvider {
   async chat(systemPrompt: string, messages: ChatMessage[]): Promise<string> {
     const response = await cb.execute(() =>
       client.chat.completions.create({
-        model: "gpt-4o",
+        model: MODEL,
         max_tokens: 2048,
         messages: [
           { role: "system", content: systemPrompt },

--- a/templates/slack-bot/skeleton/vitest.config.ts
+++ b/templates/slack-bot/skeleton/vitest.config.ts
@@ -5,5 +5,35 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the pure logic (provider registry, circuit breaker). The SDK
+      // adapters (providers/bedrock|anthropic|openai|mock), Bolt handlers
+      // (events, commands), metrics, logger, and bootstrap are exercised by
+      // live SDKs / integration, not unit-covered.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/index.ts",
+        "src/bootstrap.ts",
+        "src/logger.ts",
+        "src/metrics.ts",
+        "src/config.ts",
+        "src/providers/bedrock.ts",
+        "src/providers/anthropic.ts",
+        "src/providers/openai.ts",
+        "src/providers/mock.ts",
+        "src/events/**",
+        "src/commands/**",
+      ],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        statements: 70,
+        branches: 70,
+      },
+    },
   },
 });

--- a/templates/slack-bot/template.yaml
+++ b/templates/slack-bot/template.yaml
@@ -6,8 +6,9 @@ description: >
   Scaffolds a TypeScript Slack bot using @slack/bolt with Socket Mode for
   local development and HTTP for production. Includes AI-powered message
   and app-mention handlers, an optional /ask slash command, a pluggable
-  LLM provider registry (Anthropic and OpenAI), and thread-aware
-  conversation context for multi-turn AI responses.
+  LLM provider registry (AWS Bedrock by default — Converse with prompt
+  caching, on IRSA, no keys — plus Anthropic and OpenAI alternates), and
+  thread-aware conversation context for multi-turn AI responses.
 version: "0.1.0"
 license: Apache-2.0
 persona: [engineering]
@@ -35,9 +36,9 @@ variables:
   - name: LlmProvider
     type: string
     placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider to use for AI responses"
+    description: "Default LLM provider — bedrock (AWS Bedrock, IRSA, prompt-cached), anthropic, or openai"
     prompt: "LLM provider"
-    default: "anthropic"
+    default: "bedrock"
 
   - name: IncludeSlashCommands
     type: bool
@@ -72,6 +73,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
+    version: ">=24"
     purpose: "Node.js runtime for the Slack bot"
     optional: false

--- a/templates/ts-service/skeleton/.dockerignore
+++ b/templates/ts-service/skeleton/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+dist
+coverage
+.git
+.github
+.env
+.env.*
+*.test.ts
+src/__tests__
+load-test
+docker-compose.yml
+Dockerfile
+.dockerignore
+npm-debug.log*
+.DS_Store

--- a/templates/ts-service/skeleton/.github/workflows/ci.yml
+++ b/templates/ts-service/skeleton/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [24]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,14 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm test
+      - name: Test (with coverage)
+        run: npm run test:coverage
+
+      - name: Audit (production dependencies)
+        run: npm audit --audit-level=high --omit=dev

--- a/templates/ts-service/skeleton/Dockerfile
+++ b/templates/ts-service/skeleton/Dockerfile
@@ -1,6 +1,6 @@
 # ── Build Stage ───────────────────────────────────────────────────────
 
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN npm run build
 
 # ── Production Stage ──────────────────────────────────────────────────
 
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 
 WORKDIR /app
 

--- a/templates/ts-service/skeleton/package.json
+++ b/templates/ts-service/skeleton/package.json
@@ -12,7 +12,10 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "audit:prod": "npm audit --audit-level=high --omit=dev"
   },
   "dependencies": {
     "hono": "^4.12.0",
@@ -33,9 +36,10 @@
     "tsx": "^4.21.0",
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.59.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/templates/ts-service/skeleton/src/__tests__/integration.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { json } from "./helpers.js";
 import { app } from "../app.js";
+import { markReady, setReadinessProbe } from "../routes/readiness.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -119,20 +120,27 @@ describe("GET /health", () => {
 });
 
 describe("GET /readyz", () => {
-  it("returns 503 when not marked ready", async () => {
-    // In test context, markReady() is not called — service starts not ready
+  // These run in order: the service starts not-ready (markReady() has not been
+  // called in test context), so each case sets the state it asserts on.
+  it("returns 503 before the service is marked ready", async () => {
     const res = await app.request("/readyz");
+    expect(res.status).toBe(503);
+    expect(await json(res)).toHaveProperty("status", "not_ready");
+  });
 
-    // Default state is not ready (503) unless markReady was called
-    // by another test or the bootstrap. Both 200 and 503 are valid
-    // depending on test ordering, but we verify the response shape.
-    const body = await json(res);
+  it("returns 503 when the dependency probe fails", async () => {
+    markReady();
+    setReadinessProbe(() => false);
+    const res = await app.request("/readyz");
+    expect(res.status).toBe(503);
+    expect(await json(res)).toHaveProperty("status", "not_ready");
+  });
 
-    if (res.status === 503) {
-      expect(body).toHaveProperty("status", "not_ready");
-    } else {
-      expect(res.status).toBe(200);
-      expect(body).toHaveProperty("status", "ready");
-    }
+  it("returns 200 once started and the dependency probe passes", async () => {
+    markReady();
+    setReadinessProbe(() => true);
+    const res = await app.request("/readyz");
+    expect(res.status).toBe(200);
+    expect(await json(res)).toHaveProperty("status", "ready");
   });
 });

--- a/templates/ts-service/skeleton/src/__tests__/mask.test.ts
+++ b/templates/ts-service/skeleton/src/__tests__/mask.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { maskSensitive, maskHeaders } from "../middleware/mask.js";
+
+describe("maskSensitive", () => {
+  it("masks bearer tokens but keeps the scheme", () => {
+    expect(maskSensitive("Authorization: Bearer abc.def.ghi")).toBe(
+      "Authorization: Bearer ***",
+    );
+  });
+
+  it("masks passwords embedded in connection URLs", () => {
+    expect(maskSensitive("postgres://user:s3cret@db:5432/app")).toBe(
+      "postgres://***@db:5432/app",
+    );
+  });
+
+  it("masks API-key-shaped substrings", () => {
+    expect(maskSensitive("key=sk-livetoken123")).toBe("key=***");
+    expect(maskSensitive("ghp_abc123 and xoxb-9-9")).toBe("*** and ***");
+  });
+
+  it("leaves benign strings untouched", () => {
+    expect(maskSensitive("just a normal log line")).toBe("just a normal log line");
+  });
+});
+
+describe("maskHeaders", () => {
+  it("masks known sensitive headers", () => {
+    const out = maskHeaders({
+      authorization: "Bearer xyz",
+      cookie: "sid=1",
+      "x-api-key": "k",
+    });
+    expect(out.authorization).toBe("Bearer ***");
+    expect(out.cookie).toBe("***");
+    expect(out["x-api-key"]).toBe("***");
+  });
+
+  it("masks headers whose name contains a sensitive substring", () => {
+    const out = maskHeaders({ "x-session-token": "t", "my-secret-thing": "s" });
+    expect(out["x-session-token"]).toBe("***");
+    expect(out["my-secret-thing"]).toBe("***");
+  });
+
+  it("preserves the Bearer scheme hint on sensitive non-auth headers", () => {
+    expect(maskHeaders({ "x-proxy-token": "Bearer abc" })["x-proxy-token"]).toBe(
+      "Bearer ***",
+    );
+  });
+
+  it("passes non-sensitive headers through unchanged", () => {
+    const out = maskHeaders({ "content-type": "application/json", accept: "*/*" });
+    expect(out["content-type"]).toBe("application/json");
+    expect(out.accept).toBe("*/*");
+  });
+});

--- a/templates/ts-service/skeleton/src/metrics.ts
+++ b/templates/ts-service/skeleton/src/metrics.ts
@@ -20,3 +20,8 @@ export const httpRequestDuration = meter.createHistogram("http_request_duration_
   description: "HTTP request latency in milliseconds",
   unit: "ms",
 });
+
+/** Total HTTP responses with a server-error (5xx) status — the "errors" of RED. */
+export const httpErrorsTotal = meter.createCounter("http_errors_total", {
+  description: "Total number of HTTP responses with a 5xx status",
+});

--- a/templates/ts-service/skeleton/src/middleware/metrics.ts
+++ b/templates/ts-service/skeleton/src/middleware/metrics.ts
@@ -1,5 +1,5 @@
 import type { Context, Next } from "hono";
-import { httpRequestTotal, httpRequestDuration } from "../metrics.js";
+import { httpRequestTotal, httpRequestDuration, httpErrorsTotal } from "../metrics.js";
 
 // ── Metrics Middleware ─────────────────────────────────────────────
 //
@@ -23,4 +23,7 @@ export async function metricsMiddleware(c: Context, next: Next): Promise<void> {
 
   httpRequestTotal.add(1, labels);
   httpRequestDuration.record(durationMs, labels);
+  if (c.res.status >= 500) {
+    httpErrorsTotal.add(1, labels);
+  }
 }

--- a/templates/ts-service/skeleton/src/routes/readiness.ts
+++ b/templates/ts-service/skeleton/src/routes/readiness.ts
@@ -4,19 +4,38 @@ export const readinessRoutes = new Hono();
 
 // ── GET /readyz ─────────────────────────────────────────────────────
 //
-// Readiness probe — returns 200 when the service is ready to accept
-// traffic, 503 otherwise. Kubernetes uses this to decide whether to
-// route requests to this pod during rolling updates.
+// Readiness probe — returns 200 only once the service has started AND the
+// registered dependency probe passes; 503 otherwise. Kubernetes uses this to
+// decide whether to route traffic to the pod. Distinct from /health (liveness),
+// which only proves the process is up.
 //
+// `markReady()` flips the started flag after bootstrap wiring completes.
+// `setReadinessProbe()` wires a real dependency check (DB ping, cache reachable,
+// upstream healthy). The default probe is always-ready, suitable for a stateless
+// service; a probe that returns false or throws yields 503.
 
-let ready = false;
+export type ReadinessProbe = () => boolean | Promise<boolean>;
+
+let started = false;
+let probe: ReadinessProbe = () => true;
 
 export function markReady(): void {
-  ready = true;
+  started = true;
 }
 
-readinessRoutes.get("/readyz", (c) => {
-  if (!ready) {
+export function setReadinessProbe(fn: ReadinessProbe): void {
+  probe = fn;
+}
+
+readinessRoutes.get("/readyz", async (c) => {
+  if (!started) {
+    return c.json({ status: "not_ready" }, 503);
+  }
+  try {
+    if (!(await probe())) {
+      return c.json({ status: "not_ready" }, 503);
+    }
+  } catch {
     return c.json({ status: "not_ready" }, 503);
   }
   return c.json({ status: "ready" });

--- a/templates/ts-service/skeleton/vitest.config.ts
+++ b/templates/ts-service/skeleton/vitest.config.ts
@@ -5,5 +5,35 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the reusable scaffolding (middleware, domain, health/readiness,
+      // metrics). Excluded: wiring/bootstrap (index, bootstrap, app, config,
+      // telemetry), generated/openapi surfaces, type decls, and the `example.*`
+      // demo handlers a consumer replaces.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/__tests__/**",
+        "src/index.ts",
+        "src/bootstrap.ts",
+        "src/app.ts",
+        "src/config.ts",
+        "src/telemetry/**",
+        "src/openapi.ts",
+        "src/routes/openapi.ts",
+        "src/routes/example.ts",
+        "src/services/example.ts",
+        "src/schemas/example.ts",
+        "src/types/**",
+      ],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        statements: 70,
+        branches: 70,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Why

Phase 3 of the template quality uplift: the four application templates the org's tenant repos are built from. Each is brought to the LLM-policy + systems + security bar, with the CI/coverage/audit lineage `ts-service` establishes.

## What changed (per template)

- **ts-service** (reference lineage): `typecheck` + failing `npm audit` + `@vitest/coverage-v8` 70% gate; dependency-aware `/readyz`; `http_errors_total`; Node 24; `.dockerignore`.
- **slack-bot**: Bedrock-default LLM (Converse + cachePoint prompt caching, IRSA), timeouts on every LLM call, OTel token/RED metrics, injectable model, dropped baked keys, added the missing Dockerfile/CI/.dockerignore.
- **rag-pipeline**: Bedrock-default LLM **and** Titan-v2 embeddings (zod-validated output), timeouts across providers, Dockerfile/CI, dropped baked keys. (openai/chromadb/zod held at a mutually-compatible set — chromadb 1.x peers openai ^4 peers zod ^3; chromadb 3.x is a follow-up.)
- **data-pipeline**: SSRF url-guard on web ingest (closes the server-side request forgery hole), Bedrock-default Titan embeddings, `pipeline_errors_total{stage}`, Dockerfile/CI.

Shared: Node 24 / vitest 4 / eslint 10 / TypeScript 6, coverage gates over the unit-tested surface, eslint honoring the `_`-prefix convention.

## Verification

Each template rendered and run through the full gate on Node 24 — `npm install` → typecheck → lint → build → `test:coverage` (70% thresholds) all green. (ts-service ~89%, rag ~88%, data-pipeline ~86% on the gated surface.)