### PR TITLE
ci: scope workflow GITHUB_TOKEN to least privilege

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -11,6 +11,9 @@ on:
       - "docs/**"
       - "*.md"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Markdown

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths: ['sdk/**', 'schemas/**']
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build and test SDK

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate template catalog


### PR DESCRIPTION
Clears the 6 CodeQL `actions/missing-workflow-permissions` alerts by adding a top-level `permissions: contents: read` default to `validate-templates.yml`, `sdk.yml`, and `lint-docs.yml`. Every job is read-only (validate / build / test / lint / schema-diff) — none write contents, comment on PRs, or release — so read-only covers them all. No behavior change.