### PR TITLE
fix(deps): upgrade module-observability-ts to OpenTelemetry 2.x

### DIFF
--- a/templates/module-observability-ts/skeleton/package.json
+++ b/templates/module-observability-ts/skeleton/package.json
@@ -24,17 +24,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/sdk-node": "^0.57.0",
-    "@opentelemetry/sdk-trace-node": "^1.30.0",
-    "@opentelemetry/sdk-metrics": "^1.30.0",
-    "@opentelemetry/resources": "^1.30.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0"
+    "@opentelemetry/sdk-node": "^0.219.0",
+    "@opentelemetry/sdk-trace-node": "^2.8.0",
+    "@opentelemetry/sdk-metrics": "^2.8.0",
+    "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
-    "@opentelemetry/context-async-hooks": "^1.30.0",
+    "@opentelemetry/context-async-hooks": "^2.8.0",
     "@types/node": "^22.0.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",

--- a/templates/module-observability-ts/skeleton/src/telemetry/__tests__/logger.test.ts
+++ b/templates/module-observability-ts/skeleton/src/telemetry/__tests__/logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { trace, context, SpanContext, TraceFlags } from "@opentelemetry/api";
+import { trace, context, TraceFlags, type SpanContext } from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import { logger } from "../logger.js";
 

--- a/templates/module-observability-ts/skeleton/src/telemetry/exporters/datadog.ts
+++ b/templates/module-observability-ts/skeleton/src/telemetry/exporters/datadog.ts
@@ -16,6 +16,7 @@ import { registerExporter } from "./registry.js";
  *   DD_OTLP_ENDPOINT  (default: http://localhost:4318)
  */
 class DatadogTelemetryExporter implements TelemetryExporter {
+  readonly name = "datadog";
   private readonly endpoint: string;
 
   constructor() {

--- a/templates/module-observability-ts/skeleton/src/telemetry/index.ts
+++ b/templates/module-observability-ts/skeleton/src/telemetry/index.ts
@@ -1,6 +1,6 @@
 import { validateBootstrap } from "./bootstrap.js";
 import { NodeSDK } from "@opentelemetry/sdk-node";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-node";
@@ -58,7 +58,7 @@ export function initTelemetry(config: TelemetryConfig): () => Promise<void> {
   const exporterName = config.exporterName ?? "__EXPORTER__";
   const exporter = getExporter(exporterName);
 
-  const resource = new Resource({
+  const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: config.serviceName,
     [ATTR_SERVICE_VERSION]: config.serviceVersion ?? "0.0.0",
   });


### PR DESCRIPTION
Upgrades the `module-observability-ts` skeleton to the OpenTelemetry JS 2.x line,
clearing the `@opentelemetry/sdk-node` advisory (GHSA-q7rr-3cgh-j5r3, Prometheus
exporter crash; vulnerable `< 0.217.0`, the skeleton was on 0.57.0).

- **Coordinated stack bump** (sdk-node alone can't move without the rest):
  sdk-node + otlp exporters → ^0.219.0; sdk-trace-node / sdk-metrics / resources /
  context-async-hooks → ^2.8.0; semantic-conventions → ^1.41.1; api stays ^1.9.0.
- **2.x API change:** `new Resource({...})` → `resourceFromAttributes({...})` in
  `telemetry/index.ts` (the `Resource` class constructor was removed in 2.0).
  Every other otel import the skeleton uses is unchanged across 1.x→2.x.

Folded in two pre-existing tsc errors this skeleton already had (the template
test harness doesn't typecheck skeletons, so they were latent) so the upgraded
skeleton builds clean:
- `datadog.ts` was missing the `readonly name` required by the `TelemetryExporter`
  interface — added `name = "datadog"`.
- `logger.test.ts` imported the `SpanContext` type as a value — made it
  `type`-only (verbatimModuleSyntax).

Verified: rendered the skeleton and ran `npm install` + `tsc` + `vitest` + `eslint`
— all clean (10/10 tests).
