### PR TITLE
Templates: add tenant-chart-base, the catalog's first library chart

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/catalog.schema.json",
   "kind": "nanohype/catalog",
   "version": "1",
-  "generated_at": "2026-05-30T23:30:18.000Z",
+  "generated_at": "2026-06-07T02:14:06.000Z",
   "templates": [
     {
       "name": "a2a-agent",
@@ -1724,6 +1724,26 @@
       ],
       "kind": "template",
       "path": "templates/spring-boot-service"
+    },
+    {
+      "name": "tenant-chart-base",
+      "displayName": "Tenant Chart Base (Helm library)",
+      "description": "A Helm library chart (type: library) that defines the named templates every nanohype Platform-tenant chart shares — the ServiceAccount (IRSA), NetworkPolicy (egress baseline + values-driven ingress), PrometheusRule, Grafana dashboard ConfigMap, and the name/label/selector helpers. Consumer charts vendor it under chart/charts/tenant-chart-base, declare it as a file:// dependency, and replace their copy-pasted templates with one-line `{{ include \"tenant-chart-base.*\" . }}` wrappers. The named templates run in the consumer's context, so `.Chart`, `.Values`, and `.Release` resolve to the consuming app. Workload topology (Deployments, CronJobs, Services) and the per-tenant ExternalSecret stay in the consumer — those are the legitimate per-app divergences. The catalog's first library chart.",
+      "version": "0.1.0",
+      "category": "infrastructure",
+      "persona": [
+        "engineering"
+      ],
+      "tags": [
+        "kubernetes",
+        "k8s",
+        "helm",
+        "library",
+        "platform",
+        "nanohype"
+      ],
+      "kind": "template",
+      "path": "templates/tenant-chart-base"
     },
     {
       "name": "test-automation",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "validate:manifest": "ajv validate -s schemas/catalog.schema.json -d catalog.json --spec=draft2020 --strict=false",
     "generate:catalog": "node scripts/generate-catalog.mjs",
     "verify:catalog": "node scripts/generate-catalog.mjs && git diff --exit-code catalog.json",
+    "sync:library": "node scripts/sync-library.mjs",
+    "verify:library": "node scripts/sync-library.mjs --check",
     "lint:docs": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!templates/*/skeleton/**' '!.github/ISSUE_DRAFTS/**'"
   },
   "devDependencies": {

--- a/scripts/sync-library.mjs
+++ b/scripts/sync-library.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Vendor the tenant-chart-base library chart into every consumer chart that
+ * declares it as a `file://charts/tenant-chart-base` dependency.
+ *
+ * The SDK renders skeleton files and never runs `helm`, so a consumer can't
+ * fetch a library dependency at build time — it carries a vendored copy under
+ * `chart/charts/tenant-chart-base/`. The library template is the single source
+ * of truth; this script keeps the copies identical to it.
+ *
+ *   node scripts/sync-library.mjs            # write the vendored copies
+ *   node scripts/sync-library.mjs --check    # CI gate: exit 1 if any copy drifted
+ */
+import { readdir, readFile, rm, cp, stat } from 'node:fs/promises';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const LIB_NAME = 'tenant-chart-base';
+const LIB_SRC = join(ROOT, 'templates', LIB_NAME, 'skeleton', 'chart');
+const TEMPLATES_DIR = join(ROOT, 'templates');
+const CHECK = process.argv.includes('--check');
+
+/** Recursively list files under a dir, relative to it (sorted). */
+async function listFiles(dir, base = dir) {
+  const out = [];
+  for (const e of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...(await listFiles(p, base)));
+    else out.push(relative(base, p));
+  }
+  return out.sort();
+}
+
+/** Find consumer chart directories: a skeleton Chart.yaml that declares the file:// dep. */
+async function findConsumers() {
+  const dirs = [];
+  async function walk(dir) {
+    for (const e of await readdir(dir, { withFileTypes: true })) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === 'node_modules' || e.name === 'charts') continue; // don't descend into vendored copies
+        await walk(p);
+      } else if (e.name === 'Chart.yaml') {
+        if ((await readFile(p, 'utf8')).includes(`file://charts/${LIB_NAME}`)) dirs.push(dirname(p));
+      }
+    }
+  }
+  for (const e of await readdir(TEMPLATES_DIR, { withFileTypes: true })) {
+    if (!e.isDirectory() || e.name === LIB_NAME) continue;
+    const skel = join(TEMPLATES_DIR, e.name, 'skeleton');
+    try {
+      await stat(skel);
+    } catch {
+      continue;
+    }
+    await walk(skel);
+  }
+  return dirs;
+}
+
+async function main() {
+  const consumers = await findConsumers();
+  if (consumers.length === 0) {
+    console.log(`no consumer declares file://charts/${LIB_NAME} yet (nothing to vendor)`);
+    return;
+  }
+  const srcFiles = await listFiles(LIB_SRC);
+  let drift = 0;
+  for (const chartDir of consumers) {
+    const dest = join(chartDir, 'charts', LIB_NAME);
+    const rel = relative(ROOT, dest);
+    if (CHECK) {
+      let copyFiles;
+      try {
+        copyFiles = await listFiles(dest);
+      } catch {
+        copyFiles = null;
+      }
+      const same =
+        copyFiles &&
+        copyFiles.join('\n') === srcFiles.join('\n') &&
+        (
+          await Promise.all(
+            srcFiles.map(async (f) =>
+              (await readFile(join(LIB_SRC, f), 'utf8')) === (await readFile(join(dest, f), 'utf8')),
+            ),
+          )
+        ).every(Boolean);
+      if (same) {
+        console.log(`ok  ${rel}`);
+      } else {
+        console.error(`DRIFT  ${rel} — run \`npm run sync:library\``);
+        drift++;
+      }
+    } else {
+      await rm(dest, { recursive: true, force: true });
+      await cp(LIB_SRC, dest, { recursive: true });
+      console.log(`vendored ${LIB_NAME} -> ${rel}`);
+    }
+  }
+  if (CHECK && drift > 0) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/templates/tenant-chart-base/README.md
+++ b/templates/tenant-chart-base/README.md
@@ -1,0 +1,79 @@
+# tenant-chart-base
+
+A Helm **library chart** (`type: library`) holding the named templates every nanohype Platform-tenant chart shares. It's the catalog's first library chart.
+
+## What you get
+
+A `chart/` directory containing a library chart with these named templates (all in `templates/_*.tpl`):
+
+- `tenant-chart-base.serviceaccount` — ServiceAccount with the tenant's IRSA role annotation (`aws.platformRoleArn`). No inline IAM — it only references the role landing-zone provisions.
+- `tenant-chart-base.networkpolicy` — the NetworkPolicy CR scaffold with values-driven `ingress` (varies by workload topology) and `egress` (the DNS + HTTPS-out baseline).
+- `tenant-chart-base.prometheusrule` — the PrometheusRule CR scaffold; alert groups come from `prometheusRule.groups` (each app's SLOs differ).
+- `tenant-chart-base.grafanaDashboard` — the dashboard ConfigMap; loads `chart/dashboards/<name>.json` verbatim.
+- helpers — `tenant-chart-base.name` / `.fullname` / `.labels` / `.selectorLabels` / `.serviceAccountName`. The tenant/platform labels come from `otel.resourceAttributes`.
+
+The named templates run in the **consumer's** context, so `.Chart`, `.Values`, and `.Release` resolve to the consuming app — `tenant-chart-base.name` returns the app's name, not `tenant-chart-base`.
+
+Two things are **not** in the base, by design:
+
+- **Workload topology** (Deployments, CronJobs, Services, Ingress) — the one legitimate per-app divergence (single-pod vs api+web vs webhook+processor).
+- **ExternalSecret** — secret keys are per-tenant, and some apps compose values via `target.template`. It stays in the consumer.
+
+## How to consume it
+
+The SDK renders files; it doesn't run `helm`. So a consumer **vendors** this library rather than fetching it.
+
+First, copy `chart/` into the consumer at `chart/charts/tenant-chart-base/` (the `sync-library` script does this automatically — see below).
+
+Then declare it as a local dependency in the consumer's `Chart.yaml`:
+
+```yaml
+dependencies:
+  - name: tenant-chart-base
+    version: 0.1.0
+    repository: file://charts/tenant-chart-base
+```
+
+Finally, replace each lifted template with a one-line wrapper, e.g. `chart/templates/serviceaccount.yaml`:
+
+```yaml
+{{ include "tenant-chart-base.serviceaccount" . }}
+```
+
+Because the library is vendored (present in `charts/`), `helm template` / `helm lint` work offline — no `helm dependency build` needed.
+
+### Keeping the vendored copy in sync
+
+The library template here is the single source of truth. Consumer copies are kept honest by:
+
+```sh
+npm run sync:library      # vendor this chart into every consumer that declares the file:// dependency
+npm run verify:library    # CI gate: re-vendor + fail on drift
+```
+
+`k8s-app-tenant` is the reference consumer.
+
+## Variables
+
+None — a library chart is consumed as-is; the named templates read the consumer's values at include time.
+
+## Project layout
+
+```text
+chart/
+  Chart.yaml                       # type: library
+  templates/
+    _helpers.tpl                   # name / fullname / labels / selectorLabels / serviceAccountName
+    _serviceaccount.tpl
+    _networkpolicy.tpl
+    _prometheusrule.tpl
+    _grafana-dashboard.tpl
+```
+
+## Pairs with
+
+- `k8s-app-tenant` — the primary consumer; its chart vendors this library and thin-includes the named templates.
+
+## Nests inside
+
+- `monorepo`

--- a/templates/tenant-chart-base/skeleton/chart/Chart.yaml
+++ b/templates/tenant-chart-base/skeleton/chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: tenant-chart-base
+description: Shared named templates for nanohype Platform-tenant charts.
+type: library
+version: 0.1.0
+maintainers:
+  - name: nanohype

--- a/templates/tenant-chart-base/skeleton/chart/templates/_grafana-dashboard.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_grafana-dashboard.tpl
@@ -1,0 +1,23 @@
+{{/*
+Grafana dashboard ConfigMap, discovered by the Grafana sidecar via the
+`grafana_dashboard` label. The JSON is loaded verbatim from the consumer's
+chart/dashboards/<name>.json (filename derived from the chart name) — edit that
+file, not this template.
+
+Usage (consumer templates/grafana-dashboard.yaml):
+  {{ include "tenant-chart-base.grafanaDashboard" . }}
+*/}}
+{{- define "tenant-chart-base.grafanaDashboard" -}}
+{{- if .Values.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tenant-chart-base.fullname" . }}-dashboard
+  labels:
+    {{- include "tenant-chart-base.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+data:
+  {{ include "tenant-chart-base.name" . }}.json: |-
+    {{- .Files.Get (printf "dashboards/%s.json" (include "tenant-chart-base.name" .)) | nindent 4 }}
+{{- end }}
+{{- end -}}

--- a/templates/tenant-chart-base/skeleton/chart/templates/_helpers.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Name/label/selector helpers shared by every Platform-tenant chart. These are
+included with the CONSUMER's context (`.`), so `.Chart`, `.Release`, and
+`.Values` resolve to the consuming app — `tenant-chart-base.name` returns the
+app's name, not "tenant-chart-base".
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tenant-chart-base.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "tenant-chart-base.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels. The tenant/platform labels come from the OTel resource attributes
+the consumer sets, falling back to the chart name for the platform.
+*/}}
+{{- define "tenant-chart-base.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "tenant-chart-base.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+agents.nanohype.dev/tenant: {{ (index .Values.otel.resourceAttributes "agents.tenant") | default "unknown" | quote }}
+agents.nanohype.dev/platform: {{ (index .Values.otel.resourceAttributes "agents.platform") | default .Chart.Name | quote }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "tenant-chart-base.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tenant-chart-base.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Service account name.
+*/}}
+{{- define "tenant-chart-base.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "tenant-chart-base.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/templates/tenant-chart-base/skeleton/chart/templates/_networkpolicy.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_networkpolicy.tpl
@@ -1,0 +1,30 @@
+{{/*
+NetworkPolicy: the CR scaffold + a values-driven ingress and egress allow-list.
+Ingress varies by workload topology (single-pod vs api+web vs webhook+processor),
+so it's supplied per-app via `.Values.networkPolicy.ingress`; egress is the
+common DNS + HTTPS-out baseline, also values-driven so an app can tighten it.
+
+Usage (consumer templates/networkpolicy.yaml):
+  {{ include "tenant-chart-base.networkpolicy" . }}
+*/}}
+{{- define "tenant-chart-base.networkpolicy" -}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tenant-chart-base.fullname" . }}
+  labels:
+    {{- include "tenant-chart-base.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tenant-chart-base.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+{{- end }}
+{{- end -}}

--- a/templates/tenant-chart-base/skeleton/chart/templates/_prometheusrule.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_prometheusrule.tpl
@@ -1,0 +1,25 @@
+{{/*
+PrometheusRule: the CR scaffold + alert groups supplied per-app via
+`.Values.prometheusRule.groups` (each app's SLOs differ). The OTel metrics the
+app emits arrive in Mimir with service.name as the metric prefix (dashes →
+underscores per the OTLP→Prometheus convention).
+
+Usage (consumer templates/prometheusrule.yaml):
+  {{ include "tenant-chart-base.prometheusrule" . }}
+*/}}
+{{- define "tenant-chart-base.prometheusrule" -}}
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "tenant-chart-base.fullname" . }}
+  labels:
+    {{- include "tenant-chart-base.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    {{- toYaml .Values.prometheusRule.groups | nindent 4 }}
+{{- end }}
+{{- end -}}

--- a/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
@@ -1,0 +1,27 @@
+{{/*
+ServiceAccount with the tenant's IRSA role annotation. The role itself is
+provisioned by landing-zone's <app>-platform component; this only references its
+ARN via `aws.platformRoleArn`. No inline IAM is defined here.
+
+Usage (consumer templates/serviceaccount.yaml):
+  {{ include "tenant-chart-base.serviceaccount" . }}
+*/}}
+{{- define "tenant-chart-base.serviceaccount" -}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tenant-chart-base.serviceAccountName" . }}
+  labels:
+    {{- include "tenant-chart-base.labels" . | nindent 4 }}
+  {{- if or .Values.aws.platformRoleArn .Values.serviceAccount.annotations }}
+  annotations:
+    {{- if .Values.aws.platformRoleArn }}
+    eks.amazonaws.com/role-arn: {{ .Values.aws.platformRoleArn | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/templates/tenant-chart-base/template.yaml
+++ b/templates/tenant-chart-base/template.yaml
@@ -1,0 +1,39 @@
+apiVersion: nanohype/v1
+
+name: tenant-chart-base
+displayName: "Tenant Chart Base (Helm library)"
+description: >
+  A Helm library chart (type: library) that defines the named templates every
+  nanohype Platform-tenant chart shares — the ServiceAccount (IRSA), NetworkPolicy
+  (egress baseline + values-driven ingress), PrometheusRule, Grafana dashboard
+  ConfigMap, and the name/label/selector helpers. Consumer charts vendor it under
+  chart/charts/tenant-chart-base, declare it as a file:// dependency, and replace
+  their copy-pasted templates with one-line `{{ include "tenant-chart-base.*" . }}`
+  wrappers. The named templates run in the consumer's context, so `.Chart`, `.Values`,
+  and `.Release` resolve to the consuming app. Workload topology (Deployments,
+  CronJobs, Services) and the per-tenant ExternalSecret stay in the consumer — those
+  are the legitimate per-app divergences. The catalog's first library chart.
+version: "0.1.0"
+license: Apache-2.0
+persona: [engineering]
+category: infrastructure
+tags: [kubernetes, k8s, helm, library, platform, nanohype]
+
+# A library chart is consumed as-is (vendored into a parent chart); it has no
+# per-instance placeholders — the named templates read the consumer's values at
+# include time.
+variables: []
+
+conditionals: []
+
+composition:
+  pairsWith: [k8s-app-tenant]
+  nestsInside: [monorepo]
+
+prerequisites:
+  - name: helm
+    version: ">=3.0"
+    purpose: "Render + lint a consumer chart that depends on this library"
+    optional: false
+
+hooks: {}


### PR DESCRIPTION
The four Platform-tenant apps each copy-paste the same chart scaffolding. This lifts the genuinely-shared templates into a Helm **library chart** (`type: library`) — the catalog's first — so consumers carry one definition + one-line includes, and every future tenant the factory emits inherits it.

**The library** (`templates/tenant-chart-base/`, named templates in `templates/_*.tpl`):
- `tenant-chart-base.serviceaccount` — ServiceAccount + IRSA annotation (`aws.platformRoleArn`); no inline IAM
- `tenant-chart-base.networkpolicy` — CR scaffold; values-driven `ingress` (per-topology) + `egress` baseline
- `tenant-chart-base.prometheusrule` — CR scaffold; alert groups from values
- `tenant-chart-base.grafanaDashboard` — dashboard ConfigMap
- helpers — `name`/`fullname`/`labels`/`selectorLabels`/`serviceAccountName`; tenant/platform labels from `otel.resourceAttributes`

The named templates run in the **consumer's** context (`.Chart`/`.Values`/`.Release` resolve to the consuming app). **Not** lifted, by design: workload topology (the legitimate per-app divergence) and the per-tenant `ExternalSecret` (per-tenant secret keys; some apps compose via `target.template`).

**Vendoring:** the SDK renders files and never runs helm, so consumers vendor the chart under `chart/charts/tenant-chart-base/` + declare a `file://` dependency — `helm template`/`lint` then work offline, no `helm dependency build`. `scripts/sync-library.mjs` vendors it into every declaring consumer; `npm run verify:library` is the drift gate. No consumer wires it yet — that's the `k8s-app-tenant` refactor in the next PR.

**Verified:** `validate.sh` + `validate:catalog` + `validate:manifest` pass; a fixture consumer `helm lint`s clean and `helm template`s all four resources with names/labels/platform-label resolving to the consuming app.

Second of the lift-tenants-into-the-catalog series (after the testing-rubric standard, #101).