### PR TITLE
fix(deps): bump go-service skeleton deps (pgx critical, otel, chi)

### DIFF
--- a/templates/go-service/skeleton/go.mod
+++ b/templates/go-service/skeleton/go.mod
@@ -3,12 +3,12 @@ module __GO_MODULE__
 go 1.24
 
 require (
-	github.com/go-chi/chi/v5 v5.2.1
-	github.com/jackc/pgx/v5 v5.7.4
+	github.com/go-chi/chi/v5 v5.2.2
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/spf13/viper v1.20.1
-	go.opentelemetry.io/otel v1.35.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.35.0
-	go.opentelemetry.io/otel/sdk v1.35.0
-	go.opentelemetry.io/otel/trace v1.35.0
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 )


### PR DESCRIPTION
Clears the Dependabot advisories on `templates/go-service/skeleton/go.mod` that
org-wide scanning surfaced:

- **github.com/jackc/pgx/v5 5.7.4 → 5.9.2** — the repo's only **critical**
  (memory-safety) plus a low (SQL-injection via dollar-quoting). In-major,
  non-breaking.
- **go.opentelemetry.io/otel{,/sdk,/trace,/exporters/stdout/stdouttrace} 1.35.0 → 1.43.0**
  — the PATH-hijacking highs. Bumped as a set so the otel module versions stay
  aligned; all within the v1 stable line.
- **github.com/go-chi/chi/v5 5.2.1 → 5.2.2** — host-header open-redirect in
  `RedirectSlashes`.

Verified by rendering the skeleton (`example.com/go-service`) and running
`go mod tidy` + `go build ./...` + `go vet ./...` clean against the new versions.
