### PR TITLE
fix(deps): upgrade electron-app skeleton to Electron 42 (clears 17 advisories)

### DIFF
--- a/templates/electron-app/skeleton/package.json
+++ b/templates/electron-app/skeleton/package.json
@@ -30,7 +30,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "concurrently": "^9.1.0",
-    "electron": "^33.0.0",
+    "electron": "^42.0.0",
     "esbuild": "^0.24.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",

--- a/templates/electron-app/skeleton/src/renderer/App.tsx
+++ b/templates/electron-app/skeleton/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, type CSSProperties } from "react";
 import { Chat } from "./components/Chat";
 
 interface Message {
@@ -79,8 +79,10 @@ export function App() {
           letterSpacing: "-0.015em",
           color: "var(--foreground)",
           background: "var(--card)",
+          // -webkit-app-region makes the custom title bar draggable; not in
+          // @types/react's CSSProperties, so cast.
           WebkitAppRegion: "drag",
-        }}
+        } as CSSProperties}
       >
         __PROJECT_NAME__
       </header>


### PR DESCRIPTION
Upgrades the `electron-app` skeleton from Electron 33 to **42** (latest stable),
clearing all 17 open Electron advisories (high/medium/low; the highest patched
floor across them was 39.x, so 42 covers everything and keeps the skeleton on
the current major).

- **No app-code changes needed for the API jump:** every Electron API the
  skeleton uses — `app`, `BrowserWindow`, `ipcMain.handle`, `ipcRenderer.invoke`,
  `contextBridge.exposeInMainWorld`, `webContents.openDevTools` — is stable
  across 33→42. Typechecking the main + renderer against Electron 42's types is
  clean.
- Folded in one pre-existing renderer tsc error so the skeleton typechecks:
  `App.tsx` set `WebkitAppRegion: "drag"` (the Electron draggable-title-bar CSS
  prop, absent from `@types/react`'s `CSSProperties`) in an inline style — now
  imported `CSSProperties` and cast.

Verified by rendering the skeleton and running `npm install` + `tsc --noEmit` +
`vite build` + `vitest` — all clean (7/7 tests). (The skeleton also has pre-
existing eslint nits in `esbuild.config.mjs`/`index.ts` unrelated to this change;
left as separate lint debt.)
