### PR TITLE
standards: add the resource-tagging taxonomy

### DIFF
--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -21,6 +21,7 @@ const STANDARD_NAMES: StandardName[] = [
   'llm-policy',
   'quality-rubric-dimensions',
   'testing-rubric',
+  'resource-tagging',
 ];
 
 interface StaticResource {
@@ -48,7 +49,7 @@ export function listResources(): StaticResource[] {
       uri: 'nanohype://standards',
       name: 'nanohype standards (bundle)',
       description:
-        'All published standards files bundled under one resource. Includes language toolchain, version currency, platform-tenant contract, LLM policy, quality-rubric dimension names, and the testing rubric.',
+        'All published standards files bundled under one resource. Includes language toolchain, version currency, platform-tenant contract, LLM policy, quality-rubric dimension names, the testing rubric, and the resource-tagging taxonomy.',
       mimeType: 'application/json',
     },
   ];

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -17,6 +17,7 @@ const STANDARD_NAMES: StandardName[] = [
   'llm-policy',
   'quality-rubric-dimensions',
   'testing-rubric',
+  'resource-tagging',
 ];
 
 interface ToolDescriptor {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "validate": "for t in templates/*/; do ./scripts/validate.sh \"$t\" || exit 1; done",
     "validate:schema": "ajv validate -s schemas/template.schema.json -d 'templates/*/template.yaml' --spec=draft2020 --strict=false",
     "validate:catalog": "./scripts/validate-catalog.sh",
-    "validate:standards": "ajv validate -s schemas/standards.schema.json -d 'standards/*.json' --spec=draft2020 --strict=false",
+    "validate:standards": "ajv validate -s schemas/standards.schema.json -d 'standards/*.json' --spec=draft2020 --strict=false && node scripts/check-tagging-standard.mjs",
     "validate:manifest": "ajv validate -s schemas/catalog.schema.json -d catalog.json --spec=draft2020 --strict=false",
     "generate:catalog": "node scripts/generate-catalog.mjs",
     "verify:catalog": "node scripts/generate-catalog.mjs && git diff --exit-code -I generated_at catalog.json",

--- a/schemas/standards.schema.json
+++ b/schemas/standards.schema.json
@@ -16,7 +16,8 @@
         "nanohype/standards/platform-tenant-contract",
         "nanohype/standards/llm-policy",
         "nanohype/standards/quality-rubric-dimensions",
-        "nanohype/standards/testing-rubric"
+        "nanohype/standards/testing-rubric",
+        "nanohype/standards/resource-tagging"
       ]
     },
     "version": {
@@ -233,6 +234,60 @@
                     "severity": { "type": "string", "enum": ["reject", "warn"] }
                   }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "kind": { "const": "nanohype/standards/resource-tagging" } } },
+      "then": {
+        "properties": {
+          "content": {
+            "type": "object",
+            "required": ["transforms", "reserved_prefixes", "dimensions", "required_by_surface"],
+            "properties": {
+              "transforms": { "type": "object", "additionalProperties": { "type": "string" } },
+              "reserved_prefixes": {
+                "type": "object",
+                "required": ["k8s", "otel", "app_extension"],
+                "properties": {
+                  "k8s": { "type": "array", "items": { "type": "string" } },
+                  "otel": { "type": "array", "items": { "type": "string" } },
+                  "app_extension": { "type": "object", "additionalProperties": { "type": "string" } }
+                }
+              },
+              "dimensions": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": ["id", "tier", "meaning", "render"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+                    "tier": { "type": "string", "enum": ["required", "recommended", "contextual"] },
+                    "meaning": { "type": "string" },
+                    "render": {
+                      "type": "object",
+                      "required": ["aws", "azure", "gcp", "k8s", "otel"],
+                      "additionalProperties": false,
+                      "properties": {
+                        "aws": { "type": ["string", "null"] },
+                        "azure": { "type": ["string", "null"] },
+                        "gcp": { "type": ["string", "null"] },
+                        "k8s": { "type": ["string", "null"] },
+                        "otel": { "type": ["string", "null"] }
+                      }
+                    }
+                  }
+                }
+              },
+              "required_by_surface": {
+                "type": "object",
+                "required": ["aws", "azure", "gcp", "k8s", "otel"],
+                "additionalProperties": { "type": "array", "items": { "type": "string" } }
               }
             }
           }

