### PR TITLE
Standards: add the testing-rubric baseline

### DIFF
--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -20,6 +20,7 @@ const STANDARD_NAMES: StandardName[] = [
   'platform-tenant-contract',
   'llm-policy',
   'quality-rubric-dimensions',
+  'testing-rubric',
 ];
 
 interface StaticResource {
@@ -47,7 +48,7 @@ export function listResources(): StaticResource[] {
       uri: 'nanohype://standards',
       name: 'nanohype standards (bundle)',
       description:
-        'All five published standards files bundled under one resource. Includes language toolchain, version currency, platform-tenant contract, LLM policy, and quality-rubric dimension names.',
+        'All published standards files bundled under one resource. Includes language toolchain, version currency, platform-tenant contract, LLM policy, quality-rubric dimension names, and the testing rubric.',
       mimeType: 'application/json',
     },
   ];

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -16,6 +16,7 @@ const STANDARD_NAMES: StandardName[] = [
   'platform-tenant-contract',
   'llm-policy',
   'quality-rubric-dimensions',
+  'testing-rubric',
 ];
 
 interface ToolDescriptor {

--- a/schemas/standards.schema.json
+++ b/schemas/standards.schema.json
@@ -15,7 +15,8 @@
         "nanohype/standards/version-currency",
         "nanohype/standards/platform-tenant-contract",
         "nanohype/standards/llm-policy",
-        "nanohype/standards/quality-rubric-dimensions"
+        "nanohype/standards/quality-rubric-dimensions",
+        "nanohype/standards/testing-rubric"
       ]
     },
     "version": {
@@ -193,6 +194,43 @@
                     "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
                     "name": { "type": "string" },
                     "summary": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "kind": { "const": "nanohype/standards/testing-rubric" } } },
