### PR TITLE
Templates: add module-audit-ledger-ts (storage adapters behind one port)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/catalog.schema.json",
   "kind": "nanohype/catalog",
   "version": "1",
-  "generated_at": "2026-06-07T02:34:52.000Z",
+  "generated_at": "2026-06-07T03:05:54.000Z",
   "templates": [
     {
       "name": "a2a-agent",
@@ -957,6 +957,27 @@
       ],
       "kind": "template",
       "path": "templates/module-analytics-ts"
+    },
+    {
+      "name": "module-audit-ledger-ts",
+      "displayName": "Module: Audit Ledger",
+      "description": "Append-only audit ledger with pluggable storage backends. One AuditLedger port (append + queryByContext) over four adapters: an in-memory store for development, Postgres (immutable append), DynamoDB (conditional write + strongly-consistent read), and SQS→consumer (FIFO with a DLQ fallback for at-least-once delivery). The module owns persistence only — domain logic such as approval gates, edit-distance scoring, and PII scrubbing stays in the app that owns the events.",
+      "version": "0.1.0",
+      "category": "composable-modules",
+      "persona": [
+        "engineering"
+      ],
+      "tags": [
+        "audit",
+        "ledger",
+        "compliance",
+        "postgres",
+        "dynamodb",
+        "sqs",
+        "typescript"
+      ],
+      "kind": "template",
+      "path": "templates/module-audit-ledger-ts"
     },
     {
       "name": "module-auth-go",

--- a/composites/platform-tenant.yaml
+++ b/composites/platform-tenant.yaml
@@ -75,6 +75,18 @@ variables:
     description: "Default vector store backend."
     default: "memory"
 
+  - name: IncludeAuditLedger
+    type: bool
+    placeholder: "__INCLUDE_AUDIT_LEDGER__"
+    description: "Include the audit ledger package (append-only event log over pluggable storage)."
+    default: false
+
+  - name: AuditProvider
+    type: string
+    placeholder: "__AUDIT_PROVIDER__"
+    description: "Default audit ledger backend."
+    default: "memory"
+
 templates:
   - template: k8s-app-tenant
     root: true
@@ -98,3 +110,10 @@ templates:
     variables:
       ProjectName: "${AppName}-vectors"
       VectorProvider: "${VectorProvider}"
+
+  - template: module-audit-ledger-ts
+    path: packages/audit
+    condition: IncludeAuditLedger
+    variables:
+      ProjectName: "${AppName}-audit"
+      AuditProvider: "${AuditProvider}"

--- a/templates/module-audit-ledger-ts/README.md
+++ b/templates/module-audit-ledger-ts/README.md
@@ -1,0 +1,50 @@
+# module-audit-ledger-ts
+
+An append-only audit ledger with pluggable storage backends. One `AuditLedger` port over four adapters, sharing the registry pattern with the other `module-*-ts` modules.
+
+## What you get
+
+- An `AuditLedger` facade — `append(event)` and `query(contextId)` — over a self-registering adapter registry
+- Four adapters:
+  - **memory** — in-process, for development and tests (the default)
+  - **postgres** — immutable append-only table, `ON CONFLICT DO NOTHING` for idempotent retries
+  - **dynamodb** — single-table (`PK=CTX#<id>`, `SK=AUDIT#<ts>#<eventId>`), conditional write for idempotency, TTL, strongly-consistent reads on demand (for read-gates-write checks)
+  - **sqs** — at-least-once to a FIFO queue with a DLQ fallback; write-only (a consumer drains it to a queryable store)
+- Deterministic, content-addressed event ids so an append is idempotent across all backends
+- OTel counters: `audit_append_total` (by provider + result) and `audit_query_total`
+
+**Boundary:** this module owns *persistence only*. Domain logic — approval gates, edit-distance scoring, PII scrubbing — stays in the app that owns the events. Scrub `details` before appending.
+
+## Variables
+
+| Variable | Placeholder | Default | Description |
+| --- | --- | --- | --- |
+| `ProjectName` | `__PROJECT_NAME__` | — | Package name + directory (kebab-case, required) |
+| `Description` | `__DESCRIPTION__` | Append-only audit ledger… | package.json + README description |
+| `AuditProvider` | `__AUDIT_PROVIDER__` | `memory` | Default backend (memory, postgres, dynamodb, sqs, or a custom name) |
+
+## Project layout
+
+```text
+src/audit/
+  types.ts                     # AuditEvent, AuditConfig, QueryOptions
+  event-id.ts                  # deterministic content-addressed event id (pure)
+  index.ts                     # createAuditLedger facade
+  bootstrap.ts                 # placeholder guard
+  metrics.ts                   # OTel counters
+  providers/
+    types.ts                   # AuditAdapter port
+    registry.ts                # register / get / list
+    memory.ts  postgres.ts  dynamodb.ts  sqs.ts
+    index.ts                   # barrel (self-registration)
+  __tests__/
+```
+
+## Pairs with
+
+- `k8s-app-tenant` — deploy the app whose events you're recording
+- `ts-service`, `agentic-loop` — the services that emit the events
+
+## Nests inside
+
+- `monorepo`

--- a/templates/module-audit-ledger-ts/skeleton/.env.example
+++ b/templates/module-audit-ledger-ts/skeleton/.env.example
@@ -1,0 +1,15 @@
+# Audit ledger configuration. Copy to .env and fill in per the backend you use.
+# The default backend is __AUDIT_PROVIDER__.
+
+# AWS region for the dynamodb / sqs adapters (falls back to the ambient AWS config).
+AWS_REGION=us-west-2
+
+# postgres adapter — a connection string, or pass an existing Pool in code.
+# DATABASE_URL=postgresql://user:pass@host:5432/db
+
+# dynamodb adapter — the audit table name.
+# AUDIT_TABLE_NAME=my-app-audit
+
+# sqs adapter — the FIFO queue + its dead-letter queue.
+# AUDIT_QUEUE_URL=https://sqs.us-west-2.amazonaws.com/000000000000/my-app-audit.fifo
+# AUDIT_DLQ_URL=https://sqs.us-west-2.amazonaws.com/000000000000/my-app-audit-dlq.fifo

--- a/templates/module-audit-ledger-ts/skeleton/.gitignore
+++ b/templates/module-audit-ledger-ts/skeleton/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+*.log
+*.tsbuildinfo

--- a/templates/module-audit-ledger-ts/skeleton/.prettierrc
+++ b/templates/module-audit-ledger-ts/skeleton/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/templates/module-audit-ledger-ts/skeleton/eslint.config.js
+++ b/templates/module-audit-ledger-ts/skeleton/eslint.config.js
@@ -1,0 +1,25 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
+  {
+    ignores: ["dist/", "node_modules/"],
+  },
+);