--- a/scripts/check-tagging-standard.mjs
+++ b/scripts/check-tagging-standard.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Cross-checks standards/resource-tagging.json beyond what JSON Schema can express:
+// the denormalized required_by_surface lists must agree with dimensions[].
+//
+//   - aws / azure / gcp: the required set is the EXACT render of every required-tier
+//     dimension that applies to that cloud (a full derivation — cloudgov reads it verbatim).
+//   - k8s / otel: every listed key must be a real render of some dimension (no typos /
+//     orphans); the required subset here is curated, not a full derivation.
+//
+// Exits non-zero with a precise message on any drift.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const path = join(here, '..', 'standards', 'resource-tagging.json');
+
+const std = JSON.parse(readFileSync(path, 'utf-8'));
+const { dimensions, required_by_surface } = std.content;
+const errors = [];
+
+const setEq = (a, b) => a.length === b.length && [...a].sort().join('|') === [...b].sort().join('|');
+
+// Full-derivation surfaces: required_by_surface must equal the rendered required dims exactly.
+for (const surface of ['aws', 'azure', 'gcp']) {
+  const derived = dimensions
+    .filter((d) => d.tier === 'required' && d.render[surface] != null)
+    .map((d) => d.render[surface]);
+  const declared = required_by_surface[surface] ?? [];
+  if (!setEq(derived, declared)) {
+    errors.push(
+      `required_by_surface.${surface} disagrees with dimensions[]:\n` +
+        `  derived (required-tier renders): ${[...derived].sort().join(', ')}\n` +
+        `  declared:                        ${[...declared].sort().join(', ')}`,
+    );
+  }
+}
+
+// Curated surfaces: every declared key must be a real render of some dimension.
+for (const surface of ['k8s', 'otel']) {
+  const known = new Set(dimensions.map((d) => d.render[surface]).filter((v) => v != null));
+  for (const key of required_by_surface[surface] ?? []) {
+    if (!known.has(key)) {
+      errors.push(`required_by_surface.${surface} lists "${key}", which no dimension renders.`);
+    }
+  }
+}
+
+// Every required-tier dimension must render on at least one surface (a required tag nobody
+// can carry is a mistake).
+for (const d of dimensions) {
+  if (d.tier === 'required' && Object.values(d.render).every((v) => v == null)) {
+    errors.push(`dimension "${d.id}" is required but renders on no surface.`);
+  }
+}
+
+if (errors.length) {
+  console.error('resource-tagging.json consistency check FAILED:\n');
+  for (const e of errors) console.error('  - ' + e + '\n');
+  process.exit(1);
+}
+console.log('resource-tagging.json consistency check passed.');