+      "then": {
+        "properties": {
+          "content": {
+            "type": "object",
+            "required": ["shape", "coverage_floor", "rules"],
+            "properties": {
+              "shape": { "type": "string" },
+              "coverage_floor": {
+                "type": "object",
+                "required": ["branches", "lines", "functions", "statements"],
+                "properties": {
+                  "branches": { "type": "integer", "minimum": 0, "maximum": 100 },
+                  "lines": { "type": "integer", "minimum": 0, "maximum": 100 },
+                  "functions": { "type": "integer", "minimum": 0, "maximum": 100 },
+                  "statements": { "type": "integer", "minimum": 0, "maximum": 100 }
+                }
+              },
+              "rules": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": ["id", "summary"],
+                  "properties": {
+                    "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+                    "summary": { "type": "string" },
+                    "severity": { "type": "string", "enum": ["reject", "warn"] }
                   }
                 }
               }

--- a/sdk/__tests__/standards.test.ts
+++ b/sdk/__tests__/standards.test.ts
@@ -64,6 +64,15 @@ describe('loadStandard', () => {
     }
   });
 
+  it('loads testing-rubric with a coverage floor and enforcement rules', async () => {
+    const s = await loadStandard(source, 'testing-rubric');
+    if (s.kind !== 'nanohype/standards/testing-rubric') throw new Error('kind narrow');
+    expect(s.content.coverage_floor.branches).toBeGreaterThanOrEqual(60);
+    expect(s.content.coverage_floor.lines).toBeGreaterThanOrEqual(75);
+    expect(s.content.rules.length).toBeGreaterThan(0);
+    expect(s.content.rules.some((r) => r.id === 'typecheck-includes-tests')).toBe(true);
+  });
+
   it('throws NanohypeError when the standard is missing', async () => {
     const broken = new LocalSource({ rootDir: '/tmp/nonexistent-nanohype-standards' });
     await expect(loadStandard(broken, 'llm-policy')).rejects.toBeInstanceOf(NanohypeError);
@@ -84,5 +93,6 @@ describe('loadStandards (bundle)', () => {
     expect(bundle['quality-rubric-dimensions'].kind).toBe(
       'nanohype/standards/quality-rubric-dimensions',
     );
+    expect(bundle['testing-rubric'].kind).toBe('nanohype/standards/testing-rubric');
   });
 });

--- a/sdk/src/standards.ts
+++ b/sdk/src/standards.ts
@@ -7,6 +7,7 @@ import type {
   Standard,
   StandardName,
   Standards,
+  TestingRubricStandard,
   VersionCurrencyStandard,
 } from './types.js';
 import { NanohypeError } from './errors.js';
@@ -17,6 +18,7 @@ const ALL_STANDARDS: StandardName[] = [
   'platform-tenant-contract',
   'llm-policy',
   'quality-rubric-dimensions',
+  'testing-rubric',
 ];
 
 const EXPECTED_KIND: Record<StandardName, Standard['kind']> = {
@@ -25,6 +27,7 @@ const EXPECTED_KIND: Record<StandardName, Standard['kind']> = {
   'platform-tenant-contract': 'nanohype/standards/platform-tenant-contract',
   'llm-policy': 'nanohype/standards/llm-policy',
   'quality-rubric-dimensions': 'nanohype/standards/quality-rubric-dimensions',
+  'testing-rubric': 'nanohype/standards/testing-rubric',
 };
 
 /**
@@ -51,13 +54,13 @@ export async function loadStandard(
 /**
  * Load every published standard in a single bundle.
  *
- * Fires the five fetches in parallel. The return shape exposes each
+ * Fires the fetches in parallel. The return shape exposes each
  * standard under its canonical name so consumers don't have to remember
  * the `kind` discriminator strings (`bundle['language-toolchain']` rather
  * than scanning the union).
  */
 export async function loadStandards(source: CatalogSource): Promise<Standards> {
-  const [toolchain, currency, contract, llm, rubric] = await Promise.all(
+  const [toolchain, currency, contract, llm, rubric, testing] = await Promise.all(
     ALL_STANDARDS.map((name) => loadStandard(source, name)),
   );
   return {
@@ -66,5 +69,6 @@ export async function loadStandards(source: CatalogSource): Promise<Standards> {
     'platform-tenant-contract': contract as PlatformTenantContractStandard,
     'llm-policy': llm as LLMPolicyStandard,
     'quality-rubric-dimensions': rubric as QualityRubricDimensionsStandard,
+    'testing-rubric': testing as TestingRubricStandard,
   };
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -159,7 +159,8 @@ export type StandardName =
   | 'version-currency'
   | 'platform-tenant-contract'
   | 'llm-policy'
-  | 'quality-rubric-dimensions';
+  | 'quality-rubric-dimensions'
+  | 'testing-rubric';
 
 /** Per-language toolchain: install + four-phase commands + manifest/registry metadata. */
 export interface Toolchain {
@@ -239,13 +240,27 @@ export interface QualityRubricDimensionsStandard {
   };
 }
 
+/** Standards file: testing rubric — the org test baseline (shape, coverage floor, practices). */
+export interface TestingRubricStandard {
+  kind: 'nanohype/standards/testing-rubric';
+  version: string;
+  title: string;
+  summary: string;
+  content: {
+    shape: string;
+    coverage_floor: { branches: number; lines: number; functions: number; statements: number };
+    rules: { id: string; summary: string; severity?: 'reject' | 'warn' }[];
+  };
+}
+
 /** Union of every published standard. Discriminated by `kind`. */
 export type Standard =
   | LanguageToolchainStandard
   | VersionCurrencyStandard
   | PlatformTenantContractStandard
   | LLMPolicyStandard
-  | QualityRubricDimensionsStandard;
+  | QualityRubricDimensionsStandard
+  | TestingRubricStandard;
 
 /**
  * Parsed bundle of every published standard. The shape an external client
@@ -258,6 +273,7 @@ export interface Standards {
   'platform-tenant-contract': PlatformTenantContractStandard;
   'llm-policy': LLMPolicyStandard;
   'quality-rubric-dimensions': QualityRubricDimensionsStandard;
+  'testing-rubric': TestingRubricStandard;
 }
 
 /** The raw markdown content of a supporting repo's AGENTS.md. */

--- a/standards/README.md
+++ b/standards/README.md
@@ -92,6 +92,18 @@ Nine dimensions every build is graded against. This file names them and summariz
 
 ---
 
+## Testing rubric — `testing-rubric.json`
+
+The org's test baseline: the testing shape, the coverage floor, and the practices a build is held to. Read it when wiring up a project's test runner or grading the testing dimension.
+
+- **Shape** — Testing Trophy: a wide static-analysis base (types + lint), an integration-heavy middle that carries the bulk of confidence, and a thin e2e cap. Integration over isolated unit tests for orchestration code.
+- **Coverage floor** — branches ≥ 60; lines, functions, statements ≥ 75.
+- **Rules** — encode the floor in the runner config (not just a CI flag); 100% on security-critical files; typecheck includes test files; hermetic integration (no live network in the default run); contract tests for every external API; per-package floors allowed but never below the global floor.
+
+The deeper per-language enforcement (how each runner is configured, the REJECT criteria) lives in the reference client's bundled `quality-check` skill.
+
+---
+
 ## Versioning
 
 Each file declares its `version` (a positive integer). Bump the version field on any breaking shape change. Agents that consume these standards should pin to a major version range (the `version` field == major; minor evolution within a major must be backwards-compatible).

--- a/standards/testing-rubric.json
+++ b/standards/testing-rubric.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../schemas/standards.schema.json",
+  "kind": "nanohype/standards/testing-rubric",
+  "version": "1",
+  "title": "Testing rubric — the org test baseline",
+  "summary": "The testing shape and coverage floor every build on the nanohype stack is held to: a Testing-Trophy distribution (static base, integration-heavy middle, thin e2e), a global coverage floor, stricter enforcement on security-critical files, and a few non-negotiable practices. Read this when setting up a project's test runner or grading the testing dimension. The deeper per-language enforcement lives in the reference client's bundled quality-check skill.",
+  "content": {
+    "shape": "Testing Trophy (Dodds): a wide static-analysis base (strict types + lint, the cheapest signal), an integration-heavy middle that carries the bulk of confidence (real collaborators wired together, external boundaries faked hermetically), and a thin end-to-end cap over the few critical user paths. Favor integration tests over isolated unit tests for orchestration code; reserve unit tests for pure logic with real branching.",
+    "coverage_floor": {
+      "branches": 60,
+      "lines": 75,
+      "functions": 75,
+      "statements": 75
+    },
+    "rules": [
+      {
+        "id": "enforce-floor-in-config",
+        "summary": "Encode the coverage floor in the test-runner config (vitest `coverage.thresholds`, jest `coverageThreshold.global`), not just a CI flag — a regression must fail the build, not pass silently. A project that ships no thresholds at all is the anti-pattern this prevents.",
+        "severity": "reject"
+      },
+      {
+        "id": "security-critical-100",
+        "summary": "Files on a security- or compliance-critical path (auth, audit ledgers, approval gates, secret handling, signature verification) carry a per-file 100% branch/line/function override above the global floor.",
+        "severity": "reject"
+      },
+      {
+        "id": "typecheck-includes-tests",
+        "summary": "The typecheck step covers test files. vitest/jest don't type-check at runtime, so test-only type drift (wrong mock shapes, stale fixtures) is invisible unless tsc sees the tests.",
+        "severity": "reject"
+      },
+      {
+        "id": "hermetic-integration",
+        "summary": "Integration tests run against hermetic fakes or local containers for external services — no live network in the default test run. Orchestrators are exercised end-to-end against those fakes.",
+        "severity": "reject"
+      },
+      {
+        "id": "contract-tests",
+        "summary": "Every external API the service depends on has a contract test pinning the request/response shape the code relies on, so an upstream change surfaces as a test failure rather than a production incident.",
+        "severity": "warn"
+      },
+      {
+        "id": "per-package-floors",
+        "summary": "Monorepos may set per-package coverage floors; a package may exceed the global floor but never drop below it. Coverage exclusions (bootstrap entrypoints, generated code, type-only files) are listed explicitly, never blanket-disabled.",
+        "severity": "warn"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds `testing-rubric.json`, the org's published test baseline, so every build is graded against one declared shape + coverage floor instead of each project inventing its own. (Recon across the four tenant apps found the spread this fixes: jest@55, vitest@60, and two apps with no coverage thresholds at all.)

**The standard declares:**
- **Shape** — Testing Trophy: static base, integration-heavy middle, thin e2e.
- **Coverage floor** — branches ≥ 60; lines/functions/statements ≥ 75.
- **Rules** — enforce the floor in the runner config (not just a CI flag); 100% on security-critical files; typecheck includes test files; hermetic integration (no live network in the default run); contract tests per external API; per-package floors allowed but never below the global floor.

Deeper per-language enforcement stays in the reference client's `quality-check` skill.

**Wired end to end** like the other standards: the `nanohype/standards/testing-rubric` kind + content shape in `schemas/standards.schema.json`; the `StandardName` union + `TestingRubricStandard` interface + `Standard` union + `Standards` map in the SDK; `ALL_STANDARDS`/`EXPECTED_KIND`/`loadStandards` in the loader; `STANDARD_NAMES` in the MCP server's tools + resources; a `standards/README.md` section; and SDK test coverage.

Validated: `npm run validate:standards` (schema), SDK typecheck + 82 tests, MCP typecheck + 26 tests, `npm run validate:catalog`. First of the "lift tenants into the catalog" series (the warm-up that exercises the standards plumbing).