### PR TITLE
Module templates — fix high-severity LLM/cache bugs

### DIFF
--- a/templates/module-llm-gateway/skeleton/README.md
+++ b/templates/module-llm-gateway/skeleton/README.md
@@ -34,7 +34,7 @@ console.log(cached.cached);       // true
 // Query costs
 const costs = gateway.getCosts({ tags: { user: "alice" } });
 console.log(costs.totalCost);     // 0.000135
-console.log(costs.byModel);       // { "claude-sonnet-4-20250514": 0.000135 }
+console.log(costs.byModel);       // { "claude-sonnet-4-6": 0.000135 }
 
 // Shut down
 gateway.close();
@@ -44,7 +44,7 @@ gateway.close();
 
 | Provider | Backend | Default Model | Pricing (input/output per 1M) |
 |----------|---------|---------------|-------------------------------|
-| `anthropic` | Claude Sonnet | `claude-sonnet-4-20250514` | $3 / $15 |
+| `anthropic` | Claude Sonnet | `claude-sonnet-4-6` | $3 / $15 |
 | `openai` | GPT-4o | `gpt-4o` | $2.50 / $10 |
 | `groq` | Llama 3 70B | `llama-3.3-70b-versatile` | $0.59 / $0.79 |
 | `mock` | In-memory | `mock-model` | $0 / $0 |

--- a/templates/module-llm-gateway/skeleton/src/gateway/__tests__/cost.test.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/__tests__/cost.test.ts
@@ -21,7 +21,7 @@ describe("pricing", () => {
   });
 
   it("looks up pricing for known models", () => {
-    const pricing = getModelPricing("claude-sonnet-4-20250514");
+    const pricing = getModelPricing("claude-sonnet-4-6");
     expect(pricing.input).toBe(3);
     expect(pricing.output).toBe(15);
   });
@@ -48,7 +48,7 @@ describe("cost tracker", () => {
   it("records and queries cost entries", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
       user: "alice",
       project: "alpha",
     });
@@ -56,7 +56,7 @@ describe("cost tracker", () => {
       user: "bob",
       project: "alpha",
     });
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.02), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.02), {
       user: "alice",
       project: "beta",
     });
@@ -69,7 +69,7 @@ describe("cost tracker", () => {
   it("filters by provider", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.01));
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01));
     tracker.record(makeResponse("openai", "gpt-4o", 0.005));
 
     const summary = tracker.query({ provider: "anthropic" });
@@ -80,10 +80,10 @@ describe("cost tracker", () => {
   it("breaks down cost by user", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
       user: "alice",
     });
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.02), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.02), {
       user: "alice",
     });
     tracker.record(makeResponse("openai", "gpt-4o", 0.005), { user: "bob" });
@@ -96,7 +96,7 @@ describe("cost tracker", () => {
   it("breaks down cost by project", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
       project: "alpha",
     });
     tracker.record(makeResponse("openai", "gpt-4o", 0.02), { project: "beta" });
@@ -109,19 +109,19 @@ describe("cost tracker", () => {
   it("breaks down cost by model", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.01));
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.02));
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01));
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.02));
     tracker.record(makeResponse("openai", "gpt-4o", 0.005));
 
     const summary = tracker.query();
-    expect(summary.byModel["claude-sonnet-4-20250514"]).toBeCloseTo(0.03, 6);
+    expect(summary.byModel["claude-sonnet-4-6"]).toBeCloseTo(0.03, 6);
     expect(summary.byModel["gpt-4o"]).toBeCloseTo(0.005, 6);
   });
 
   it("filters by tags", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-20250514", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
       user: "alice",
       project: "alpha",
     });
