### PR TITLE
module-llm-gateway: measure Bedrock prompt-cache effectiveness

### DIFF
--- a/templates/module-llm-gateway/README.md
+++ b/templates/module-llm-gateway/README.md
@@ -11,7 +11,20 @@ Unified LLM gateway with pluggable routing strategies, response caching, and cos
 - Anomaly detection using z-score analysis on rolling cost windows
 - Token counting via js-tiktoken with model-aware encoding cache
 - Circuit breaker on every provider for fault isolation
-- OTel metrics for request count, latency, token usage, and cost
+- OTel metrics for request count, latency, token usage, cost, and Bedrock prompt-cache effectiveness
+
+## Bedrock prompt caching
+
+The Bedrock provider sends a `cachePoint` after the system prompt, so a stable prefix is
+amortized across turns. Converse reports `cacheReadInputTokens` / `cacheWriteInputTokens`,
+which the provider surfaces on the response (`cacheReadTokens` / `cacheWriteTokens`) and
+prices correctly (reads ~10%, writes ~125% of the input rate). The gateway emits a
+`bedrock_cache_total` counter labeled `kind` (hit / write / miss) so the hit ratio —
+`hit / (hit + write)` — is observable and the prompt-caching mandate is verifiable.
+
+This is measurable only via Converse: the raw InvokeModel API marks the system prompt with
+`cache_control: ephemeral` but does not return cache token counts, so the gateway
+standardizes on Converse for measured caching.
 
 ## Variables
 

