### PR TITLE
fix(deps): bump go-service chi to v5.3.0

### DIFF
--- a/templates/go-service/skeleton/go.mod
+++ b/templates/go-service/skeleton/go.mod
@@ -3,7 +3,7 @@ module __GO_MODULE__
 go 1.24
 
 require (
-	github.com/go-chi/chi/v5 v5.2.2
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/spf13/viper v1.20.1


### PR DESCRIPTION
Clears `GHSA-mqqf-5wvp-8fh8` (vulnerable `>=5.2.2 <5.2.4`) — a newly-disclosed chi advisory that the earlier #111 bump (5.2.1→5.2.2) happened to land inside. Moves to the latest **5.3.0**. Verified: rendered go-service skeleton `go mod tidy` + `go build` + `go vet` clean.