### PR TITLE
fix(templates): repair template-doctor + clear electron-app lint debt

### DIFF
--- a/scripts/template-doctor/checks/go.sh
+++ b/scripts/template-doctor/checks/go.sh
@@ -37,8 +37,11 @@ _check_go_template() {
   name="$(template_name "$tmpl")"
 
   work="$(mktemp -d)"
-  # Guarantee cleanup even on early return / error.
-  trap 'rm -rf "$work"' RETURN
+  # Guarantee cleanup even on early return / error. The RETURN trap also fires
+  # when the *caller* returns (bash traps aren't function-scoped), where `work`
+  # is out of scope, so guard the expansion to avoid an unbound-variable error
+  # under `set -u`.
+  trap 'rm -rf "${work:-}"' RETURN
   cp -R "${tmpl}/skeleton/." "${work}/"
 
   _materialize_placeholders "$work" "$name"

--- a/scripts/template-doctor/checks/java.sh
+++ b/scripts/template-doctor/checks/java.sh
@@ -36,7 +36,10 @@ _check_java_template() {
   name="$(template_name "$tmpl")"
 
   work="$(mktemp -d)"
-  trap 'rm -rf "$work"' RETURN
+  # Guard the expansion: this RETURN trap also fires when the caller returns
+  # (bash traps aren't function-scoped), where `work` is out of scope, which
+  # would trip `set -u`.
+  trap 'rm -rf "${work:-}"' RETURN
   cp -R "${tmpl}/skeleton/." "${work}/"
 
   _java_materialize "$work" "$name"

--- a/templates/electron-app/skeleton/eslint.config.js
+++ b/templates/electron-app/skeleton/eslint.config.js
@@ -1,10 +1,16 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
     ignores: ["dist/", "node_modules/"],
+  },
+  {
+    // Node build/config scripts (esbuild.config.mjs, vite/vitest config).
+    files: ["**/*.mjs", "**/*.config.{js,ts}"],
+    languageOptions: { globals: globals.node },
   },
 );

--- a/templates/electron-app/skeleton/package.json
+++ b/templates/electron-app/skeleton/package.json
@@ -33,6 +33,7 @@
     "electron": "^42.0.0",
     "esbuild": "^0.24.0",
     "eslint": "^9.20.0",
+    "globals": "^17.6.0",
     "prettier": "^3.5.0",
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.25.0",

--- a/templates/electron-app/skeleton/src/main/index.ts
+++ b/templates/electron-app/skeleton/src/main/index.ts
@@ -13,7 +13,9 @@ import { registerIpcHandlers } from "./ipc-handlers.js";
 
 validateBootstrap();
 
-const config = loadConfig();
+// Validates env and exits on invalid config. The IPC handlers read their keys
+// from the environment directly, so the returned object isn't needed here.
+loadConfig();
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 


### PR DESCRIPTION
Fixes the two side-findings from the security sweep.

**template-doctor** (`checks/{go,java}.sh`): the cleanup `trap 'rm -rf "$work"' RETURN` also fires when the *caller* returns (bash traps aren't function-scoped), where `work` is out of scope — tripping `set -u` ("work: unbound variable") and aborting before any skeleton was checked. Guarded the expansion. (CI's "Test template skeletons" only runs each skeleton's `npm test`, never tsc/lint — template-doctor is the tool that does, and it was broken; that's why pre-existing tsc/lint debt went unnoticed.)

**electron-app lint debt** (what template-doctor surfaces): `eslint.config.js` set no globals → `esbuild.config.mjs` tripped `no-undef` on process/console (added `globals` + a Node-globals block); `index.ts` had an unused `const config = loadConfig()` (the handlers read env directly) → dropped the binding, keeping the validation call.

Verified: `template-doctor --only go` runs clean; the rendered electron-app skeleton lints + typechecks + builds + tests clean (7/7).