--- a/sdk/src/standards.ts
+++ b/sdk/src/standards.ts
@@ -4,6 +4,7 @@ import type {
   LLMPolicyStandard,
   PlatformTenantContractStandard,
   QualityRubricDimensionsStandard,
+  ResourceTaggingStandard,
   Standard,
   StandardName,
   Standards,
@@ -19,6 +20,7 @@ const ALL_STANDARDS: StandardName[] = [
   'llm-policy',
   'quality-rubric-dimensions',
   'testing-rubric',
+  'resource-tagging',
 ];
 
 const EXPECTED_KIND: Record<StandardName, Standard['kind']> = {
@@ -28,6 +30,7 @@ const EXPECTED_KIND: Record<StandardName, Standard['kind']> = {
   'llm-policy': 'nanohype/standards/llm-policy',
   'quality-rubric-dimensions': 'nanohype/standards/quality-rubric-dimensions',
   'testing-rubric': 'nanohype/standards/testing-rubric',
+  'resource-tagging': 'nanohype/standards/resource-tagging',
 };
 
 /**
@@ -60,7 +63,7 @@ export async function loadStandard(
  * than scanning the union).
  */
 export async function loadStandards(source: CatalogSource): Promise<Standards> {
-  const [toolchain, currency, contract, llm, rubric, testing] = await Promise.all(
+  const [toolchain, currency, contract, llm, rubric, testing, tagging] = await Promise.all(
     ALL_STANDARDS.map((name) => loadStandard(source, name)),
   );
   return {
@@ -70,5 +73,6 @@ export async function loadStandards(source: CatalogSource): Promise<Standards> {
     'llm-policy': llm as LLMPolicyStandard,
     'quality-rubric-dimensions': rubric as QualityRubricDimensionsStandard,
     'testing-rubric': testing as TestingRubricStandard,
+    'resource-tagging': tagging as ResourceTaggingStandard,
   };
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -160,7 +160,8 @@ export type StandardName =
   | 'platform-tenant-contract'
   | 'llm-policy'
   | 'quality-rubric-dimensions'
-  | 'testing-rubric';
+  | 'testing-rubric'
+  | 'resource-tagging';
 
 /** Per-language toolchain: install + four-phase commands + manifest/registry metadata. */
 export interface Toolchain {
@@ -253,6 +254,38 @@ export interface TestingRubricStandard {
   };
 }
 
+/** One canonical tag/label dimension and how it renders on each surface. A null render means the dimension does not apply to that surface. */
+export interface TagDimension {
+  id: string;
+  tier: 'required' | 'recommended' | 'contextual';
+  meaning: string;
+  render: {
+    aws: string | null;
+    azure: string | null;
+    gcp: string | null;
+    k8s: string | null;
+    otel: string | null;
+  };
+}
+
+/** Standards file: resource tagging/labeling taxonomy. The single source of truth for the canonical tag set and its per-surface rendering. */
+export interface ResourceTaggingStandard {
+  kind: 'nanohype/standards/resource-tagging';
+  version: string;
+  title: string;
+  summary: string;
+  content: {
+    transforms: Record<string, string>;
+    reserved_prefixes: {
+      k8s: string[];
+      otel: string[];
+      app_extension: Record<string, string>;
+    };
+    dimensions: TagDimension[];
+    required_by_surface: Record<'aws' | 'azure' | 'gcp' | 'k8s' | 'otel', string[]>;
+  };
+}
+
 /** Union of every published standard. Discriminated by `kind`. */
 export type Standard =
   | LanguageToolchainStandard
@@ -260,7 +293,8 @@ export type Standard =
   | PlatformTenantContractStandard
   | LLMPolicyStandard
   | QualityRubricDimensionsStandard
-  | TestingRubricStandard;
+  | TestingRubricStandard
+  | ResourceTaggingStandard;
 
 /**
  * Parsed bundle of every published standard. The shape an external client
@@ -274,6 +308,7 @@ export interface Standards {
   'llm-policy': LLMPolicyStandard;
   'quality-rubric-dimensions': QualityRubricDimensionsStandard;
   'testing-rubric': TestingRubricStandard;
+  'resource-tagging': ResourceTaggingStandard;
 }
 
 /** The raw markdown content of a supporting repo's AGENTS.md. */

--- a/standards/README.md
+++ b/standards/README.md
@@ -104,6 +104,29 @@ The deeper per-language enforcement (how each runner is configured, the REJECT c
 
 ---
 
+## Resource tagging — `resource-tagging.json`
+
+The canonical tag/label taxonomy every cloud resource and k8s object on the stack carries. One vendor-neutral dimension set, rendered idiomatically per surface. Read it when injecting tags in `landing-zone`, stamping labels in the operator or a tenant chart, or auditing tags with `cloudgov`.
+
+The taxonomy is three tiers:
+
+- **Required (10)** — the billing + ownership + security skeleton, auto-injected on every resource: `environment`, `managed-by`, `project`, `repository`, `cost-center`, `business-unit`, `data-classification`, `compliance`, `component`, `team`.
+- **Recommended (5)** — the *own / trace / expire* idiom: `owner` (escalation handle), `revision` (deployed source rev), `provisioner` (the factory job that created it), `lifecycle` (`ephemeral` | `persistent`), `expiry` (the date an ephemeral resource is reapable). All auto-derivable; `lifecycle`+`expiry` make orphan-reaping policy-driven, `provisioner`+`revision` carry provenance.
+- **Contextual (4)** — applied only where meaningful: `tenant`, `platform` (per-tenant / per-app identity), `model-family`, `model-id` (AI-workload OTel only).
+
+Each dimension renders per surface by deterministic transform:
+
+- **AWS / Azure tag key** — PascalCase (`cost-center` → `CostCenter`).
+- **GCP label key** — snake_case (`cost-center` → `cost_center`); the value is lower-cased with `-`/`/` mapped to `_` and truncated to 63 (GCP labels accept only `[a-z0-9_-]`).
+- **k8s label** — well-known dimensions under `app.kubernetes.io/*`, agent/tenant identity under `agents.nanohype.dev/*`, and org governance metadata under `platform.nanohype.dev/*`. These three prefixes are reserved.
+- **OTel attribute** — the narrow operational-identity subset only: `deployment.environment`, `service.version`, and the reserved `agents.*` namespace (`agents.tenant`, `agents.platform`, `agents.model_family`, `agents.model_id`). Billing metadata stays out of OTel.
+
+Apps extend with their own tags under a per-app namespace that avoids the reserved prefixes — `<app>.tenants.nanohype.dev/*` (k8s), `app:<key>` (AWS/Azure), `app_<key>` (GCP), their own OTel namespace. Audits only gate the required tier, so extensions never trip the gate.
+
+The `required_by_surface` block is the flat, directly-consumable list of required keys per surface — `cloudgov tags --standard-file` reads `required_by_surface.aws` to gate CI without re-deriving the rendering.
+
+---
+
 ## Versioning
 
 Each file declares its `version` (a positive integer). Bump the version field on any breaking shape change. Agents that consume these standards should pin to a major version range (the `version` field == major; minor evolution within a major must be backwards-compatible).

--- a/standards/resource-tagging.json
+++ b/standards/resource-tagging.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "../schemas/standards.schema.json",
+  "kind": "nanohype/standards/resource-tagging",
+  "version": "1",
+  "title": "Resource tagging and labeling standard",
+  "summary": "The canonical org-wide tag/label taxonomy every cloud resource and k8s object on the nanohype stack carries. Defines vendor-neutral dimensions, their per-surface rendering (AWS/Azure tag keys, GCP labels, k8s labels, OTel attributes), the deterministic casing transforms, the reserved namespaces, and which dimensions are required. cloudgov reads the required-tier keys from this file to gate CI; landing-zone and the eks-agent-platform operator inject them; tenant charts label workloads from it.",
+  "content": {
+    "transforms": {
+      "aws": "Render the canonical kebab-case id as PascalCase (split on '-', capitalize each part, join). cost-center -> CostCenter.",
+      "azure": "Same as aws (PascalCase). Azure tag keys are case-insensitive with a broad charset; reuse the AWS rendering for cross-cloud consistency.",
+      "gcp_key": "Render the canonical id as snake_case (replace '-' with '_'; the id is already lowercase). cost-center -> cost_center.",
+      "gcp_value": "Sanitize the value: lower-case it, replace '-' with '_', replace '/' with '_', truncate to 63 chars. GCP label values accept only [a-z0-9_-]. nanohype/landing-zone -> nanohype_landing_zone.",
+      "k8s": "Well-known dimensions render under app.kubernetes.io/<leaf>; org dimensions render under <group>.nanohype.dev/<id>. The label value must match [a-z0-9A-Z._-]{0,63}.",
+      "otel": "Dotted lower-case attribute names. Reserved namespace agents.* (tenant/platform/model identity) plus the well-known deployment.environment and service.version."
+    },
+    "reserved_prefixes": {
+      "k8s": [
+        "app.kubernetes.io/",
+        "platform.nanohype.dev/",
+        "agents.nanohype.dev/",
+        "tenants.nanohype.dev/",
+        "governance.nanohype.dev/"
+      ],
+      "otel": [
+        "agents.",
+        "deployment.",
+        "service."
+      ],
+      "app_extension": {
+        "k8s": "<app>.tenants.nanohype.dev/<key>",
+        "aws": "app:<key>",
+        "azure": "app:<key>",
+        "gcp": "app_<key>",
+        "otel": "<app-namespace>.<key> (never under agents.*)"
+      }
+    },
+    "dimensions": [
+      {
+        "id": "environment",
+        "tier": "required",
+        "meaning": "Deploy stage: dev, staging, production, or org.",
+        "render": { "aws": "Environment", "azure": "Environment", "gcp": "environment", "k8s": "platform.nanohype.dev/environment", "otel": "deployment.environment" }
+      },
+      {
+        "id": "managed-by",
+        "tier": "required",
+        "meaning": "The tool that owns the resource lifecycle. Value: opentofu (substrate) or eks-agent-platform (operator-reconciled).",
+        "render": { "aws": "ManagedBy", "azure": "ManagedBy", "gcp": "managed_by", "k8s": "app.kubernetes.io/managed-by", "otel": null }
+      },
+      {
+        "id": "project",
+        "tier": "required",
+        "meaning": "The substrate project the resource belongs to. Value: landing-zone.",
+        "render": { "aws": "Project", "azure": "Project", "gcp": "project", "k8s": "platform.nanohype.dev/project", "otel": null }
+      },
+      {
+        "id": "repository",
+        "tier": "required",
+        "meaning": "The source repository as org/name (e.g. nanohype/landing-zone).",
+        "render": { "aws": "Repository", "azure": "Repository", "gcp": "repository", "k8s": "platform.nanohype.dev/repository", "otel": null }
+      },
+      {
+        "id": "cost-center",
+        "tier": "required",
+        "meaning": "Billing rollup unit (e.g. platform-engineering).",
+        "render": { "aws": "CostCenter", "azure": "CostCenter", "gcp": "cost_center", "k8s": "platform.nanohype.dev/cost-center", "otel": null }
+      },
+      {
+        "id": "business-unit",
+        "tier": "required",
+        "meaning": "Organizational rollup above cost-center (e.g. engineering).",
+        "render": { "aws": "BusinessUnit", "azure": "BusinessUnit", "gcp": "business_unit", "k8s": "platform.nanohype.dev/business-unit", "otel": null }
+      },
+      {
+        "id": "data-classification",
+        "tier": "required",
+        "meaning": "Data sensitivity: public, internal, confidential, or restricted.",
+        "render": { "aws": "DataClassification", "azure": "DataClassification", "gcp": "data_classification", "k8s": "platform.nanohype.dev/data-classification", "otel": null }
+      },
+      {
+        "id": "compliance",
+        "tier": "required",
+        "meaning": "Compliance regime: soc2, hipaa, or none.",
+        "render": { "aws": "Compliance", "azure": "Compliance", "gcp": "compliance", "k8s": "platform.nanohype.dev/compliance", "otel": null }
+      },
+      {
+        "id": "component",
+        "tier": "required",
+        "meaning": "The substrate component or workload role (network, cluster, llm, ...).",
+        "render": { "aws": "Component", "azure": "Component", "gcp": "component", "k8s": "app.kubernetes.io/component", "otel": null }
+      },
+      {
+        "id": "team",
+        "tier": "required",
+        "meaning": "The owning team that operates the resource (e.g. platform).",
+        "render": { "aws": "Team", "azure": "Team", "gcp": "team", "k8s": "platform.nanohype.dev/team", "otel": null }
+      },
+      {
+        "id": "owner",
+        "tier": "recommended",
+        "meaning": "Accountable handle for escalation (a team or GitHub-team slug). Auto-filled from the env-level owner, defaulting to team when unset; never hand-entered per resource.",
+        "render": { "aws": "Owner", "azure": "Owner", "gcp": "owner", "k8s": "platform.nanohype.dev/owner", "otel": null }
+      },
+      {
+        "id": "revision",
+        "tier": "recommended",
+        "meaning": "The deployed source revision (a short git SHA or chart appVersion) for provenance and rollback correlation.",
+        "render": { "aws": "Revision", "azure": "Revision", "gcp": "revision", "k8s": "app.kubernetes.io/version", "otel": "service.version" }
+      },
+      {
+        "id": "provisioner",
+        "tier": "recommended",
+        "meaning": "The factory job or CI run that created the resource (a pipeline run id). Feeds provenance and attribution.",
+        "render": { "aws": "Provisioner", "azure": "Provisioner", "gcp": "provisioner", "k8s": "platform.nanohype.dev/provisioner", "otel": null }
+      },
+      {
+        "id": "lifecycle",
+        "tier": "recommended",
+        "meaning": "Whether the resource is reapable: ephemeral or persistent. Ephemeral resources past their expiry are cleanup candidates.",
+        "render": { "aws": "Lifecycle", "azure": "Lifecycle", "gcp": "lifecycle", "k8s": "platform.nanohype.dev/lifecycle", "otel": null }
+      },
+      {
+        "id": "expiry",
+        "tier": "recommended",
+        "meaning": "An ISO-8601 date (YYYY-MM-DD) after which an ephemeral resource is safe to reap. Set by the vend layer as now + ttl; omit on persistent resources.",
+        "render": { "aws": "Expiry", "azure": "Expiry", "gcp": "expiry", "k8s": "platform.nanohype.dev/expiry", "otel": null }
+      },
+      {
+        "id": "tenant",
+        "tier": "contextual",
+        "meaning": "The Platform tenant a per-tenant resource belongs to. Applies only to multi-tenant components and per-tenant cloud resources.",
+        "render": { "aws": "Tenant", "azure": "Tenant", "gcp": "tenant", "k8s": "agents.nanohype.dev/tenant", "otel": "agents.tenant" }
+      },
+      {
+        "id": "platform",
+        "tier": "contextual",
+        "meaning": "The Platform CR name (the app). k8s and OTel only — never a cloud tag.",
+        "render": { "aws": null, "azure": null, "gcp": null, "k8s": "agents.nanohype.dev/platform", "otel": "agents.platform" }
+      },
+      {
+        "id": "model-family",
+        "tier": "contextual",
+        "meaning": "The LLM family for AI workloads. OTel only — runtime cost attribution.",
+        "render": { "aws": null, "azure": null, "gcp": null, "k8s": null, "otel": "agents.model_family" }
+      },
+      {
+        "id": "model-id",
+        "tier": "contextual",
+        "meaning": "The full Bedrock model id for AI workloads. OTel only — runtime cost attribution.",
+        "render": { "aws": null, "azure": null, "gcp": null, "k8s": null, "otel": "agents.model_id" }
+      }
+    ],
+    "required_by_surface": {
+      "aws": ["Environment", "ManagedBy", "Project", "Repository", "CostCenter", "BusinessUnit", "DataClassification", "Compliance", "Component", "Team"],
+      "azure": ["Environment", "ManagedBy", "Project", "Repository", "CostCenter", "BusinessUnit", "DataClassification", "Compliance", "Component", "Team"],
+      "gcp": ["environment", "managed_by", "project", "repository", "cost_center", "business_unit", "data_classification", "compliance", "component", "team"],
+      "k8s": ["app.kubernetes.io/managed-by", "app.kubernetes.io/component", "platform.nanohype.dev/environment", "platform.nanohype.dev/team"],
+      "otel": ["agents.tenant", "agents.platform"]
+    }
+  }
+}


### PR DESCRIPTION
The canonical org-wide tag/label taxonomy as a published nanohype standard — the source of truth the substrate conforms to and cloudgov gates against. Phase 1 of the define → conform → enforce rollout (this PR is pure addition; no infra touched).

## The taxonomy (`standards/resource-tagging.json`)

19 dimensions, three tiers, each rendered idiomatically per surface (AWS/Azure tags · GCP labels · k8s labels · OTel attrs):

- **Required (10)** — billing + ownership + security skeleton, exactly what `landing-zone/live/root.hcl` already injects on AWS/GCP.
- **Recommended (5)** — the *own / trace / expire* idiom: `owner`, `revision`, `provisioner`, `lifecycle`, `expiry`. `lifecycle`+`expiry` make orphan-reaping policy-driven; `provisioner`+`revision` carry provenance.
- **Contextual (4)** — `tenant`, `platform`, `model-family`, `model-id`.

k8s renders anchor on the three prefixes already in the codebase (`app.kubernetes.io/*`, `agents.nanohype.dev/*`, `platform.nanohype.dev/*`) — no fourth invented. OTel stays the narrow `agents.*` + `deployment.environment` + `service.version` subset (no billing metadata).

## Wiring

- `schemas/standards.schema.json` — kind enum + per-kind content block.
- `sdk` — types, `Standard` union + `Standards` bundle, `ALL_STANDARDS`/`EXPECTED_KIND`, loader.
- `mcp-server` — `STANDARD_NAMES` so `list_standards` / `get_standard` / `nanohype://standards/resource-tagging` serve it.
- `standards/README.md` — normative section.
- `scripts/check-tagging-standard.mjs` — consistency check (wired into `validate:standards`) asserting `required_by_surface` agrees with `dimensions[]`.

## Verification

`validate:standards` (schema + consistency) green · SDK typecheck + 82 tests green · MCP typecheck + 26 tests green.