### PR TITLE
rag-pipeline: bump openai to 6 and zod to 4

### DIFF
--- a/templates/rag-pipeline/skeleton/package.json
+++ b/templates/rag-pipeline/skeleton/package.json
@@ -25,9 +25,9 @@
     "chromadb": "^3.4.3",
     "cohere-ai": "^7.0.0",
     "dotenv": "^17.4.2",
-    "openai": "^4.104.0",
+    "openai": "^6.42.0",
     "pg": "^8.13.0",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Follow-on to the chromadb v3 migration (#99), which removed the `openai: ^3 || ^4` peer-dep ceiling. Brings the rag-pipeline template's deps to current:
- `openai` 4.104 → 6.42
- `zod` 3.25 → 4.4

**Zero code changes.** The openai provider uses only stable core APIs (`new OpenAI({...})`, `chat.completions.create`, `embeddings.create`, `response.choices`/`.usage`/`.data`), and the config schemas use only zod patterns unchanged in v4 (`z.object`, `z.string`, `z.coerce.number().int().positive()`, `.default`, `z.array(z.number())`). `tsc --noEmit`, `eslint`, the `tsc` build, the vitest suite (47 passed | 3 skipped), and `audit:prod` all stay green.

The broader catalog-wide openai/zod currency sweep across other templates is a separate, larger item.