### PR TITLE
fix(security): close 4 knowledge-base CodeQL sanitization findings

### DIFF
--- a/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/providers/confluence.ts
+++ b/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/providers/confluence.ts
@@ -38,6 +38,19 @@ function getConfig(): { baseUrl: string; email: string; token: string } {
 }
 
 /** Convert Confluence storage format (simplified XHTML) to markdown. */
+// Strip HTML tags, looping until the string stabilizes. A single global replace
+// is insufficient — nested/overlapping constructs like `<scr<x>ipt>` can leave a
+// live tag behind after one pass — so repeat until no `<...>` remains.
+function stripHtmlTags(input: string): string {
+  let out = input;
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(/<[^>]*>/g, "");
+  } while (out !== prev);
+  return out;
+}
+
 function storageToMarkdown(html: string): string {
   let md = html;
 
@@ -89,7 +102,7 @@ function storageToMarkdown(html: string): string {
       const cells: string[] = [];
       const cellMatches = rowHtml.match(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/gi) ?? [];
       for (const cellHtml of cellMatches) {
-        const cellContent = cellHtml.replace(/<[^>]+>/g, "").trim();
+        const cellContent = stripHtmlTags(cellHtml).trim();
         cells.push(cellContent);
       }
       rows.push(cells);
@@ -106,16 +119,17 @@ function storageToMarkdown(html: string): string {
     return lines.join("\n") + "\n\n";
   });
 
-  // Strip remaining HTML tags
-  md = md.replace(/<[^>]+>/g, "");
+  // Strip remaining HTML tags (iteratively, so nested tags can't survive a pass)
+  md = stripHtmlTags(md);
 
-  // Decode HTML entities
-  md = md.replace(/&amp;/g, "&");
+  // Decode HTML entities. `&amp;` is decoded LAST so an input like `&amp;lt;`
+  // resolves to the literal `&lt;` instead of being double-unescaped to `<`.
   md = md.replace(/&lt;/g, "<");
   md = md.replace(/&gt;/g, ">");
   md = md.replace(/&quot;/g, '"');
   md = md.replace(/&#39;/g, "'");
   md = md.replace(/&nbsp;/g, " ");
+  md = md.replace(/&amp;/g, "&");
 
   // Clean up excessive newlines
   md = md.replace(/\n{3,}/g, "\n\n");

--- a/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/providers/google-docs.ts
+++ b/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/providers/google-docs.ts
@@ -382,7 +382,7 @@ function createGoogleDocsProvider(): KnowledgeProvider {
       logger.debug("google-docs searchPages", { query: options.query });
 
       const limit = options.limit ?? 20;
-      let q = `mimeType='application/vnd.google-apps.document' and fullText contains '${options.query.replace(/'/g, "\\'")}'`;
+      let q = `mimeType='application/vnd.google-apps.document' and fullText contains '${options.query.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
 
       if (options.parentId) {
         q += ` and '${options.parentId}' in parents`;


### PR DESCRIPTION
Closes the four real CodeQL sanitization findings in the knowledge-base
template skeleton (all `high`).

- **`incomplete-multi-character-sanitization` ×2** (`confluence.ts:92,110`): the
  HTML→markdown converter stripped tags with a single `replace(/<[^>]+>/g, "")`,
  which a nested construct like `<scr<x>ipt>` survives. Added a `stripHtmlTags`
  helper that loops until the string stabilizes, used at both sites.
- **`double-escaping`** (`confluence.ts:113`): entity decoding ran `&amp;`→`&`
  *first*, so `&amp;lt;` double-unescaped to `<`. Reordered so `&amp;` is decoded
  last — `&amp;lt;` now resolves to the literal `&lt;`.
- **`incomplete-sanitization`** (`google-docs.ts:385`): the Drive query builder
  escaped `'` but not `\`. Now escapes backslash first, then the quote.

These are template skeletons; the `Test template skeletons` CI job renders and
builds them.
