### PR TITLE
tenant-chart-base: emit resource-tagging governance labels

### DIFF
--- a/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_helpers.tpl
+++ b/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_helpers.tpl
@@ -30,7 +30,11 @@ Fully qualified app name.
 
 {{/*
 Common labels. The tenant/platform labels come from the OTel resource attributes
-the consumer sets, falling back to the chart name for the platform.
+the consumer sets, falling back to the chart name for the platform. Any
+`.Values.commonLabels` the consumer sets are merged in verbatim — that's where
+the resource-tagging governance labels land (platform.nanohype.dev/environment,
+.../team, .../cost-center, …) under the standard's reserved k8s prefixes. These
+go on metadata + pod-template labels only, never on the immutable selectorLabels.
 */}}
 {{- define "tenant-chart-base.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
@@ -41,6 +45,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 agents.nanohype.dev/tenant: {{ (index .Values.otel.resourceAttributes "agents.tenant") | default "unknown" | quote }}
 agents.nanohype.dev/platform: {{ (index .Values.otel.resourceAttributes "agents.platform") | default .Chart.Name | quote }}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/templates/k8s-app-tenant/skeleton/chart/values-dev.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-dev.yaml
@@ -4,6 +4,9 @@ image:
 
 replicaCount: 1
 
+commonLabels:
+  platform.nanohype.dev/environment: dev
+
 # Set from landing-zone's __APP_NAME__-platform component (dev):
 #   terraform output -raw irsa_role_arn
 # aws:

--- a/templates/k8s-app-tenant/skeleton/chart/values-production.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-production.yaml
@@ -4,6 +4,9 @@ image:
 
 replicaCount: 3
 
+commonLabels:
+  platform.nanohype.dev/environment: production
+
 resources:
   requests:
     cpu: 250m

--- a/templates/k8s-app-tenant/skeleton/chart/values-staging.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-staging.yaml
@@ -4,6 +4,9 @@ image:
 
 replicaCount: 2
 
+commonLabels:
+  platform.nanohype.dev/environment: staging
+
 # Set from landing-zone's __APP_NAME__-platform component (staging):
 #   terraform output -raw irsa_role_arn
 # aws:

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -132,6 +132,14 @@ otel:
     agents.tenant: __TENANT__
     agents.platform: __APP_NAME__
 
+# Resource-tagging governance labels (the resource-tagging standard). Merged onto
+# every resource's metadata + pod labels by tenant-chart-base.labels, under the
+# reserved k8s prefixes. environment is set per-env in values-{env}.yaml; add
+# platform.nanohype.dev/cost-center / .../owner here if you want them in-cluster.
+commonLabels:
+  platform.nanohype.dev/team: __TENANT__
+  app.kubernetes.io/component: __PERSONA__
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/templates/tenant-chart-base/skeleton/chart/templates/_helpers.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_helpers.tpl
@@ -30,7 +30,11 @@ Fully qualified app name.
 
 {{/*
 Common labels. The tenant/platform labels come from the OTel resource attributes
-the consumer sets, falling back to the chart name for the platform.
+the consumer sets, falling back to the chart name for the platform. Any
+`.Values.commonLabels` the consumer sets are merged in verbatim — that's where
+the resource-tagging governance labels land (platform.nanohype.dev/environment,
+.../team, .../cost-center, …) under the standard's reserved k8s prefixes. These
+go on metadata + pod-template labels only, never on the immutable selectorLabels.
 */}}
 {{- define "tenant-chart-base.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
@@ -41,6 +45,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 agents.nanohype.dev/tenant: {{ (index .Values.otel.resourceAttributes "agents.tenant") | default "unknown" | quote }}
 agents.nanohype.dev/platform: {{ (index .Values.otel.resourceAttributes "agents.platform") | default .Chart.Name | quote }}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Phase 4 of the tagging rollout — the clean single point for tenant-workload k8s labels. **Additive, backward-compatible, nothing migrates** (the chart already uses the standard's `agents.nanohype.dev/*` identity prefix).

## What changed
`tenant-chart-base.labels` — the one helper every Platform-tenant chart includes — now merges a consumer-provided `commonLabels` map onto every resource's **metadata + pod-template labels** (never the immutable `selectorLabels`). That's the injection point for the [resource-tagging standard](https://github.com/nanohype/nanohype/blob/main/standards/resource-tagging.json)'s k8s governance labels under the reserved `platform.nanohype.dev/*` prefix.

`k8s-app-tenant` wires it: base values set `platform.nanohype.dev/team` (the tenant) + `app.kubernetes.io/component` (the persona); each `values-<env>.yaml` adds `platform.nanohype.dev/environment`. The vendored library copy is re-synced.

## Verification
`validate:catalog` clean (0 errors) · `verify:library` in sync · helm render of a substituted chart shows the governance labels on metadata + pod labels with the selector untouched:
```
platform.nanohype.dev/environment: dev
platform.nanohype.dev/team: acme
app.kubernetes.io/component: founder
agents.nanohype.dev/{tenant,platform}: ...
```