--- a/templates/module-audit-ledger-ts/skeleton/package.json
+++ b/templates/module-audit-ledger-ts/skeleton/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "__PROJECT_NAME__",
+  "version": "0.1.0",
+  "description": "__DESCRIPTION__",
+  "type": "module",
+  "main": "dist/audit/index.js",
+  "types": "dist/audit/index.d.ts",
+  "exports": {
+    ".": "./dist/audit/index.js",
+    "./providers": "./dist/audit/providers/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx --watch src/audit/index.ts",
+    "start": "node dist/audit/index.js",
+    "lint": "eslint src/",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.700.0",
+    "@aws-sdk/client-sqs": "^3.700.0",
+    "@aws-sdk/lib-dynamodb": "^3.700.0",
+    "@opentelemetry/api": "^1.9.0",
+    "pg": "^8.13.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.20.0",
+    "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
+    "eslint": "^9.20.0",
+    "prettier": "^3.5.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0",
+    "typescript-eslint": "^8.25.0",
+    "vitest": "^3.1.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/__tests__/event-id.test.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/__tests__/event-id.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { deriveEventId, eventIdOf } from "../event-id.js";
+import type { AuditEvent } from "../types.js";
+
+const base: AuditEvent = {
+  contextId: "incident-1",
+  eventType: "APPROVED",
+  actor: "u-1",
+  details: { draftId: "d-1" },
+  timestamp: "2026-01-01T00:00:00.000Z",
+};
+
+describe("deriveEventId", () => {
+  it("is deterministic for the same event content", () => {
+    expect(deriveEventId(base)).toBe(deriveEventId({ ...base }));
+  });
+
+  it("changes when any identifying field changes", () => {
+    expect(deriveEventId(base)).not.toBe(deriveEventId({ ...base, timestamp: "2026-01-02T00:00:00.000Z" }));
+    expect(deriveEventId(base)).not.toBe(deriveEventId({ ...base, details: { draftId: "d-2" } }));
+    expect(deriveEventId(base)).not.toBe(deriveEventId({ ...base, actor: "u-2" }));
+  });
+});
+
+describe("eventIdOf", () => {
+  it("uses an explicit eventId when present", () => {
+    expect(eventIdOf({ ...base, eventId: "explicit" })).toBe("explicit");
+  });
+
+  it("derives one when absent", () => {
+    expect(eventIdOf(base)).toBe(deriveEventId(base));
+  });
+});

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/__tests__/ledger.test.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/__tests__/ledger.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { createAuditLedger } from "../index.js";
+
+describe("createAuditLedger (memory)", () => {
+  it("appends and reads back a context's trail newest-first", async () => {
+    const audit = await createAuditLedger("memory");
+    await audit.append({
+      contextId: "run-1",
+      eventType: "DRAFT_GENERATED",
+      actor: "system",
+      details: {},
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    await audit.append({
+      contextId: "run-1",
+      eventType: "APPROVED",
+      actor: "u-1",
+      details: {},
+      timestamp: "2026-01-01T01:00:00.000Z",
+    });
+    await audit.append({
+      contextId: "run-2",
+      eventType: "APPROVED",
+      actor: "u-2",
+      details: {},
+      timestamp: "2026-01-01T02:00:00.000Z",
+    });
+
+    const trail = await audit.query("run-1");
+    expect(trail).toHaveLength(2);
+    expect(trail[0].eventType).toBe("APPROVED"); // newest first
+    expect(trail[1].eventType).toBe("DRAFT_GENERATED");
+    await audit.close();
+  });
+
+  it("is idempotent on the derived event id", async () => {
+    const audit = await createAuditLedger("memory");
+    const event = {
+      contextId: "run-1",
+      eventType: "SENT",
+      actor: "system",
+      details: { messageId: "m-1" },
+      timestamp: "2026-01-01T00:00:00.000Z",
+    };
+    await audit.append(event);
+    await audit.append(event); // same content → same id → collapsed
+    expect(await audit.query("run-1")).toHaveLength(1);
+    await audit.close();
+  });
+
+  it("honors since and limit", async () => {
+    const audit = await createAuditLedger("memory");
+    for (let h = 0; h < 4; h++) {
+      await audit.append({
+        contextId: "run-1",
+        eventType: "TICK",
+        actor: "system",
+        details: { h },
+        timestamp: `2026-01-01T0${h}:00:00.000Z`,
+      });
+    }
+    expect(await audit.query("run-1", { since: "2026-01-01T02:00:00.000Z" })).toHaveLength(2);
+    expect(await audit.query("run-1", { limit: 1 })).toHaveLength(1);
+    await audit.close();
+  });
+
+  it("defaults the timestamp when omitted", async () => {
+    const audit = await createAuditLedger("memory");
+    await audit.append({ contextId: "run-1", eventType: "PING", actor: "system", details: {} });
+    const [e] = await audit.query("run-1");
+    expect(e.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    await audit.close();
+  });
+});

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/__tests__/registry.test.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/__tests__/registry.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { getProvider, listProviders } from "../providers/index.js";
+
+describe("adapter registry", () => {
+  it("registers all four built-in adapters", () => {
+    const names = listProviders();
+    for (const name of ["memory", "postgres", "dynamodb", "sqs"]) {
+      expect(names).toContain(name);
+    }
+  });
+
+  it("returns a fresh adapter by name", () => {
+    expect(getProvider("memory").name).toBe("memory");
+  });
+
+  it("throws for an unknown adapter", () => {
+    expect(() => getProvider("nope")).toThrow(/not found/);
+  });
+});

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/bootstrap.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/bootstrap.ts
@@ -1,0 +1,32 @@
+// ── Bootstrap Validation ────────────────────────────────────────────
+//
+// Catches unresolved nanohype placeholders left from incomplete
+// scaffolding. Runs once at startup — exits with a helpful message
+// if any __PLACEHOLDER__ patterns remain in package metadata.
+//
+
+const PLACEHOLDER_RE = /__[A-Z][A-Z0-9_]*__/;
+
+export function validateBootstrap(): void {
+  // Vitest runs tests against the raw, unrendered skeleton — placeholder
+  // substitution only happens at scaffold time — so skip the check when
+  // the vitest env flag is present.
+  if (process.env.VITEST) return;
+
+  const checks: Record<string, string | undefined> = {
+    "package name": process.env.npm_package_name,
+    "package description": process.env.npm_package_description,
+  };
+
+  for (const [label, value] of Object.entries(checks)) {
+    if (value && PLACEHOLDER_RE.test(value)) {
+      console.error(
+        `\n  Unresolved placeholder in ${label}: ${value}\n\n` +
+          "  This project was scaffolded from a nanohype template but\n" +
+          "  some variables were not replaced. Re-run the scaffolding\n" +
+          "  tool or replace placeholders manually.\n",
+      );
+      process.exit(1);
+    }
+  }
+}

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/event-id.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/event-id.ts
@@ -1,0 +1,31 @@
+// ── Deterministic event id ──────────────────────────────────────────
+//
+// Pure + dependency-free (only node:crypto) so it's unit-testable in isolation.
+// When an AuditEvent carries no eventId, the ledger derives a stable one from
+// the event's content, so retrying the same append is idempotent on backends
+// that condition on the id (Postgres ON CONFLICT, DynamoDB attribute_not_exists,
+// SQS MessageDeduplicationId).
+
+import { createHash } from "node:crypto";
+import type { AuditEvent } from "./types.js";
+
+/**
+ * A content-addressed id for an event: sha256 over the identifying fields. Two
+ * appends with the same context/type/actor/timestamp/details collapse to one;
+ * a genuinely new event (different timestamp or details) gets a new id.
+ */
+export function deriveEventId(event: AuditEvent): string {
+  const canonical = JSON.stringify([
+    event.contextId,
+    event.eventType,
+    event.actor,
+    event.timestamp,
+    event.details,
+  ]);
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/** The event's id, deriving a deterministic one if it doesn't carry its own. */
+export function eventIdOf(event: AuditEvent): string {
+  return event.eventId ?? deriveEventId(event);
+}

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/index.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/index.ts
@@ -1,0 +1,101 @@
+// ── Module Audit Ledger — Main Exports ──────────────────────────────
+//
+// Public API. Import adapters so they self-register, then expose
+// createAuditLedger as the primary entry point.
+//
+
+import { z } from "zod";
+import { validateBootstrap } from "./bootstrap.js";
+import { getProvider } from "./providers/index.js";
+import { auditAppendTotal, auditQueryTotal } from "./metrics.js";
+import type { AuditAdapter } from "./providers/types.js";
+import type { AuditConfig, AuditEvent, QueryOptions } from "./types.js";
+
+// Re-export everything consumers need.
+export { getProvider, listProviders, registerProvider } from "./providers/index.js";
+export { deriveEventId, eventIdOf } from "./event-id.js";
+export type { AuditAdapter } from "./providers/types.js";
+export type { AuditConfig, AuditEvent, QueryOptions } from "./types.js";
+
+/** An event to append. timestamp + eventId are optional — the ledger fills them. */
+export type AppendInput = Omit<AuditEvent, "timestamp" | "eventId"> & {
+  timestamp?: string;
+  eventId?: string;
+};
+
+// ── Audit Ledger Facade ─────────────────────────────────────────────
+
+export interface AuditLedger {
+  /** The underlying adapter instance. */
+  adapter: AuditAdapter;
+
+  /** Append one event (append-only). timestamp defaults to now() if omitted. */
+  append(event: AppendInput): Promise<void>;
+
+  /** Read a context's events, newest-first. Throws on write-only backends. */
+  query(contextId: string, opts?: QueryOptions): Promise<AuditEvent[]>;
+
+  /** Release the adapter's resources. */
+  close(): Promise<void>;
+}
+
+const CreateSchema = z.object({
+  providerName: z.string().min(1, "providerName must be a non-empty string"),
+  config: z.object({}).passthrough(),
+});
+
+/**
+ * Create an audit ledger backed by the named adapter. The adapter must already
+ * be registered (built-ins self-register via the providers barrel).
+ *
+ *   const audit = await createAuditLedger("postgres", { connectionString });
+ *   await audit.append({ contextId: incidentId, eventType: "APPROVED", actor, details });
+ *   const trail = await audit.query(incidentId);
+ *
+ * Domain logic (approval gates, edit-distance scoring, PII scrubbing) is the
+ * caller's responsibility — scrub `details` before appending; this module only
+ * persists and reads events back.
+ */
+export async function createAuditLedger(
+  providerName: string = "__AUDIT_PROVIDER__",
+  config: AuditConfig = {},
+): Promise<AuditLedger> {
+  const parsed = CreateSchema.safeParse({ providerName, config });
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");
+    throw new Error(`Invalid audit config: ${issues}`);
+  }
+
+  validateBootstrap();
+
+  const adapter = getProvider(providerName);
+  await adapter.init(config);
+
+  return {
+    adapter,
+
+    async append(input: AppendInput): Promise<void> {
+      const event: AuditEvent = {
+        ...input,
+        timestamp: input.timestamp ?? new Date().toISOString(),
+      };
+      try {
+        await adapter.append(event);
+        auditAppendTotal.add(1, { provider: adapter.name, result: "ok" });
+      } catch (err) {
+        auditAppendTotal.add(1, { provider: adapter.name, result: "error" });
+        throw err;
+      }
+    },
+
+    async query(contextId: string, opts?: QueryOptions): Promise<AuditEvent[]> {
+      const events = await adapter.queryByContext(contextId, opts);
+      auditQueryTotal.add(1, { provider: adapter.name });
+      return events;
+    },
+
+    async close(): Promise<void> {
+      await adapter.close();
+    },
+  };
+}

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/metrics.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/metrics.ts
@@ -1,0 +1,19 @@
+import { metrics } from "@opentelemetry/api";
+
+// ── Audit Ledger Metrics ────────────────────────────────────────────
+//
+// OTel counters for audit observability. No-ops unless an OTel SDK is
+// wired in by the consumer.
+//
+
+const meter = metrics.getMeter("__PROJECT_NAME__");
+
+/** Events appended, labeled by provider and result (ok | error). */
+export const auditAppendTotal = meter.createCounter("audit_append_total", {
+  description: "Audit events appended, by provider and result",
+});
+
+/** Context queries, labeled by provider. */
+export const auditQueryTotal = meter.createCounter("audit_query_total", {
+  description: "Audit context queries, by provider",
+});

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/providers/dynamodb.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/providers/dynamodb.ts
@@ -1,0 +1,111 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import type { AuditAdapter } from "./types.js";
+import type { AuditConfig, AuditEvent, QueryOptions } from "../types.js";
+import { registerProvider } from "./registry.js";
+import { eventIdOf } from "../event-id.js";
+
+// ── DynamoDB Adapter ────────────────────────────────────────────────
+//
+// Single-table ledger. Each event is an item keyed PK = `CTX#<contextId>`,
+// SK = `AUDIT#<timestamp>#<eventId>`, so a context's events sort by time within
+// the partition. append uses ConditionExpression attribute_not_exists(SK) for
+// idempotency and sets a TTL. queryByContext reads the partition newest-first;
+// pass consistentRead when a read must see a just-written event (a read-gates-
+// write check). config: { tableName, client?, ttlDays? }.
+//
+
+const SK_PREFIX = "AUDIT#";
+
+class DynamoDBAuditAdapter implements AuditAdapter {
+  readonly name = "dynamodb";
+  private doc!: DynamoDBDocumentClient;
+  private ownsClient = false;
+  private tableName!: string;
+  private ttlDays = 366;
+
+  async init(config: AuditConfig): Promise<void> {
+    if (!config.tableName) throw new Error("dynamodb audit adapter requires config.tableName");
+    this.tableName = String(config.tableName);
+    if (config.ttlDays !== undefined) this.ttlDays = Number(config.ttlDays);
+    if (config.client) {
+      this.doc = config.client as DynamoDBDocumentClient;
+    } else {
+      this.doc = DynamoDBDocumentClient.from(
+        new DynamoDBClient({ region: (config.region as string) ?? process.env.AWS_REGION }),
+      );
+      this.ownsClient = true;
+    }
+  }
+
+  async append(event: AuditEvent): Promise<void> {
+    const eventId = eventIdOf(event);
+    const ttl = Math.floor(Date.now() / 1000) + this.ttlDays * 86_400;
+    try {
+      await this.doc.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: {
+            PK: `CTX#${event.contextId}`,
+            SK: `${SK_PREFIX}${event.timestamp}#${eventId}`,
+            contextId: event.contextId,
+            eventType: event.eventType,
+            actor: event.actor,
+            details: event.details,
+            timestamp: event.timestamp,
+            eventId,
+            ttl,
+          },
+          ConditionExpression: "attribute_not_exists(SK)",
+        }),
+      );
+    } catch (err) {
+      // A duplicate (same SK) means the event is already recorded — idempotent.
+      if ((err as { name?: string }).name === "ConditionalCheckFailedException") return;
+      throw err;
+    }
+  }
+
+  async queryByContext(contextId: string, opts?: QueryOptions): Promise<AuditEvent[]> {
+    const values: Record<string, unknown> = {
+      ":pk": `CTX#${contextId}`,
+      ":pfx": SK_PREFIX,
+    };
+    let filter = "";
+    const names: Record<string, string> = {};
+    if (opts?.since) {
+      values[":since"] = opts.since;
+      names["#ts"] = "timestamp"; // `timestamp` is a DynamoDB reserved word
+      filter = "#ts >= :since";
+    }
+    const res = await this.doc.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: "PK = :pk AND begins_with(SK, :pfx)",
+        ...(filter ? { FilterExpression: filter, ExpressionAttributeNames: names } : {}),
+        ExpressionAttributeValues: values,
+        ConsistentRead: opts?.consistentRead ?? false,
+        ScanIndexForward: false, // newest-first
+        ...(opts?.limit !== undefined ? { Limit: opts.limit } : {}),
+      }),
+    );
+    return (res.Items ?? []).map((it) => ({
+      contextId: it.contextId as string,
+      eventType: it.eventType as string,
+      actor: it.actor as string,
+      details: it.details as Record<string, unknown>,
+      timestamp: it.timestamp as string,
+      eventId: it.eventId as string,
+    }));
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsClient) this.doc.destroy();
+  }
+}
+
+registerProvider("dynamodb", () => new DynamoDBAuditAdapter());

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/providers/index.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/providers/index.ts
@@ -1,0 +1,14 @@
+// ── Adapter Barrel ──────────────────────────────────────────────────
+//
+// Importing this module imports every built-in adapter for its
+// self-registration side effect, then re-exports the registry API.
+//
+
+import "./memory.js";
+import "./postgres.js";
+import "./dynamodb.js";
+import "./sqs.js";
+
+export { getProvider, listProviders, registerProvider } from "./registry.js";
+export type { AuditAdapterFactory } from "./registry.js";
+export type { AuditAdapter } from "./types.js";

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/providers/memory.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/providers/memory.ts
@@ -1,0 +1,41 @@
+import type { AuditAdapter } from "./types.js";
+import type { AuditEvent, QueryOptions } from "../types.js";
+import { registerProvider } from "./registry.js";
+import { eventIdOf } from "../event-id.js";
+
+// ── Memory Adapter ──────────────────────────────────────────────────
+//
+// In-process, append-only ledger for development and tests. Not durable —
+// events are lost on restart. Idempotent on the event id like the durable
+// backends, so tests exercise the same semantics.
+//
+
+class MemoryAuditAdapter implements AuditAdapter {
+  readonly name = "memory";
+  private events: AuditEvent[] = [];
+  private seen = new Set<string>();
+
+  async init(): Promise<void> {}
+
+  async append(event: AuditEvent): Promise<void> {
+    const eventId = eventIdOf(event);
+    if (this.seen.has(eventId)) return; // idempotent
+    this.seen.add(eventId);
+    this.events.push({ ...event, eventId });
+  }
+
+  async queryByContext(contextId: string, opts?: QueryOptions): Promise<AuditEvent[]> {
+    let out = this.events.filter((e) => e.contextId === contextId);
+    if (opts?.since) out = out.filter((e) => e.timestamp >= opts.since!);
+    out = [...out].sort((a, b) => b.timestamp.localeCompare(a.timestamp)); // newest-first
+    if (opts?.limit !== undefined) out = out.slice(0, opts.limit);
+    return out;
+  }
+
+  async close(): Promise<void> {
+    this.events = [];
+    this.seen.clear();
+  }
+}
+
+registerProvider("memory", () => new MemoryAuditAdapter());

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/providers/postgres.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/providers/postgres.ts
@@ -1,0 +1,82 @@
+import pg from "pg";
+import type { Pool } from "pg";
+import type { AuditAdapter } from "./types.js";
+import type { AuditConfig, AuditEvent, QueryOptions } from "../types.js";
+import { registerProvider } from "./registry.js";
+import { eventIdOf } from "../event-id.js";
+
+// ── Postgres Adapter ────────────────────────────────────────────────
+//
+// Immutable append-only ledger in a single table. Create it once:
+//
+//   CREATE TABLE audit_events (
+//     event_id   text PRIMARY KEY,
+//     context_id text NOT NULL,
+//     event_type text NOT NULL,
+//     actor      text NOT NULL,
+//     details    jsonb NOT NULL,
+//     created_at timestamptz NOT NULL DEFAULT now()
+//   );
+//   CREATE INDEX ON audit_events (context_id, created_at DESC);
+//
+// append INSERTs with ON CONFLICT DO NOTHING, so a retry of the same event id is
+// idempotent. config: { connectionString?, pool?, table? } — pass an existing
+// Pool to share the app's, or a connectionString to open one this adapter owns.
+//
+
+class PostgresAuditAdapter implements AuditAdapter {
+  readonly name = "postgres";
+  private pool!: Pool;
+  private ownsPool = false;
+  private table = "audit_events";
+
+  async init(config: AuditConfig): Promise<void> {
+    if (config.table) this.table = String(config.table);
+    if (config.pool) {
+      this.pool = config.pool as Pool;
+    } else {
+      this.pool = new pg.Pool({ connectionString: config.connectionString as string | undefined });
+      this.ownsPool = true;
+    }
+  }
+
+  async append(event: AuditEvent): Promise<void> {
+    const eventId = eventIdOf(event);
+    await this.pool.query(
+      `INSERT INTO ${this.table} (event_id, context_id, event_type, actor, details, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (event_id) DO NOTHING`,
+      [eventId, event.contextId, event.eventType, event.actor, event.details, event.timestamp],
+    );
+  }
+
+  async queryByContext(contextId: string, opts?: QueryOptions): Promise<AuditEvent[]> {
+    const params: unknown[] = [contextId];
+    let sql = `SELECT event_id, context_id, event_type, actor, details, created_at
+               FROM ${this.table} WHERE context_id = $1`;
+    if (opts?.since) {
+      params.push(opts.since);
+      sql += ` AND created_at >= $${params.length}`;
+    }
+    sql += ` ORDER BY created_at DESC`;
+    if (opts?.limit !== undefined) {
+      params.push(opts.limit);
+      sql += ` LIMIT $${params.length}`;
+    }
+    const res = await this.pool.query(sql, params);
+    return res.rows.map((r) => ({
+      contextId: r.context_id as string,
+      eventType: r.event_type as string,
+      actor: r.actor as string,
+      details: r.details as Record<string, unknown>,
+      timestamp: new Date(r.created_at as string).toISOString(),
+      eventId: r.event_id as string,
+    }));
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsPool) await this.pool.end();
+  }
+}
+
+registerProvider("postgres", () => new PostgresAuditAdapter());

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/providers/registry.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/providers/registry.ts
@@ -1,0 +1,32 @@
+import type { AuditAdapter } from "./types.js";
+
+// ── Adapter Registry ────────────────────────────────────────────────
+//
+// Central registry for audit adapter factories. Each adapter module
+// self-registers by calling registerProvider() at import time. Consumer
+// code calls getProvider() to obtain a fresh adapter instance.
+//
+
+export type AuditAdapterFactory = () => AuditAdapter;
+
+const factories = new Map<string, AuditAdapterFactory>();
+
+export function registerProvider(name: string, factory: AuditAdapterFactory): void {
+  if (factories.has(name)) {
+    throw new Error(`Audit adapter "${name}" is already registered`);
+  }
+  factories.set(name, factory);
+}
+
+export function getProvider(name: string): AuditAdapter {
+  const factory = factories.get(name);
+  if (!factory) {
+    const available = Array.from(factories.keys()).join(", ") || "(none)";
+    throw new Error(`Audit adapter "${name}" not found. Available: ${available}`);
+  }
+  return factory();
+}
+
+export function listProviders(): string[] {
+  return Array.from(factories.keys());
+}

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/providers/sqs.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/providers/sqs.ts
@@ -1,0 +1,87 @@
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import type { AuditAdapter } from "./types.js";
+import type { AuditConfig, AuditEvent, QueryOptions } from "../types.js";
+import { registerProvider } from "./registry.js";
+import { eventIdOf } from "../event-id.js";
+
+// ── SQS Adapter ─────────────────────────────────────────────────────
+//
+// At-least-once delivery to a FIFO queue, drained by a separate consumer to a
+// durable, queryable store (DynamoDB + S3). append sends with MessageGroupId =
+// contextId (per-context ordering) and MessageDeduplicationId = the event id
+// (dedup). On a send failure it falls back to a DLQ so an event is never
+// silently dropped; if the DLQ also fails it throws. Because the queue is
+// write-only from this side, queryByContext is unsupported — query the drained
+// store instead. config: { queueUrl, dlqUrl?, client?, onCounter? }.
+//
+
+type Counter = (metric: string) => void;
+
+class SQSAuditAdapter implements AuditAdapter {
+  readonly name = "sqs";
+  private client!: SQSClient;
+  private ownsClient = false;
+  private queueUrl!: string;
+  private dlqUrl?: string;
+  private onCounter: Counter = () => {};
+
+  async init(config: AuditConfig): Promise<void> {
+    if (!config.queueUrl) throw new Error("sqs audit adapter requires config.queueUrl");
+    this.queueUrl = String(config.queueUrl);
+    if (config.dlqUrl) this.dlqUrl = String(config.dlqUrl);
+    if (typeof config.onCounter === "function") this.onCounter = config.onCounter as Counter;
+    if (config.client) {
+      this.client = config.client as SQSClient;
+    } else {
+      this.client = new SQSClient({ region: (config.region as string) ?? process.env.AWS_REGION });
+      this.ownsClient = true;
+    }
+  }
+
+  async append(event: AuditEvent): Promise<void> {
+    const eventId = eventIdOf(event);
+    const body = JSON.stringify({ ...event, eventId });
+    try {
+      await this.client.send(
+        new SendMessageCommand({
+          QueueUrl: this.queueUrl,
+          MessageBody: body,
+          MessageGroupId: event.contextId,
+          MessageDeduplicationId: eventId,
+        }),
+      );
+      this.onCounter("audit_sqs_ok");
+    } catch (err) {
+      if (!this.dlqUrl) {
+        this.onCounter("audit_sqs_error");
+        throw err;
+      }
+      try {
+        await this.client.send(
+          new SendMessageCommand({
+            QueueUrl: this.dlqUrl,
+            MessageBody: JSON.stringify({ ...event, eventId, failureReason: String(err) }),
+            MessageGroupId: event.contextId,
+            MessageDeduplicationId: eventId,
+          }),
+        );
+        this.onCounter("audit_sqs_dlq");
+      } catch (dlqErr) {
+        this.onCounter("audit_sqs_total_loss");
+        throw dlqErr;
+      }
+    }
+  }
+
+  async queryByContext(_contextId: string, _opts?: QueryOptions): Promise<AuditEvent[]> {
+    throw new Error(
+      "sqs audit adapter is write-only — query the store the consumer drains to (DynamoDB/S3), not the queue",
+    );
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsClient) this.client.destroy();
+  }
+}
+
+registerProvider("sqs", () => new SQSAuditAdapter());

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/providers/types.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/providers/types.ts
@@ -1,0 +1,31 @@
+// ── Audit Adapter Interface ─────────────────────────────────────────
+//
+// Every storage backend implements this. The registry pattern lets new
+// adapters self-register at import time; consumers call getProvider().
+//
+
+import type { AuditConfig, AuditEvent, QueryOptions } from "../types.js";
+
+export interface AuditAdapter {
+  /** Unique adapter name (e.g. "memory", "postgres", "dynamodb", "sqs"). */
+  readonly name: string;
+
+  /** Initialize with configuration (open the pool/client). */
+  init(config: AuditConfig): Promise<void>;
+
+  /**
+   * Append one event. Append-only — never updates or deletes. Idempotent on the
+   * event's id where the backend supports a conditional write.
+   */
+  append(event: AuditEvent): Promise<void>;
+
+  /**
+   * Read a context's events, newest-first. Throws on write-only backends (e.g.
+   * the SQS adapter, whose events are drained to a queryable store by a
+   * consumer) — those are queried on the drained store, not here.
+   */
+  queryByContext(contextId: string, opts?: QueryOptions): Promise<AuditEvent[]>;
+
+  /** Release connections. */
+  close(): Promise<void>;
+}