@@ -146,7 +146,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01 + Math.random() * 0.001,
@@ -159,7 +159,7 @@ describe("anomaly detection", () => {
     entries.push({
       timestamp: new Date(baseTimestamp.getTime() + 25000).toISOString(),
       provider: "anthropic",
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       inputTokens: 10000,
       outputTokens: 5000,
       cost: 0.5,
@@ -187,7 +187,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,
@@ -205,7 +205,7 @@ describe("anomaly detection", () => {
       {
         timestamp: new Date().toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,

--- a/templates/module-llm-gateway/skeleton/src/gateway/cost/pricing.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/cost/pricing.ts
@@ -14,7 +14,7 @@ export interface ModelPricing {
 
 export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   // Anthropic
-  "claude-sonnet-4-20250514": { input: 3, output: 15 },
+  "claude-sonnet-4-6": { input: 3, output: 15 },
   "claude-haiku-4-20250514": { input: 0.8, output: 4 },
   "claude-opus-4-20250514": { input: 15, output: 75 },
 

--- a/templates/module-llm-gateway/skeleton/src/gateway/providers/anthropic.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/providers/anthropic.ts
@@ -12,7 +12,7 @@ import { countTokens } from "../tokens/counter.js";
 // responses into the unified GatewayResponse shape.
 //
 
-const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 let client: Anthropic | null = null;
 function getClient(): Anthropic {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
@@ -12,7 +12,7 @@ function makeSpan(overrides: Partial<LlmSpan> = {}): LlmSpan {
     startedAt: new Date().toISOString(),
     endedAt: new Date().toISOString(),
     durationMs: 200,
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-4-6",
     provider: "anthropic",
     inputTokens: 1000,
     outputTokens: 500,
@@ -37,7 +37,7 @@ describe("pricing", () => {
   });
 
   it("looks up pricing for known models", () => {
-    const pricing = getModelPricing("claude-sonnet-4-20250514");
+    const pricing = getModelPricing("claude-sonnet-4-6");
     expect(pricing.input).toBe(3);
     expect(pricing.output).toBe(15);
   });
@@ -55,14 +55,14 @@ describe("cost calculator", () => {
 
     const entry = calculator.record(makeSpan());
     expect(entry.cost).toBeGreaterThan(0);
-    expect(entry.model).toBe("claude-sonnet-4-20250514");
+    expect(entry.model).toBe("claude-sonnet-4-6");
     expect(entry.provider).toBe("anthropic");
   });
 
   it("queries with no filters returns all entries", () => {
     const calculator = createCostCalculator();
 
-    calculator.record(makeSpan({ model: "claude-sonnet-4-20250514", inputTokens: 100, outputTokens: 50 }));
+    calculator.record(makeSpan({ model: "claude-sonnet-4-6", inputTokens: 100, outputTokens: 50 }));
     calculator.record(makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 200, outputTokens: 100 }));
 
     const summary = calculator.query();
@@ -83,7 +83,7 @@ describe("cost calculator", () => {
   it("filters by model", () => {
     const calculator = createCostCalculator();
 
-    calculator.record(makeSpan({ model: "claude-sonnet-4-20250514" }));
+    calculator.record(makeSpan({ model: "claude-sonnet-4-6" }));
     calculator.record(makeSpan({ model: "gpt-4o", provider: "openai" }));
 
     const summary = calculator.query({ model: "gpt-4o" });
@@ -93,11 +93,11 @@ describe("cost calculator", () => {
   it("breaks down cost by model", () => {
     const calculator = createCostCalculator();
 
-    calculator.record(makeSpan({ model: "claude-sonnet-4-20250514", inputTokens: 1000, outputTokens: 500 }));
+    calculator.record(makeSpan({ model: "claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500 }));
     calculator.record(makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 1000, outputTokens: 500 }));
 
     const summary = calculator.query();
-    expect(summary.byModel["claude-sonnet-4-20250514"]).toBeGreaterThan(0);
+    expect(summary.byModel["claude-sonnet-4-6"]).toBeGreaterThan(0);
     expect(summary.byModel["gpt-4o"]).toBeGreaterThan(0);
   });
 
@@ -145,7 +145,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01 + Math.random() * 0.001,
@@ -158,7 +158,7 @@ describe("anomaly detection", () => {
     entries.push({
       timestamp: new Date(baseTimestamp.getTime() + 25000).toISOString(),
       provider: "anthropic",
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       inputTokens: 10000,
       outputTokens: 5000,
       cost: 0.5,
@@ -186,7 +186,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,
@@ -204,7 +204,7 @@ describe("anomaly detection", () => {
       {
         timestamp: new Date().toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createLlmTracer } from "../tracer/index.js";
+import { createLlmTracer, TracedError } from "../tracer/index.js";
 import type { LlmResponse } from "../types.js";
 
 // ── LLM Tracer Tests ───────────────────────────────────────────────
@@ -7,7 +7,7 @@ import type { LlmResponse } from "../types.js";
 function makeResponse(overrides: Partial<LlmResponse> = {}): LlmResponse {
   return {
     text: "Hello, world!",
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-4-6",
     provider: "anthropic",
     inputTokens: 100,
     outputTokens: 50,
@@ -24,7 +24,7 @@ describe("LLM tracer", () => {
     );
 
     expect(response.text).toBe("Hello, world!");
-    expect(span.model).toBe("claude-sonnet-4-20250514");
+    expect(span.model).toBe("claude-sonnet-4-6");
     expect(span.provider).toBe("anthropic");
     expect(span.inputTokens).toBe(100);
     expect(span.outputTokens).toBe(50);
@@ -48,18 +48,25 @@ describe("LLM tracer", () => {
     expect(span.durationMs).toBeLessThan(200);
   });
 
-  it("captures errors without throwing", async () => {
+  it("throws a TracedError carrying the error span — never a fake response", async () => {
     const tracer = createLlmTracer({ serviceName: "test-service" });
 
-    const { response, span } = await tracer.trace(async () => {
-      throw new Error("LLM provider timeout");
-    });
+    let caught: unknown;
+    try {
+      await tracer.trace(async () => {
+        throw new Error("LLM provider timeout");
+      });
+    } catch (err) {
+      caught = err;
+    }
 
-    expect(span.success).toBe(false);
-    expect(span.error).toBe("LLM provider timeout");
-    expect(span.model).toBe("unknown");
-    expect(span.provider).toBe("unknown");
-    expect(response.text).toBe("");
+    expect(caught).toBeInstanceOf(TracedError);
+    const traced = caught as TracedError;
+    // The error span is still captured (the observer exports it), but the
+    // original failure propagates rather than becoming an empty "success".
+    expect(traced.span.success).toBe(false);
+    expect(traced.span.error).toBe("LLM provider timeout");
+    expect(traced.cause).toBeInstanceOf(Error);
   });
 
   it("merges default tags with per-call tags", async () => {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/cost/pricing.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/cost/pricing.ts
@@ -14,7 +14,7 @@ export interface ModelPricing {
 
 export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   // Anthropic
-  "claude-sonnet-4-20250514": { input: 3, output: 15 },
+  "claude-sonnet-4-6": { input: 3, output: 15 },
   "claude-haiku-4-20250514": { input: 0.8, output: 4 },
   "claude-opus-4-20250514": { input: 15, output: 75 },
 

--- a/templates/module-llm-observability/skeleton/src/llm-observability/cost/types.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/cost/types.ts
@@ -1,7 +1,10 @@
 // ── Cost Types ─────────────────────────────────────────────────────
 
-// Re-export CostEntry from the shared types for convenience
-export type { CostEntry } from "../types.js";
+// Import for local use below, and re-export from the shared types for convenience.
+// (A bare `export ... from` re-export does not create a local binding, so
+// CostEntry must be imported to be referenced in this file.)
+import type { CostEntry } from "../types.js";
+export type { CostEntry };
 
 /** Filters for querying cost entries. */
 export interface CostFilters {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/index.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/index.ts
@@ -10,7 +10,7 @@
 import { validateBootstrap } from "./bootstrap.js";
 import { logger } from "./logger.js";
 import { createLlmMetrics } from "./metrics.js";
-import { createLlmTracer } from "./tracer/index.js";
+import { createLlmTracer, TracedError } from "./tracer/index.js";
 import { createQualityMonitor } from "./quality/monitor.js";
 import { getExporter } from "./exporters/index.js";
 import { ObserverConfigSchema } from "./types.js";
@@ -92,7 +92,26 @@ export function createLlmObserver(config: ObserverConfig): LlmObserver {
     fn: () => Promise<LlmResponse>,
     tags: Record<string, string> = {},
   ): Promise<LlmResponse> {
-    const { response, span } = await tracer.trace(fn, tags);
+    let response: LlmResponse;
+    let span: LlmSpan;
+    try {
+      ({ response, span } = await tracer.trace(fn, tags));
+    } catch (err) {
+      // The call failed. Still export the error span + record the failed trace
+      // for observability, then propagate the real error — never return a
+      // fabricated empty response.
+      if (err instanceof TracedError) {
+        exporter.exportSpan(err.span);
+        llmMetrics.recordTrace(
+          err.span.model,
+          err.span.provider,
+          err.span.durationMs,
+          false,
+        );
+        throw err.cause;
+      }
+      throw err;
+    }
 
     // Calculate and attach cost if enabled
     if (costEnabled && calculateCostFn && span.success) {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/logger.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/logger.ts
@@ -59,7 +59,7 @@ function emit(level: LogLevel, message: string, fields?: Record<string, unknown>
  * Structured logger that propagates OpenTelemetry trace context.
  *
  * Usage:
- *   logger.info("span captured", { model: "claude-sonnet-4-20250514", durationMs: 340 });
+ *   logger.info("span captured", { model: "claude-sonnet-4-6", durationMs: 340 });
  */
 export const logger = {
   debug: (message: string, fields?: Record<string, unknown>) =>

--- a/templates/module-llm-observability/skeleton/src/llm-observability/tracer/index.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/tracer/index.ts
@@ -13,6 +13,22 @@ import type { TracerOptions } from "./types.js";
 export type { TracerOptions, SpanContext } from "./types.js";
 
 /**
+ * Thrown by the tracer when the wrapped LLM call fails. Carries the captured
+ * error span (so the observer can still export it and record metrics) and the
+ * original error as `cause`. The tracer never swallows a failure into a fake
+ * success response — callers always see the real error.
+ */
+export class TracedError extends Error {
+  constructor(
+    public readonly span: LlmSpan,
+    public readonly cause: unknown,
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "TracedError";
+  }
+}
+
+/**
  * Create an LLM tracer instance. All state is scoped to the
  * returned object — no module-level mutable state.
  */
@@ -75,7 +91,9 @@ export function createLlmTracer(options: TracerOptions) {
         tags: mergedTags,
       };
 
-      return { response: { text: "", model: "unknown", provider: "unknown", inputTokens: 0, outputTokens: 0 }, span };
+      // Surface the failure — hand the error span to the caller for export, but
+      // never fabricate a success-shaped (empty-text) response.
+      throw new TracedError(span, error);
     }
   }
 

--- a/templates/module-llm-observability/skeleton/src/llm-observability/types.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/types.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 export interface LlmResponse {
   /** Generated text content. */
   text: string;
-  /** Model identifier (e.g., "claude-sonnet-4-20250514"). */
+  /** Model identifier (e.g., "claude-sonnet-4-6"). */
   model: string;
   /** Provider name (e.g., "anthropic", "openai"). */
   provider: string;

--- a/templates/module-llm-providers/skeleton/README.md
+++ b/templates/module-llm-providers/skeleton/README.md
@@ -36,11 +36,11 @@ console.log(`\nTotal tokens: ${final.usage.outputTokens}`);
 
 | Provider | SDK | Default Model | Auth | Always Included |
 |----------|-----|---------------|------|-----------------|
-| `anthropic` | @anthropic-ai/sdk | claude-sonnet-4-20250514 | `ANTHROPIC_API_KEY` | Yes |
+| `anthropic` | @anthropic-ai/sdk | claude-sonnet-4-6 | `ANTHROPIC_API_KEY` | Yes |
 | `openai` | openai | gpt-4o | `OPENAI_API_KEY` | Yes |
 | `groq` | groq-sdk | llama-3.3-70b-versatile | `GROQ_API_KEY` | Yes |
 | `mock` | none | mock-model | none | Yes |
-| `bedrock` | @aws-sdk/client-bedrock-runtime | anthropic.claude-sonnet-4-20250514-v1:0 | IAM / AWS credentials | Conditional |
+| `bedrock` | @aws-sdk/client-bedrock-runtime | anthropic.claude-sonnet-4-6 | IAM / AWS credentials | Conditional |
 | `azure-openai` | openai (reused) | gpt-4o | `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` | Conditional |
 | `vertex` | @google-cloud/vertexai | gemini-2.0-flash | Google ADC | Conditional |
 | `huggingface` | @huggingface/inference | meta-llama/Llama-3.3-70B-Instruct | `HF_TOKEN` | Conditional |

--- a/templates/module-llm-providers/skeleton/src/llm-providers/__tests__/tokens.test.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/__tests__/tokens.test.ts
@@ -44,7 +44,7 @@ describe("countTokens", () => {
   });
 
   it("counts different models consistently when both fall back", () => {
-    const a = countTokens("Hello", "claude-sonnet-4-20250514");
+    const a = countTokens("Hello", "claude-sonnet-4-6");
     const b = countTokens("Hello", "some-unknown-model");
     // Both fall back to gpt-4o encoding, should be equal
     expect(a).toBe(b);

--- a/templates/module-llm-providers/skeleton/src/llm-providers/providers/anthropic.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/providers/anthropic.ts
@@ -23,7 +23,7 @@ import { logger } from "../logger.js";
 // Auth: ANTHROPIC_API_KEY environment variable (read by the SDK).
 //
 
-const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 function createAnthropicProvider(): LlmProvider {
   let client: Anthropic | null = null;

--- a/templates/module-llm-providers/skeleton/src/llm-providers/providers/bedrock.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/providers/bedrock.ts
@@ -25,7 +25,7 @@ import { logger } from "../logger.js";
 // format). Uses IAM auth via standard AWS credential chain.
 //
 
-const DEFAULT_MODEL = "anthropic.claude-sonnet-4-20250514-v1:0";
+const DEFAULT_MODEL = "anthropic.claude-sonnet-4-6";
 
 /** Determine request body format based on model ID prefix. */
 function buildRequestBody(
@@ -122,7 +122,7 @@ function createBedrockProvider(): LlmProvider {
     return client;
   }
 
-  const pricing: Pricing = getPricing("claude-sonnet-4-20250514");
+  const pricing: Pricing = getPricing("claude-sonnet-4-6");
 
   return {
     name: "bedrock",

--- a/templates/module-llm-providers/skeleton/src/llm-providers/types.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/types.ts
@@ -79,7 +79,7 @@ export interface StreamResponse extends AsyncIterable<StreamChunk> {
 
 /** Default pricing per 1M tokens for known models. */
 export const DEFAULT_PRICING: Record<string, Pricing> = {
-  "claude-sonnet-4-20250514": { input: 3, output: 15 },
+  "claude-sonnet-4-6": { input: 3, output: 15 },
   "claude-opus-4-20250514": { input: 15, output: 75 },
   "claude-haiku-4-5-20251001": { input: 0.8, output: 4 },
   "gpt-4o": { input: 2.5, output: 10 },

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/store/memory.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/store/memory.ts
@@ -16,6 +16,13 @@ import type { CacheVector, CacheHit } from "../types.js";
 class MemoryVectorCacheStore implements VectorCacheStore {
   readonly name = "memory";
   private entries = new Map<string, CacheVector>();
+  private readonly maxEntries: number;
+
+  // Bound the cache so a stream of distinct prompts (every miss is upserted)
+  // can't grow memory without limit until TTL. Default 1000; override per store.
+  constructor(maxEntries = 1000) {
+    this.maxEntries = maxEntries;
+  }
 
   private isExpired(entry: CacheVector): boolean {
     return Date.now() >= entry.expiresAt;
@@ -39,7 +46,24 @@ class MemoryVectorCacheStore implements VectorCacheStore {
   }
 
   async upsert(entry: CacheVector): Promise<void> {
+    // Re-insert moves the key to the most-recently-used end of the Map.
+    this.entries.delete(entry.id);
     this.entries.set(entry.id, entry);
+    this.evictIfNeeded();
+  }
+
+  /**
+   * Keep the cache bounded: prune expired entries, then evict the oldest
+   * (least-recently-written) until within maxEntries. Map preserves insertion
+   * order, so the first key is the oldest.
+   */
+  private evictIfNeeded(): void {
+    this.pruneExpired();
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
   }
 
   async search(embedding: number[], threshold: number): Promise<CacheHit | undefined> {


### PR DESCRIPTION
## Why

Phase 4 of the template quality uplift: the REJECT/correctness bugs the audit found in the LLM and cache modules.

## What changed

- **module-llm-observability** — the tracer swallowed a failed LLM call into a fabricated empty-success response (silent data corruption in the one module meant to capture failures). It now throws a `TracedError` carrying the error span; the observer exports the span + records the failed metric, then rethrows the real error. Rewrote the test that encoded the bug. Also fixed a pre-existing `cost/types.ts` build break (`export … from` re-export left `CostEntry` unbound).
- **module-semantic-cache** — the in-memory store was unbounded (every miss upserted, TTL-only pruning). Added a `maxEntries` bound with oldest-first eviction on upsert.
- **module-llm-gateway** + **module-llm-providers** — pricing tables/default model ids keyed on the stale `claude-sonnet-4-20250514`, so cost metering silently returned $0 for the policy-default model. Renamed to `claude-sonnet-4-6` across defaults, pricing keys, tests, and docs.

## Verification

module-llm-observability rendered + validated locally (typecheck + 37 tests green). The others are string/logic fixes validated by the skeleton-test CI (`npm install && npm test`).

## Deferred (documented follow-up)

gateway Bedrock provider + remaining unbounded caches/windows; providers `JSON.parse` zod-validation + Bedrock cachePoint; module-vector-store pg/pinecone timeouts + tableName allowlist; module-oauth token-response validation; and the modules' coverage-threshold + Node-24/vitest-4 currency sweep.