--- a/templates/module-llm-gateway/skeleton/src/gateway/__tests__/bedrock-cache.test.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/__tests__/bedrock-cache.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { readBedrockCacheTokens, bedrockCacheKinds } from "../providers/bedrock-cache.js";
+
+describe("readBedrockCacheTokens", () => {
+  it("reads cache tokens off a Converse usage block", () => {
+    expect(
+      readBedrockCacheTokens({ cacheReadInputTokens: 120, cacheWriteInputTokens: 30 }),
+    ).toEqual({ cacheReadTokens: 120, cacheWriteTokens: 30 });
+  });
+
+  it("defaults to zero when caching isn't in play", () => {
+    expect(readBedrockCacheTokens(undefined)).toEqual({
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect(readBedrockCacheTokens({})).toEqual({ cacheReadTokens: 0, cacheWriteTokens: 0 });
+  });
+});
+
+describe("bedrockCacheKinds", () => {
+  it("a cache read is a hit", () => {
+    expect(bedrockCacheKinds(120, 0)).toEqual(["hit"]);
+  });
+
+  it("a cache write seeds the prefix", () => {
+    expect(bedrockCacheKinds(0, 30)).toEqual(["write"]);
+  });
+
+  it("a call that reads and writes emits both", () => {
+    expect(bedrockCacheKinds(120, 30)).toEqual(["hit", "write"]);
+  });
+
+  it("neither is a miss", () => {
+    expect(bedrockCacheKinds(0, 0)).toEqual(["miss"]);
+  });
+});

--- a/templates/module-llm-gateway/skeleton/src/gateway/index.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/index.ts
@@ -18,7 +18,9 @@ import {
   gatewayTokenUsage,
   gatewayCostTotal,
   gatewayCacheTotal,
+  bedrockCacheTotal,
 } from "./metrics.js";
+import { bedrockCacheKinds } from "./providers/bedrock-cache.js";
 import type { GatewayProvider } from "./providers/types.js";
 import type { GatewayConfig, ChatMessage, ChatOptions, GatewayResponse } from "./types.js";
 import type { CostFilters, CostSummary } from "./cost/tracker.js";
@@ -193,6 +195,17 @@ export function createGateway(config: GatewayConfig): Gateway {
       gatewayTokenUsage.add(response.inputTokens, { ...labels, direction: "input" });
       gatewayTokenUsage.add(response.outputTokens, { ...labels, direction: "output" });
       gatewayCostTotal.add(response.cost, labels);
+
+      // Bedrock prompt-cache events (only providers that report cache tokens —
+      // Bedrock via Converse — populate these; distinct from the response cache).
+      if (response.cacheReadTokens !== undefined || response.cacheWriteTokens !== undefined) {
+        for (const kind of bedrockCacheKinds(
+          response.cacheReadTokens ?? 0,
+          response.cacheWriteTokens ?? 0,
+        )) {
+          bedrockCacheTotal.add(1, { ...labels, kind });
+        }
+      }
 
       // Record cost
       costTracker.record(response, chatOpts.tags ?? {});

--- a/templates/module-llm-gateway/skeleton/src/gateway/metrics.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/metrics.ts
@@ -35,3 +35,13 @@ export const gatewayCostTotal = meter.createCounter("gateway_cost_usd", {
 export const gatewayCacheTotal = meter.createCounter("gateway_cache_total", {
   description: "Gateway cache lookups by result",
 });
+
+/**
+ * Bedrock prompt-cache events, labeled by kind (hit | write | miss). Distinct
+ * from gateway_cache_total — that tracks the gateway's own response cache; this
+ * tracks Bedrock's server-side prompt-prefix cache so the hit ratio
+ * (hit / (hit + write)) is observable and the org's caching mandate is verifiable.
+ */
+export const bedrockCacheTotal = meter.createCounter("bedrock_cache_total", {
+  description: "Bedrock prompt-cache events by kind (hit, write, miss)",
+});

--- a/templates/module-llm-gateway/skeleton/src/gateway/providers/bedrock-cache.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/providers/bedrock-cache.ts
@@ -1,0 +1,46 @@
+// ── Bedrock prompt-cache bookkeeping ────────────────────────────────
+//
+// Pure + dependency-free (no AWS SDK import) so it's unit-testable on its own.
+// The Bedrock Converse API reports prompt-cache token counts in `usage`; this
+// turns them into the cache events the gateway counts via bedrock_cache_total.
+//
+// This is the only place the cache is measurable: Converse exposes
+// cacheReadInputTokens / cacheWriteInputTokens, whereas the raw InvokeModel API
+// (system prompt marked `cache_control: ephemeral`) does NOT surface cache
+// tokens in its response body. The gateway standardizes on Converse so the
+// prompt-cache hit ratio is observable.
+
+export type BedrockCacheKind = "hit" | "write" | "miss";
+
+/** Converse usage block fields relevant to prompt caching. */
+export interface BedrockCacheUsage {
+  cacheReadInputTokens?: number;
+  cacheWriteInputTokens?: number;
+}
+
+/** Cache token counts off a Converse usage block (0 when caching isn't in play). */
+export function readBedrockCacheTokens(usage: BedrockCacheUsage | undefined): {
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+} {
+  return {
+    cacheReadTokens: usage?.cacheReadInputTokens ?? 0,
+    cacheWriteTokens: usage?.cacheWriteInputTokens ?? 0,
+  };
+}
+
+/**
+ * The cache events a single call represents: input served from cache is a hit,
+ * input written to cache is a write, and neither is a miss. A call can both read
+ * (reuse the cached prefix) and write (extend it), so it may emit two kinds.
+ */
+export function bedrockCacheKinds(
+  cacheReadTokens: number,
+  cacheWriteTokens: number,
+): BedrockCacheKind[] {
+  const kinds: BedrockCacheKind[] = [];
+  if (cacheReadTokens > 0) kinds.push("hit");
+  if (cacheWriteTokens > 0) kinds.push("write");
+  if (kinds.length === 0) kinds.push("miss");
+  return kinds;
+}

--- a/templates/module-llm-gateway/skeleton/src/gateway/providers/bedrock.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/providers/bedrock.ts
@@ -5,6 +5,7 @@ import {
 import type { GatewayProvider, ProviderPricing } from "./types.js";
 import type { ChatMessage, GatewayResponse, ChatOptions } from "../types.js";
 import { registerProvider } from "./registry.js";
+import { readBedrockCacheTokens } from "./bedrock-cache.js";
 import { createCircuitBreaker } from "./circuit-breaker.js";
 import { countTokens } from "../tokens/counter.js";
 
@@ -77,6 +78,9 @@ const bedrockProvider: GatewayProvider = {
     const usage = response.usage;
     const inputTokens = usage?.inputTokens ?? 0;
     const outputTokens = usage?.outputTokens ?? 0;
+    // Prompt-cache tokens (Converse reports these; the gateway emits
+    // bedrock_cache_total from them — see bedrock-cache.ts).
+    const { cacheReadTokens, cacheWriteTokens } = readBedrockCacheTokens(usage);
 
     const blocks = response.output?.message?.content ?? [];
     const text = blocks
@@ -84,8 +88,11 @@ const bedrockProvider: GatewayProvider = {
       .join("\n")
       .trim();
 
+    // Cache-aware cost: inputTokens is the non-cached input; reads bill at ~10%
+    // of the input rate, writes at ~125% (AWS Bedrock prompt-cache pricing).
     const cost =
-      (inputTokens * this.pricing.input) / 1_000_000 +
+      ((inputTokens + cacheReadTokens * 0.1 + cacheWriteTokens * 1.25) * this.pricing.input) /
+        1_000_000 +
       (outputTokens * this.pricing.output) / 1_000_000;
 
     return {
@@ -95,8 +102,12 @@ const bedrockProvider: GatewayProvider = {
       inputTokens,
       outputTokens,
       latencyMs,
+      // `cached` is a gateway response-cache hit; a prompt-cache read is not one
+      // (the response is freshly generated), so it stays false here.
       cached: false,
       cost,
+      cacheReadTokens,
+      cacheWriteTokens,
     };
   },
 

--- a/templates/module-llm-gateway/skeleton/src/gateway/types.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/types.ts
@@ -43,10 +43,19 @@ export interface GatewayResponse {
   outputTokens: number;
   /** Request latency in milliseconds. */
   latencyMs: number;
-  /** Whether this response was served from cache. */
+  /** Whether this response was served from the gateway's response cache. */
   cached: boolean;
   /** Cost in USD for this request. */
   cost: number;
+  /**
+   * Bedrock prompt-cache input tokens served from cache this call. Distinct from
+   * `cached` (a full gateway response-cache hit) — a prompt-cache read still
+   * generates a fresh response, just from a cached prefix. Set only by providers
+   * that report it (Bedrock via Converse); undefined elsewhere.
+   */
+  cacheReadTokens?: number;
+  /** Bedrock prompt-cache input tokens written to cache this call. */
+  cacheWriteTokens?: number;
 }
 
 /** Configuration for createGateway(). */


### PR DESCRIPTION
The Bedrock provider already sends a `cachePoint` after the system prompt, but the cache was invisible — it hardcoded `cached: false` and never read the cache tokens Converse returns, so the prompt-caching mandate couldn't be verified.

**Now:** the provider reads `usage.cacheReadInputTokens` / `cacheWriteInputTokens`, exposes them on `GatewayResponse` (`cacheReadTokens` / `cacheWriteTokens`), and prices them correctly (reads ~10%, writes ~125% of the input rate; `inputTokens` is the non-cached portion). The facade emits a `bedrock_cache_total` counter labeled `kind` (hit / write / miss) so the hit ratio `hit/(hit+write)` is observable. Distinct from `gateway_cache_total` (the gateway's own response cache) — a prompt-cache read still generates a fresh response, so `cached` stays false.

The cache-event logic lives in a pure, dependency-free `bedrock-cache.ts` (`readBedrockCacheTokens` + `bedrockCacheKinds`) so it's unit-testable without the AWS SDK. README documents the metric and the **InvokeModel limitation**: measured caching requires Converse — InvokeModel marks the prompt `cache_control: ephemeral` but doesn't return cache tokens, so the gateway standardizes on Converse.

Grounded in `competitive-intelligence/src/providers/llm.ts`. Verified: typecheck clean; all gateway tests pass including new bedrock-cache unit tests. Fourth of the lift-tenants-into-the-catalog series; closes the deferred llm-gateway Bedrock-cache follow-up.