--- a/templates/module-audit-ledger-ts/skeleton/src/audit/types.ts
+++ b/templates/module-audit-ledger-ts/skeleton/src/audit/types.ts
@@ -1,0 +1,45 @@
+// ── Audit Ledger Core Types ─────────────────────────────────────────
+//
+// Shared shapes for audit events and adapter configuration. These are
+// backend-agnostic — every storage adapter works against the same event.
+//
+
+/**
+ * A single audit record. `contextId` is the partition the event belongs to —
+ * the app's domain key (an incident id, a pipeline run id, a user id). The
+ * meaning of an event lives in `eventType` + `details`; this module never
+ * interprets them, it only persists and reads them back.
+ */
+export interface AuditEvent {
+  /** Domain partition key (incident id / run id / user id). */
+  contextId: string;
+  /** Event discriminator, e.g. "APPROVED", "HUMAN_EDIT", "query". */
+  eventType: string;
+  /** Who/what caused the event (user id, "system", a service name). */
+  actor: string;
+  /** Event-specific payload. Scrub secrets/PII before passing it in. */
+  details: Record<string, unknown>;
+  /** ISO-8601 timestamp. Defaulted to now() by the ledger if omitted. */
+  timestamp: string;
+  /**
+   * Idempotency key. Adapters that support conditional writes use it to make
+   * append exactly-once; if omitted the ledger derives a deterministic id from
+   * the event content (see event-id.ts).
+   */
+  eventId?: string;
+}
+
+/** Provider-specific connection/configuration. */
+export interface AuditConfig {
+  [key: string]: unknown;
+}
+
+/** Options for reading a context's events. */
+export interface QueryOptions {
+  /** Only events at or after this ISO-8601 timestamp. */
+  since?: string;
+  /** Strongly-consistent read (DynamoDB) — required when a read gates a write. */
+  consistentRead?: boolean;
+  /** Cap the number of events returned. */
+  limit?: number;
+}

--- a/templates/module-audit-ledger-ts/skeleton/tsconfig.json
+++ b/templates/module-audit-ledger-ts/skeleton/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2024"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/module-audit-ledger-ts/skeleton/vitest.config.ts
+++ b/templates/module-audit-ledger-ts/skeleton/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/templates/module-audit-ledger-ts/template.yaml
+++ b/templates/module-audit-ledger-ts/template.yaml
@@ -1,0 +1,56 @@
+apiVersion: nanohype/v1
+
+name: module-audit-ledger-ts
+displayName: "Module: Audit Ledger"
+description: >
+  Append-only audit ledger with pluggable storage backends. One AuditLedger
+  port (append + queryByContext) over four adapters: an in-memory store for
+  development, Postgres (immutable append), DynamoDB (conditional write +
+  strongly-consistent read), and SQS→consumer (FIFO with a DLQ fallback for
+  at-least-once delivery). The module owns persistence only — domain logic such
+  as approval gates, edit-distance scoring, and PII scrubbing stays in the app
+  that owns the events.
+version: "0.1.0"
+license: Apache-2.0
+persona: [engineering]
+category: composable-modules
+tags: [audit, ledger, compliance, postgres, dynamodb, sqs, typescript]
+
+variables:
+  - name: ProjectName
+    type: string
+    placeholder: "__PROJECT_NAME__"
+    description: "Kebab-case project name, used as package name and directory"
+    prompt: "Project name"
+    required: true
+    validation:
+      pattern: "^[a-z][a-z0-9-]*$"
+      message: "Must be lowercase kebab-case starting with a letter"
+
+  - name: Description
+    type: string
+    placeholder: "__DESCRIPTION__"
+    description: "Short project description for package.json and README"
+    prompt: "Project description"
+    default: "Append-only audit ledger with pluggable storage backends"
+
+  - name: AuditProvider
+    type: string
+    placeholder: "__AUDIT_PROVIDER__"
+    description: "Default audit backend (memory, postgres, dynamodb, sqs, or a custom name)"
+    prompt: "Audit backend"
+    default: "memory"
+
+conditionals: []
+
+composition:
+  pairsWith: [k8s-app-tenant, ts-service, agentic-loop]
+  nestsInside: [monorepo]
+
+prerequisites: []
+
+hooks:
+  post:
+    - name: install-dependencies
+      description: "Install npm dependencies"
+      run: "npm install"


### PR DESCRIPTION
The four tenant apps each hand-roll audit persistence over a different store. This extracts the **storage mechanics** into a composable module — one `AuditLedger` port over pluggable adapters — while each app's domain logic stays put.

**The module** (registry pattern, like `module-cache-ts`): an `AuditLedger` facade (`append` + `queryByContext`) over self-registering adapters —
- **memory** — in-process, the testable default
- **postgres** — immutable append-only table, `ON CONFLICT DO NOTHING` (idempotent)
- **dynamodb** — single-table (`PK=CTX#<id>` / `SK=AUDIT#<ts>#<eventId>`), conditional write for idempotency, TTL, strongly-consistent reads on demand
- **sqs** — at-least-once to a FIFO queue with a DLQ fallback; write-only (a consumer drains it to a queryable store)

Event ids are content-addressed (`event-id.ts`, pure) so an append is idempotent across every backend. OTel counters: `audit_append_total` + `audit_query_total`.

**Boundary:** storage only — the approval gate, edit-distance scoring, and PII scrubbing the apps wrap around it stay in the apps (README states this). Extracted from digest-pipeline (Postgres), incident-response (DynamoDB), slack-knowledge-bot (SQS).

**Composite:** `platform-tenant` gains a conditional `module-audit-ledger-ts` member (`IncludeAuditLedger`), completing the AI building blocks.

**Verified:** `validate.sh` + `validate:catalog` + `validate:manifest`; typecheck clean; 11 tests pass (event-id, registry, memory ledger end-to-end); eslint clean; the composite SDK-renders the audit package when enabled.

Final deliverable of the lift-tenants-into-the-catalog series (Phase A complete).