### PR TITLE
fix(templates): repair template-doctor, gate it in CI, clear the tsc debt it surfaced

### DIFF
--- a/.github/workflows/template-doctor.yml
+++ b/.github/workflows/template-doctor.yml
@@ -5,6 +5,15 @@ on:
   # weekly cadence matches how fast the ecosystem drifts in practice.
   schedule:
     - cron: "0 6 * * 0"
+  # Gate PRs that touch templates, composites, or the doctor itself: fail on
+  # hard errors so typecheck/build/lint/ref debt can't land silently. Advisory
+  # findings (outdated deps, dead deps) are reported but don't block.
+  pull_request:
+    paths:
+      - "templates/**"
+      - "composites/**"
+      - "scripts/template-doctor/**"
+      - ".github/workflows/template-doctor.yml"
   # Manual trigger for on-demand runs (e.g., before cutting a release).
   workflow_dispatch:
     inputs:
@@ -33,7 +42,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          # go-service's pgx/otel deps require go 1.25; keep the doctor on a
+          # current toolchain so it validates skeletons against what they build on.
+          go-version: "1.26"
 
       - name: Set up JDK
         uses: actions/setup-java@v5
@@ -50,15 +61,19 @@ jobs:
         id: doctor
         env:
           ONLY: ${{ github.event.inputs.only || 'ts,go,java,python,cross' }}
+          # Gate pull requests on hard errors; cron / manual runs stay report-only.
+          FAIL_ON: ${{ github.event_name == 'pull_request' && 'error' || '' }}
         run: |
-          set -e
-          ./scripts/template-doctor/run.sh --only "$ONLY" --format markdown \
-            > doctor-report.md || true
+          args=(--only "$ONLY" --format markdown)
+          [ -n "$FAIL_ON" ] && args+=(--fail-on "$FAIL_ON")
+          ./scripts/template-doctor/run.sh "${args[@]}" > doctor-report.md
 
       - name: Post report to job summary
+        if: always()
         run: cat doctor-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload report artifact
+        if: always()
         uses: actions/upload-artifact@v5
         with:
           name: doctor-report

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@ bin/
 build/
 coverage/
 
+# Template skeletons ship their own bin/ source entrypoints (CDK app.ts, CLI
+# runners). The blanket bin/ rule above targets compiled build output, so
+# re-include template sources explicitly.
+!templates/**/bin/
+!templates/**/bin/**
+
 # Environment
 .env
 .env.*

--- a/scripts/template-doctor/checks/go.sh
+++ b/scripts/template-doctor/checks/go.sh
@@ -122,13 +122,16 @@ _go_outdated() {
 
 _go_build() {
   local work="$1" name="$2"
-  local output
-  output="$(cd "$work" && GOSUMDB=off go build ./... 2>&1 || true)"
-  if [ -n "$output" ]; then
+  local output status
+  # Gate on the exit code, not on output presence: a successful `go build` can
+  # still print linker warnings (e.g. a missing optional search path), which
+  # are not build failures.
+  output="$(cd "$work" && GOSUMDB=off go build ./... 2>&1)" && status=0 || status=$?
+  if [ "${status:-0}" -ne 0 ]; then
     local error_count
-    error_count=$(printf '%s' "$output" | wc -l | tr -d ' ')
+    error_count=$(printf '%s\n' "$output" | grep -c . || true)
     finding "error" "go" "$name" "build" \
-      "go build ./... failed (${error_count} lines of output)"
+      "go build ./... failed (exit ${status}, ${error_count} lines of output)"
   fi
 }
 

--- a/scripts/template-doctor/checks/java.sh
+++ b/scripts/template-doctor/checks/java.sh
@@ -89,9 +89,11 @@ _java_outdated() {
   output="$(cd "$work" && mvn -B -q versions:display-dependency-updates 2>&1 || true)"
 
   # Maven output form: "  [INFO]   group:artifact ......... current -> latest"
-  # Parse per-line; skip anything without the arrow.
+  # Parse per-line; skip anything without the arrow. `grep` exits 1 when no deps
+  # are outdated — that is success, not failure, so swallow it (otherwise pipefail
+  # propagates the non-zero and set -e aborts the whole run).
   printf '%s\n' "$output" \
-    | grep -E "\->[[:space:]]" \
+    | { grep -E "\->[[:space:]]" || true; } \
     | sed -E 's/^\[INFO\][[:space:]]*//; s/^[[:space:]]+//' \
     | while IFS= read -r line; do
         # Strip the padding dots; extract "coord current -> latest".

--- a/scripts/template-doctor/checks/python.sh
+++ b/scripts/template-doctor/checks/python.sh
@@ -50,8 +50,11 @@ _py_compile() {
   local output error_count
   output="$(python3 -m compileall -q "$skeleton" 2>&1 || true)"
   error_count=$(printf '%s' "$output" | grep -cE "SyntaxError|IndentationError" || true)
-  [ "$error_count" -gt 0 ] && finding "error" "python" "$name" "syntax" \
-    "python3 compileall reports ${error_count} syntax errors"
+  # if/fi, not `[ ] && finding`: under `set -e` the latter returns non-zero on a
+  # clean skeleton (error_count=0) and would abort the run on the first one.
+  if [ "$error_count" -gt 0 ]; then
+    finding "error" "python" "$name" "syntax" "python3 compileall reports ${error_count} syntax errors"
+  fi
 }
 
 _py_outdated() {

--- a/scripts/template-doctor/checks/ts.sh
+++ b/scripts/template-doctor/checks/ts.sh
@@ -32,9 +32,15 @@ _check_ts_template() {
   name="$(template_name "$tmpl")"
   skeleton="${tmpl}/skeleton"
 
-  # Install once per skeleton; cached via node_modules across checks.
-  if [ ! -d "${skeleton}/node_modules" ]; then
-    if ! (cd "$skeleton" && npm install --silent --no-audit --no-fund >/dev/null 2>&1); then
+  # (Re)install when node_modules is missing or stale relative to package.json.
+  # A cached-but-stale tree makes tsc run against old dependency versions and
+  # report phantom errors against APIs the pinned versions don't expose (e.g. a
+  # node_modules left from before a dependency bump). Drop the lockfile too so
+  # versions re-resolve from the package.json ranges.
+  if [ ! -d "${skeleton}/node_modules" ] ||
+    [ "${skeleton}/package.json" -nt "${skeleton}/node_modules" ]; then
+    if ! (cd "$skeleton" && rm -rf node_modules package-lock.json &&
+      npm install --silent --no-audit --no-fund >/dev/null 2>&1); then
       finding "error" "ts" "$name" "install" "npm install failed"
       return
     fi
@@ -85,8 +91,12 @@ _ts_typecheck() {
   local output error_count
   output="$(cd "$skeleton" && npx --no-install tsc --noEmit 2>&1 || true)"
   error_count=$(printf '%s' "$output" | grep -cE "error TS[0-9]+" || true)
-  [ "$error_count" -gt 0 ] && finding "error" "ts" "$name" "typecheck" \
-    "tsc --noEmit reports ${error_count} errors"
+  # if/fi, not `[ ] && finding`: under `set -e` the latter returns non-zero when
+  # the skeleton is clean (error_count=0), which would abort the whole run on the
+  # first clean template.
+  if [ "$error_count" -gt 0 ]; then
+    finding "error" "ts" "$name" "typecheck" "tsc --noEmit reports ${error_count} errors"
+  fi
 }
 
 _ts_dead_deps() {

--- a/scripts/template-doctor/run.sh
+++ b/scripts/template-doctor/run.sh
@@ -3,14 +3,20 @@
 # aggregates findings via $REPORT_FILE, and renders a report.
 #
 # Usage:
-#   run.sh [--only <list>] [--skip <list>] [--format text|markdown]
-#   --only   comma-separated subset of {ts,go,java,python,cross} (default: all)
-#   --skip   comma-separated subset to skip (runs after --only)
-#   --format report format; default text. markdown is stdout-safe for PR comments.
+#   run.sh [--only <list>] [--skip <list>] [--format text|markdown] [--fail-on <sev>]
+#   --only    comma-separated subset of {ts,go,java,python,cross} (default: all)
+#   --skip    comma-separated subset to skip (runs after --only)
+#   --format  report format; default text. markdown is stdout-safe for PR comments.
+#   --fail-on exit non-zero on a finding at/above {error|warn|info}; default off (report-only)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Capture the checks dir before sourcing anything: each check script resets
+# SCRIPT_DIR to its own location when sourced, which would otherwise corrupt the
+# per-group lookup below into <dir>/checks/checks/<group>.sh and skip every
+# group after the first.
+CHECKS_DIR="${SCRIPT_DIR}/checks"
 # shellcheck source=lib/common.sh
 . "${SCRIPT_DIR}/lib/common.sh"
 # shellcheck source=lib/report.sh
@@ -19,12 +25,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ONLY="ts,go,java,python,cross"
 SKIP=""
 FORMAT="text"
+FAIL_ON=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --only)   ONLY="$2"; shift 2 ;;
-    --skip)   SKIP="$2"; shift 2 ;;
-    --format) FORMAT="$2"; shift 2 ;;
+    --only)    ONLY="$2"; shift 2 ;;
+    --skip)    SKIP="$2"; shift 2 ;;
+    --format)  FORMAT="$2"; shift 2 ;;
+    --fail-on) FAIL_ON="$2"; shift 2 ;;
     -h|--help)
       sed -n '3,9p' "$0" >&2
       exit 0
@@ -41,7 +49,7 @@ run_group() {
   case ",$ONLY," in *",$group,"*) ;; *) return 0 ;; esac
   case ",$SKIP," in *",$group,"*) return 0 ;; esac
 
-  local script="${SCRIPT_DIR}/checks/${group}.sh"
+  local script="${CHECKS_DIR}/${group}.sh"
   [ -f "$script" ] || { log_warn "no check script for ${group}"; return 0; }
 
   # shellcheck source=/dev/null
@@ -68,6 +76,23 @@ case "$FORMAT" in
   *) log_err "Unknown format: $FORMAT"; exit 2 ;;
 esac
 
-# Report-only: always exit 0. The fix-follow-up PR flips this when we
-# want to gate CI on hard errors.
+# Report-only by default. With `--fail-on <severity>`, exit non-zero when the
+# report holds a finding at or above that severity, so CI can gate on it.
+case "$FAIL_ON" in
+  "") ;;
+  error | warn | info)
+    if awk -F'\t' -v lvl="$FAIL_ON" '
+          function rank(s) { return s == "error" ? 3 : s == "warn" ? 2 : s == "info" ? 1 : 0 }
+          rank($1) >= rank(lvl) { found = 1 }
+          END { exit found ? 0 : 1 }
+        ' "$REPORT_FILE"; then
+      log_err "template-doctor: findings at or above '${FAIL_ON}' severity (see report above)"
+      exit 1
+    fi
+    ;;
+  *)
+    log_err "Unknown --fail-on: ${FAIL_ON} (expected error|warn|info)"
+    exit 2
+    ;;
+esac
 exit 0

--- a/templates/agentic-loop/skeleton/src/agent.ts
+++ b/templates/agentic-loop/skeleton/src/agent.ts
@@ -13,7 +13,7 @@ import {
 } from "./metrics.js";
 import type { ConversationStore } from "./memory/conversation.js";
 
-const MAX_ITERATIONS = __MAX_ITERATIONS__;
+const MAX_ITERATIONS = Number("__MAX_ITERATIONS__");
 const PROVIDER_NAME = "__LLM_PROVIDER__";
 
 /** Lazily resolved provider — avoids calling getProvider() at module scope

--- a/templates/agentic-loop/skeleton/src/providers/openai.ts
+++ b/templates/agentic-loop/skeleton/src/providers/openai.ts
@@ -211,7 +211,7 @@ class OpenAIProvider implements LlmProvider {
         contentBlocks.push({ type: "text", text: contentText });
       }
 
-      const toolCallMessages: { id: string; type: "function" as const; function: { name: string; arguments: string } }[] = [];
+      const toolCallMessages: { id: string; type: "function"; function: { name: string; arguments: string } }[] = [];
 
       for (const [, tc] of [...toolCallAccumulators.entries()].sort(
         ([a], [b]) => a - b,

--- a/templates/agentic-loop/skeleton/src/tools/registry.ts
+++ b/templates/agentic-loop/skeleton/src/tools/registry.ts
@@ -27,11 +27,15 @@ export class ToolRegistry {
   private tools = new Map<string, Tool>();
 
   /** Register a tool. Throws if a tool with the same name already exists. */
-  register(tool: Tool): void {
+  register<TSchema extends z.ZodObject<z.ZodRawShape>>(tool: Tool<TSchema>): void {
     if (this.tools.has(tool.name)) {
       throw new Error(`Tool "${tool.name}" is already registered`);
     }
-    this.tools.set(tool.name, tool);
+    // Store erased: each tool's execute is only ever invoked with input
+    // that this registry has parsed against that same tool's inputSchema
+    // (see execute() below), so the per-tool input type is preserved at
+    // the call boundary even though the map holds the widened Tool type.
+    this.tools.set(tool.name, tool as unknown as Tool);
   }
 
   /** Get a tool by name. Returns undefined if not found. */

--- a/templates/api-gateway/skeleton/src/gateway/index.ts
+++ b/templates/api-gateway/skeleton/src/gateway/index.ts
@@ -13,7 +13,19 @@ import { selectUpstream, isCanaryConfig } from "./traffic/canary.js";
 import { createHealthChecker } from "./traffic/health.js";
 import { createCircuitBreaker, type CircuitBreaker } from "./resilience/circuit-breaker.js";
 import { gatewayProxyTotal, gatewayProxyDuration } from "./metrics.js";
-import type { GatewayConfig, RouteRule } from "./types.js";
+import type { GatewayConfig, RouteRule, TransformRule } from "./types.js";
+
+// ── Hono context variables ──────────────────────────────────────────
+//
+// Typed context keys shared across middleware and the proxy handler.
+// Registering the Variables env makes c.get/c.set type-safe instead of
+// resolving to `never`.
+//
+interface GatewayEnv {
+  Variables: {
+    transformRule: TransformRule;
+  };
+}
 
 // ── Gateway Entry Point ─────────────────────────────────────────────
 //
@@ -49,7 +61,7 @@ function collectUpstreams(routes: RouteRule[]): string[] {
  */
 export function createGateway(config: GatewayConfig) {
   const logger = createLogger("gateway", (config.logLevel as "debug" | "info" | "warn" | "error") ?? "info");
-  const app = new Hono();
+  const app = new Hono<GatewayEnv>();
 
   // ── Per-upstream circuit breakers (instance-scoped) ──────────────
   const breakers = new Map<string, CircuitBreaker>();
@@ -163,7 +175,7 @@ export function createGateway(config: GatewayConfig) {
 
     // Proxy the request
     const timeoutMs = match.rule.timeoutMs ?? config.defaultTimeoutMs ?? 30_000;
-    const transform = (c.get("transformRule") as typeof match.rule.transform) ?? match.rule.transform;
+    const transform = c.get("transformRule") ?? match.rule.transform;
 
     const proxyResponse = await proxyRequest(
       upstreamUrl,

--- a/templates/api-gateway/skeleton/src/gateway/router/proxy.ts
+++ b/templates/api-gateway/skeleton/src/gateway/router/proxy.ts
@@ -116,7 +116,7 @@ export async function proxyRequest(
       headers,
       body: request.body,
       signal: controller.signal,
-      // @ts-expect-error -- Node.js fetch supports duplex for streaming request bodies
+      // Node.js fetch supports duplex for streaming request bodies
       duplex: "half",
     });
 

--- a/templates/chrome-ext/skeleton/src/content/index.ts
+++ b/templates/chrome-ext/skeleton/src/content/index.ts
@@ -68,7 +68,7 @@ function showOverlay(selection: Selection) {
       } else if (response?.content) {
         showResult(response.content, false);
       }
-    } catch (err) {
+    } catch {
       showResult("Failed to get response.", true);
     }
   });

--- a/templates/chrome-ext/skeleton/tsconfig.json
+++ b/templates/chrome-ext/skeleton/tsconfig.json
@@ -14,7 +14,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/templates/eval-harness/skeleton/bin/run-evals.ts
+++ b/templates/eval-harness/skeleton/bin/run-evals.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env tsx
+
+import { validateBootstrap } from "../src/bootstrap.js";
+import { resolve } from "node:path";
+import { runEvals } from "../src/runner.js";
+
+/**
+ * CLI entrypoint for running eval suites.
+ *
+ * Usage:
+ *   npx tsx bin/run-evals.ts [options]
+ *
+ * Options:
+ *   --suites <glob>      Glob pattern for suite files (default: "suites/*.yaml")
+ *   --reporter <type>    Reporter: "console" or "json" (default: "console")
+ *   --provider <name>    LLM provider override (any registered provider name)
+ *   --concurrency <n>    Max parallel cases per suite (default: 5)
+ *   --output <path>      Output file for JSON reporter (stdout if omitted)
+ */
+
+function parseArgs(argv: string[]): {
+  suites: string;
+  reporter: "console" | "json";
+  provider?: string;
+  concurrency: number;
+  output?: string;
+} {
+  const args = {
+    suites: "suites/*.yaml",
+    reporter: "console" as "console" | "json",
+    provider: undefined as string | undefined,
+    concurrency: 5,
+    output: undefined as string | undefined,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--suites":
+        args.suites = argv[++i]!;
+        break;
+      case "--reporter":
+        args.reporter = argv[++i] as "console" | "json";
+        break;
+      case "--provider":
+        args.provider = argv[++i];
+        break;
+      case "--concurrency":
+        args.concurrency = parseInt(argv[++i]!, 10);
+        break;
+      case "--output":
+        args.output = argv[++i];
+        break;
+      case "--help":
+        console.log("Usage: run-evals [--suites <glob>] [--reporter console|json] [--provider <name>] [--concurrency <n>] [--output <path>]");
+        process.exit(0);
+    }
+  }
+
+  return args;
+}
+
+async function main(): Promise<void> {
+  validateBootstrap();
+
+  const args = parseArgs(process.argv.slice(2));
+
+  const results = await runEvals({
+    suiteGlob: resolve(args.suites),
+    reporter: args.reporter,
+    provider: args.provider,
+    concurrency: args.concurrency,
+    outputFile: args.output,
+  });
+
+  // Exit with non-zero status if any evaluations failed
+  const allPassed = results.every((suite) =>
+    suite.cases.every((c) => c.pass),
+  );
+
+  if (!allPassed) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(2);
+});

--- a/templates/eval-harness/skeleton/src/assertions.ts
+++ b/templates/eval-harness/skeleton/src/assertions.ts
@@ -10,15 +10,22 @@ export interface AssertionResult {
 }
 
 /**
+ * A synchronous assertion function takes the LLM output string and returns
+ * a result indicating whether the output satisfies the assertion.
+ */
+export type SyncAssertionFn = (output: string) => AssertionResult;
+
+/**
  * An assertion function takes the LLM output string and returns
  * a result indicating whether the output satisfies the assertion.
+ * May be synchronous or asynchronous; `SyncAssertionFn` is assignable to it.
  */
 export type AssertionFn = (output: string) => AssertionResult | Promise<AssertionResult>;
 
 /**
  * Checks that the output contains the given substring.
  */
-export function contains(substring: string): AssertionFn {
+export function contains(substring: string): SyncAssertionFn {
   return (output: string): AssertionResult => {
     const pass = output.includes(substring);
     return {
@@ -34,7 +41,7 @@ export function contains(substring: string): AssertionFn {
 /**
  * Checks that the output does NOT contain the given substring.
  */
-export function notContains(substring: string): AssertionFn {
+export function notContains(substring: string): SyncAssertionFn {
   return (output: string): AssertionResult => {
     const pass = !output.includes(substring);
     return {
@@ -50,7 +57,7 @@ export function notContains(substring: string): AssertionFn {
 /**
  * Checks that the output matches the given regular expression pattern.
  */
-export function matchesPattern(pattern: string): AssertionFn {
+export function matchesPattern(pattern: string): SyncAssertionFn {
   return (output: string): AssertionResult => {
     const regex = new RegExp(pattern);
     const pass = regex.test(output);
@@ -71,7 +78,7 @@ export function matchesPattern(pattern: string): AssertionFn {
  *
  * Supports `type`, `required`, and `properties` fields from the schema value.
  */
-export function matchesJsonSchema(schema: Record<string, unknown>): AssertionFn {
+export function matchesJsonSchema(schema: Record<string, unknown>): SyncAssertionFn {
   return (output: string): AssertionResult => {
     let parsed: unknown;
     try {
@@ -127,7 +134,7 @@ export function matchesJsonSchema(schema: Record<string, unknown>): AssertionFn 
  * Checks that the output does not exceed the given token count.
  * Uses a simple whitespace-based tokenization as an approximation.
  */
-export function maxTokens(limit: number): AssertionFn {
+export function maxTokens(limit: number): SyncAssertionFn {
   return (output: string): AssertionResult => {
     // Approximate token count by splitting on whitespace and punctuation boundaries
     const tokens = output.split(/\s+/).filter(Boolean);
@@ -179,7 +186,7 @@ export function satisfies(
  * The `threshold` parameter sets the minimum cosine similarity score (0-1)
  * required to pass.
  */
-export function semanticSimilarity(reference: string, threshold = 0.8): AssertionFn {
+export function semanticSimilarity(reference: string, threshold = 0.8): SyncAssertionFn {
   return (output: string): AssertionResult => {
     const score = tfidfCosineSimilarity(reference, output);
     const pass = score >= threshold;

--- a/templates/infra-aws/skeleton/bin/app.ts
+++ b/templates/infra-aws/skeleton/bin/app.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import { ServiceStack } from "../lib/stack";
+
+const app = new cdk.App();
+
+// Feature flags — the scaffolder substitutes each placeholder with "true" or
+// "false"; the string annotations keep the comparison valid before rendering.
+const includeVpc: string = "__INCLUDE_VPC__";
+const includeRds: string = "__INCLUDE_RDS__";
+const includeMonitoring: string = "__INCLUDE_MONITORING__";
+
+new ServiceStack(app, "__PROJECT_NAME__-stack", {
+  env: {
+    region: "__AWS_REGION__",
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+  },
+  includeVpc: includeVpc === "true",
+  includeRds: includeRds === "true",
+  includeMonitoring: includeMonitoring === "true",
+});

--- a/templates/infra-aws/skeleton/lib/constructs/api/ecs.ts
+++ b/templates/infra-aws/skeleton/lib/constructs/api/ecs.ts
@@ -2,7 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Construct } from "constructs";
-import type { ComputeConstruct } from "../compute/__COMPUTE_TARGET__";
+import type { ComputeConstruct } from "../compute/ecs";
 
 export interface ApiConstructProps {
   readonly compute: ComputeConstruct;

--- a/templates/infra-aws/skeleton/lib/constructs/api/index.ts
+++ b/templates/infra-aws/skeleton/lib/constructs/api/index.ts
@@ -1,0 +1,27 @@
+import { Construct } from "constructs";
+import { ApiConstruct as EcsApi } from "./ecs";
+import { ApiConstruct as LambdaApi } from "./lambda";
+import type { ComputeConstruct } from "../compute";
+
+// Both API targets ship in the skeleton; the scaffolder selects one via
+// __COMPUTE_TARGET__ (resolves to "ecs" or "lambda"). The record is typed with a
+// string key so the unresolved placeholder still type-checks before rendering.
+const apiTargets: Record<string, typeof EcsApi | typeof LambdaApi> = {
+  ecs: EcsApi,
+  lambda: LambdaApi,
+};
+
+export type ApiConstruct = InstanceType<typeof EcsApi | typeof LambdaApi>;
+
+export interface ApiConstructProps {
+  readonly compute: ComputeConstruct;
+  readonly vpc?: import("aws-cdk-lib/aws-ec2").IVpc;
+}
+
+// The compute and API targets always resolve to the same platform, so the
+// selected API construct accepts whichever ComputeConstruct the barrel exports.
+export const ApiConstruct = apiTargets["__COMPUTE_TARGET__"] as new (
+  scope: Construct,
+  id: string,
+  props: ApiConstructProps
+) => ApiConstruct;

--- a/templates/infra-aws/skeleton/lib/constructs/api/lambda.ts
+++ b/templates/infra-aws/skeleton/lib/constructs/api/lambda.ts
@@ -1,7 +1,7 @@
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
-import type { ComputeConstruct } from "../compute/__COMPUTE_TARGET__";
+import type { ComputeConstruct } from "../compute/lambda";
 
 export interface ApiConstructProps {
   readonly compute: ComputeConstruct;

--- a/templates/infra-aws/skeleton/lib/constructs/compute/index.ts
+++ b/templates/infra-aws/skeleton/lib/constructs/compute/index.ts
@@ -1,0 +1,13 @@
+import { ComputeConstruct as EcsCompute } from "./ecs";
+import { ComputeConstruct as LambdaCompute } from "./lambda";
+
+// Both compute targets ship in the skeleton; the scaffolder selects one via
+// __COMPUTE_TARGET__ (resolves to "ecs" or "lambda"). The record is typed with a
+// string key so the unresolved placeholder still type-checks before rendering.
+const computeTargets: Record<string, typeof EcsCompute | typeof LambdaCompute> = {
+  ecs: EcsCompute,
+  lambda: LambdaCompute,
+};
+
+export const ComputeConstruct = computeTargets["__COMPUTE_TARGET__"];
+export type ComputeConstruct = InstanceType<typeof ComputeConstruct>;

--- a/templates/infra-aws/skeleton/lib/constructs/monitoring.ts
+++ b/templates/infra-aws/skeleton/lib/constructs/monitoring.ts
@@ -5,8 +5,8 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as sns from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
-import type { ComputeConstruct } from "./compute/__COMPUTE_TARGET__";
-import type { ApiConstruct } from "./api/__COMPUTE_TARGET__";
+import type { ComputeConstruct } from "./compute";
+import type { ApiConstruct } from "./api";
 
 export interface MonitoringConstructProps {
   readonly compute: ComputeConstruct;

--- a/templates/infra-aws/skeleton/lib/stack.ts
+++ b/templates/infra-aws/skeleton/lib/stack.ts
@@ -1,7 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { ComputeConstruct } from "./constructs/compute/__COMPUTE_TARGET__";
-import { ApiConstruct } from "./constructs/api/__COMPUTE_TARGET__";
+import { ComputeConstruct } from "./constructs/compute";
+import { ApiConstruct } from "./constructs/api";
 import { VpcConstruct } from "./constructs/vpc";
 import { DatabaseConstruct } from "./constructs/database";
 import { MonitoringConstruct } from "./constructs/monitoring";

--- a/templates/infra-aws/skeleton/tsconfig.json
+++ b/templates/infra-aws/skeleton/tsconfig.json
@@ -18,7 +18,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "verbatimModuleSyntax": true,
     "outDir": "./dist",
     "rootDir": "."
   },

--- a/templates/mcp-server-ts/skeleton/src/index.ts
+++ b/templates/mcp-server-ts/skeleton/src/index.ts
@@ -1,6 +1,6 @@
 import { validateBootstrap } from "./bootstrap.js";
 import { createServer } from "./server.js";
-import { start } from "./transports/__TRANSPORT__.js";
+import { start } from "./transports/index.js";
 
 validateBootstrap();
 

--- a/templates/mcp-server-ts/skeleton/src/transports/index.ts
+++ b/templates/mcp-server-ts/skeleton/src/transports/index.ts
@@ -1,0 +1,31 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { start as startStdio } from "./stdio.js";
+import { start as startStreamableHttp } from "./streamable-http.js";
+
+export type TransportName = "stdio" | "streamable-http";
+
+type StartFn = (server: McpServer) => Promise<void>;
+
+const transports: Record<TransportName, StartFn> = {
+  stdio: startStdio,
+  "streamable-http": startStreamableHttp,
+};
+
+function isTransportName(name: string): name is TransportName {
+  return Object.prototype.hasOwnProperty.call(transports, name);
+}
+
+/**
+ * The transport selected at scaffold time via the `Transport` variable.
+ */
+export const TRANSPORT: string = "__TRANSPORT__";
+
+/**
+ * Start the MCP server using the configured transport.
+ */
+export function start(server: McpServer): Promise<void> {
+  if (!isTransportName(TRANSPORT)) {
+    throw new Error(`Unknown transport: ${TRANSPORT}`);
+  }
+  return transports[TRANSPORT](server);
+}

--- a/templates/module-analytics-ts/skeleton/src/analytics/__tests__/middleware.test.ts
+++ b/templates/module-analytics-ts/skeleton/src/analytics/__tests__/middleware.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { createHonoAnalytics } from "../middleware/hono.js";
 import { createExpressAnalytics } from "../middleware/express.js";
 import type { AnalyticsProvider } from "../providers/types.js";
+import type { TrackEvent } from "../types.js";
 
 // ── Middleware Tests ─────────────────────────────────────────────
 //
@@ -9,8 +10,8 @@ import type { AnalyticsProvider } from "../providers/types.js";
 // both Hono and Express middleware factories.
 //
 
-function stubProvider(): AnalyticsProvider & { tracked: Record<string, unknown>[] } {
-  const tracked: Record<string, unknown>[] = [];
+function stubProvider(): AnalyticsProvider & { tracked: TrackEvent[] } {
+  const tracked: TrackEvent[] = [];
 
   return {
     name: "stub",
@@ -55,7 +56,7 @@ describe("hono analytics middleware", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(provider.tracked).toHaveLength(1);
-    const event = provider.tracked[0] as Record<string, unknown>;
+    const event = provider.tracked[0];
     expect(event.event).toBe("request");
 
     const props = event.properties as Record<string, unknown>;
@@ -77,7 +78,7 @@ describe("hono analytics middleware", () => {
     await middleware(ctx, async () => {});
     await new Promise((r) => setTimeout(r, 0));
 
-    expect((provider.tracked[0] as Record<string, unknown>).event).toBe("http_request");
+    expect(provider.tracked[0].event).toBe("http_request");
   });
 
   it("captures error status codes", async () => {
@@ -91,7 +92,7 @@ describe("hono analytics middleware", () => {
     await middleware(ctx, async () => {});
     await new Promise((r) => setTimeout(r, 0));
 
-    const props = (provider.tracked[0] as Record<string, unknown>).properties as Record<string, unknown>;
+    const props = provider.tracked[0].properties as Record<string, unknown>;
     expect(props.statusCode).toBe(500);
   });
 });
@@ -128,7 +129,7 @@ describe("express analytics middleware", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(provider.tracked).toHaveLength(1);
-    const event = provider.tracked[0] as Record<string, unknown>;
+    const event = provider.tracked[0];
     expect(event.event).toBe("request");
 
     const props = event.properties as Record<string, unknown>;
@@ -162,7 +163,7 @@ describe("express analytics middleware", () => {
     finishCallback!();
     await new Promise((r) => setTimeout(r, 0));
 
-    const props = (provider.tracked[0] as Record<string, unknown>).properties as Record<string, unknown>;
+    const props = provider.tracked[0].properties as Record<string, unknown>;
     expect(props.durationMs).toBeGreaterThanOrEqual(0);
   });
 });

--- a/templates/module-auth-ts/skeleton/src/auth/middleware.ts
+++ b/templates/module-auth-ts/skeleton/src/auth/middleware.ts
@@ -125,7 +125,7 @@ async function handleHono(
   provider: { verifyRequest: (req: AuthRequest) => Promise<AuthResult> },
   _config: AuthConfig,
   args: unknown[],
-): Promise<unknown> {
+): Promise<void> {
   const c = args[0] as {
     req: { raw: Request; header: (name: string) => string | undefined };
     json: (body: unknown, status: number) => unknown;

--- a/templates/module-auth-ts/skeleton/src/auth/providers/clerk.ts
+++ b/templates/module-auth-ts/skeleton/src/auth/providers/clerk.ts
@@ -7,7 +7,7 @@
 // Environment variables:
 //   CLERK_SECRET_KEY — Clerk secret key from the dashboard
 
-import { createClerkClient } from "@clerk/backend";
+import { createClerkClient, verifyToken } from "@clerk/backend";
 import type { AuthResult } from "../types.js";
 import type { AuthProvider, AuthRequest } from "./types.js";
 import { registerProvider } from "./registry.js";
@@ -106,7 +106,7 @@ const clerkProvider: AuthProvider = {
       // The token is extracted from the Authorization header.
       const token = authHeader.replace(/^Bearer\s+/i, "");
       const verifiedToken = await clerkCb.execute(() =>
-        clerk.verifyToken(token)
+        verifyToken(token, { secretKey })
       );
 
       // Resolve user details — check cache first to avoid redundant API calls

--- a/templates/module-billing-ts/skeleton/src/billing/index.ts
+++ b/templates/module-billing-ts/skeleton/src/billing/index.ts
@@ -132,6 +132,17 @@ export async function createBillingService(
 
   logger.info("Billing service created", { provider: providerName, currency });
 
+  // Shared usage-summary computation — used by both the public
+  // getUsageSummary method and generateInvoice. Lives in the closure
+  // so callers don't depend on the returned object's `this` type.
+  function computeUsageSummary(
+    customerId: string,
+    period: BillingPeriod,
+  ): UsageSummary {
+    const records = tracker.getRecords(customerId, period);
+    return aggregator.aggregate(records, customerId, period);
+  }
+
   return {
     recordUsage(
       customerId: string,
@@ -143,12 +154,11 @@ export async function createBillingService(
     },
 
     getUsageSummary(customerId: string, period: BillingPeriod): UsageSummary {
-      const records = tracker.getRecords(customerId, period);
-      return aggregator.aggregate(records, customerId, period);
+      return computeUsageSummary(customerId, period);
     },
 
     generateInvoice(customerId: string, period: BillingPeriod): Invoice {
-      const summary = this.getUsageSummary(customerId, period);
+      const summary = computeUsageSummary(customerId, period);
       return invoiceGen.generate(customerId, period, summary.lineItems);
     },
 

--- a/templates/module-billing-ts/skeleton/src/billing/providers/stripe.ts
+++ b/templates/module-billing-ts/skeleton/src/billing/providers/stripe.ts
@@ -61,7 +61,7 @@ function createStripeProvider(): PaymentProvider {
       // Lazy load the Stripe SDK
       const { default: Stripe } = await import("stripe");
       client = new Stripe(secretKey, {
-        apiVersion: "2024-12-18.acacia",
+        apiVersion: "2025-02-24.acacia",
       });
 
       logger.info("Stripe provider initialized");
@@ -196,7 +196,7 @@ function createStripeProvider(): PaymentProvider {
           description: line.description ?? "",
           metric: "",
           quantity: line.quantity ?? 0,
-          unitPrice: line.unit_amount ?? 0,
+          unitPrice: line.price?.unit_amount ?? 0,
           amount: line.amount,
         })),
         totalAmount: inv.total,

--- a/templates/module-cache-ts/skeleton/src/cache/index.ts
+++ b/templates/module-cache-ts/skeleton/src/cache/index.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { validateBootstrap } from "./bootstrap.js";
-import { getProvider, listProviders } from "./providers/index.js";
+import { getProvider } from "./providers/index.js";
 import { cacheGetTotal, cacheOperationDuration } from "./metrics.js";
 import type { CacheProvider } from "./providers/types.js";
 import type { CacheConfig, SetOptions } from "./types.js";
@@ -94,7 +94,7 @@ export async function createCache(
     return `${nsPrefix}${key}`;
   }
 
-  return {
+  const cache: Cache = {
     provider,
 
     async get<T = unknown>(key: string): Promise<T | undefined> {
@@ -145,14 +145,14 @@ export async function createCache(
       opts?: SetOptions,
     ): Promise<T> {
       const start = performance.now();
-      const existing = await this.get<T>(key);
+      const existing = await cache.get<T>(key);
       if (existing !== undefined) {
         cacheOperationDuration.record(performance.now() - start, { operation: "getOrSet" });
         return existing;
       }
 
       const value = await factory();
-      await this.set(key, value, opts);
+      await cache.set(key, value, opts);
       cacheOperationDuration.record(performance.now() - start, { operation: "getOrSet" });
       return value;
     },
@@ -161,4 +161,6 @@ export async function createCache(
       await provider.close();
     },
   };
+
+  return cache;
 }

--- a/templates/module-cache-ts/skeleton/src/cache/providers/memcached.ts
+++ b/templates/module-cache-ts/skeleton/src/cache/providers/memcached.ts
@@ -1,4 +1,4 @@
-import memjs from "memjs";
+import memjs, { type Client } from "memjs";
 import type { CacheConfig } from "../types.js";
 import type { CacheProvider } from "./types.js";
 import { registerProvider } from "./registry.js";
@@ -15,7 +15,7 @@ import { registerProvider } from "./registry.js";
 //   password?: string   (optional SASL auth)
 //
 
-let client: memjs.Client | null = null;
+let client: Client | null = null;
 
 const memcachedProvider: CacheProvider = {
   name: "memcached",

--- a/templates/module-cache-ts/skeleton/src/cache/providers/redis.ts
+++ b/templates/module-cache-ts/skeleton/src/cache/providers/redis.ts
@@ -1,4 +1,4 @@
-import Redis from "ioredis";
+import { Redis } from "ioredis";
 import type { CacheConfig } from "../types.js";
 import type { CacheProvider } from "./types.js";
 import { registerProvider } from "./registry.js";

--- a/templates/module-cache-ts/skeleton/src/types/memjs.d.ts
+++ b/templates/module-cache-ts/skeleton/src/types/memjs.d.ts
@@ -1,0 +1,44 @@
+// ── Ambient types for memjs ────────────────────────────────────────
+//
+// memjs ships no type declarations and there is no @types/memjs.
+// This declares the subset of the API the memcached provider uses.
+//
+
+declare module "memjs" {
+  /** Options accepted by Client.create. */
+  export interface ClientOptions {
+    username?: string;
+    password?: string;
+    expires?: number;
+    [key: string]: unknown;
+  }
+
+  /** Options accepted by Client#set. */
+  export interface SetOptions {
+    expires?: number;
+    [key: string]: unknown;
+  }
+
+  /** Result shape returned by Client#get. */
+  export interface GetResult {
+    value: Buffer | null;
+    flags: Buffer | null;
+  }
+
+  export class Client {
+    /** Construct a client from a comma-separated server list. */
+    static create(servers?: string, options?: ClientOptions): Client;
+
+    get(key: string): Promise<GetResult>;
+    set(key: string, value: string | Buffer, options?: SetOptions): Promise<boolean>;
+    delete(key: string): Promise<boolean>;
+    flush(): Promise<Record<string, boolean | Error>>;
+    close(): void;
+  }
+
+  const memjs: {
+    Client: typeof Client;
+  };
+
+  export default memjs;
+}

--- a/templates/module-feature-flags-ts/skeleton/src/feature-flags/stores/redis.ts
+++ b/templates/module-feature-flags-ts/skeleton/src/feature-flags/stores/redis.ts
@@ -1,4 +1,4 @@
-import Redis from "ioredis";
+import { Redis } from "ioredis";
 import type { Flag } from "../types.js";
 import type { FlagStore } from "./types.js";
 import { registerStore } from "./registry.js";

--- a/templates/module-media-ts/skeleton/src/media/__tests__/mock.test.ts
+++ b/templates/module-media-ts/skeleton/src/media/__tests__/mock.test.ts
@@ -134,7 +134,7 @@ describe("mock media provider", () => {
       for (const asset of assets) {
         expect(asset.id).toBeDefined();
         expect(asset.size).toBeGreaterThan(0);
-        expect((asset as Record<string, unknown>).data).toBeUndefined();
+        expect((asset as unknown as Record<string, unknown>).data).toBeUndefined();
       }
     });
 

--- a/templates/module-media-ts/skeleton/src/media/providers/cloudinary.ts
+++ b/templates/module-media-ts/skeleton/src/media/providers/cloudinary.ts
@@ -30,6 +30,23 @@ interface CloudinaryConfig {
   apiSecret: string;
 }
 
+interface CloudinaryUploadResponse {
+  public_id: string;
+  original_filename?: string;
+  format?: string;
+  bytes?: number;
+  width?: number;
+  height?: number;
+  created_at: string;
+  version?: number;
+  etag?: string;
+}
+
+interface CloudinaryListResponse {
+  resources?: Record<string, unknown>[];
+  next_cursor?: string;
+}
+
 const FIT_MAP: Record<string, string> = {
   cover: "c_fill",
   contain: "c_fit",
@@ -108,13 +125,13 @@ function createCloudinaryProvider(): MediaProvider {
 
       const url = `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`;
 
-      const response = await breaker.execute(async () => {
+      const response = await breaker.execute(async (): Promise<CloudinaryUploadResponse> => {
         const res = await fetch(url, { method: "POST", body: formData, signal: AbortSignal.timeout(30_000) });
         if (!res.ok) {
           const text = await res.text();
           throw new Error(`Cloudinary upload failed (${res.status}): ${text}`);
         }
-        return res.json();
+        return res.json() as Promise<CloudinaryUploadResponse>;
       });
 
       return {
@@ -177,7 +194,7 @@ function createCloudinaryProvider(): MediaProvider {
       const auth = Buffer.from(`${apiKey}:${apiSecret}`).toString("base64");
       const url = `https://api.cloudinary.com/v1_1/${cloudName}/resources/image?${params}`;
 
-      const response = await breaker.execute(async () => {
+      const response = await breaker.execute(async (): Promise<CloudinaryListResponse> => {
         const res = await fetch(url, {
           signal: AbortSignal.timeout(30_000),
           headers: { Authorization: `Basic ${auth}` },
@@ -186,7 +203,7 @@ function createCloudinaryProvider(): MediaProvider {
           const text = await res.text();
           throw new Error(`Cloudinary list failed (${res.status}): ${text}`);
         }
-        return res.json();
+        return res.json() as Promise<CloudinaryListResponse>;
       });
 
       const assets: MediaAsset[] = (response.resources ?? []).map((r: Record<string, unknown>) => ({

--- a/templates/module-media-ts/skeleton/src/media/providers/uploadcare.ts
+++ b/templates/module-media-ts/skeleton/src/media/providers/uploadcare.ts
@@ -28,6 +28,23 @@ interface UploadcareConfig {
   secretKey: string;
 }
 
+interface UploadcareUploadResponse {
+  file: string;
+}
+
+interface UploadcareFileInfo {
+  original_filename?: string;
+  mime_type?: string;
+  size?: number;
+  image_info?: { width?: number; height?: number };
+  datetime_uploaded?: string;
+}
+
+interface UploadcareListResponse {
+  results?: Record<string, unknown>[];
+  next?: string | null;
+}
+
 const FIT_MAP: Record<string, string> = {
   cover: "crop",
   contain: "fit",
@@ -81,7 +98,7 @@ function createUploadcareProvider(): MediaProvider {
         }
       }
 
-      const response = await breaker.execute(async () => {
+      const response = await breaker.execute(async (): Promise<UploadcareUploadResponse> => {
         const res = await fetch("https://upload.uploadcare.com/base/", {
           method: "POST",
           signal: AbortSignal.timeout(30_000),
@@ -91,7 +108,7 @@ function createUploadcareProvider(): MediaProvider {
           const text = await res.text();
           throw new Error(`Uploadcare upload failed (${res.status}): ${text}`);
         }
-        return res.json();
+        return res.json() as Promise<UploadcareUploadResponse>;
       });
 
       const uuid = response.file;
@@ -102,7 +119,7 @@ function createUploadcareProvider(): MediaProvider {
       const uri = `/files/${uuid}/`;
       const signature = buildAuthHeader("GET", "application/json", "", uri, date, secretKey);
 
-      const info = await breaker.execute(async () => {
+      const info = await breaker.execute(async (): Promise<UploadcareFileInfo> => {
         const res = await fetch(`https://api.uploadcare.com${uri}`, {
           signal: AbortSignal.timeout(30_000),
           headers: {
@@ -112,7 +129,7 @@ function createUploadcareProvider(): MediaProvider {
           },
         });
         if (!res.ok) return {};
-        return res.json();
+        return res.json() as Promise<UploadcareFileInfo>;
       });
 
       const asset: MediaAsset = {
@@ -204,7 +221,7 @@ function createUploadcareProvider(): MediaProvider {
       const uri = `/files/?${params}`;
       const signature = buildAuthHeader("GET", "application/json", "", uri, date, secretKey);
 
-      const response = await breaker.execute(async () => {
+      const response = await breaker.execute(async (): Promise<UploadcareListResponse> => {
         const res = await fetch(`https://api.uploadcare.com${uri}`, {
           signal: AbortSignal.timeout(30_000),
           headers: {
@@ -217,7 +234,7 @@ function createUploadcareProvider(): MediaProvider {
           const text = await res.text();
           throw new Error(`Uploadcare list failed (${res.status}): ${text}`);
         }
-        return res.json();
+        return res.json() as Promise<UploadcareListResponse>;
       });
 
       const resultAssets: MediaAsset[] = (response.results ?? []).map((r: Record<string, unknown>) => ({

--- a/templates/module-queue-ts/skeleton/src/queue/providers/bullmq.ts
+++ b/templates/module-queue-ts/skeleton/src/queue/providers/bullmq.ts
@@ -43,8 +43,7 @@ const bullmqProvider: QueueProvider = {
 
     // Verify Redis connectivity — fail fast if unreachable
     try {
-      const queueEvents = await queue.client;
-      await queueEvents.ping();
+      await queue.waitUntilReady();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       await queue.close().catch(() => {});

--- a/templates/module-rate-limit-ts/skeleton/src/rate-limit/stores/redis.ts
+++ b/templates/module-rate-limit-ts/skeleton/src/rate-limit/stores/redis.ts
@@ -1,4 +1,4 @@
-import Redis from "ioredis";
+import { Redis } from "ioredis";
 import type { RateLimitStore, StoreConfig } from "./types.js";
 import { registerStore } from "./registry.js";
 

--- a/templates/module-search-ts/skeleton/src/search/providers/algolia.ts
+++ b/templates/module-search-ts/skeleton/src/search/providers/algolia.ts
@@ -68,7 +68,7 @@ function createAlgoliaProvider(): SearchProvider {
     if (operator === "in" && Array.isArray(value)) {
       return value.map((v) => `${field}:${JSON.stringify(v)}`).join(" OR ");
     }
-    if (operator === "=" || operator === "==") {
+    if (operator === "=") {
       return `${field}:${JSON.stringify(value)}`;
     }
     if (operator === "!=") {

--- a/templates/module-storage-ts/skeleton/src/storage/providers/gcs.ts
+++ b/templates/module-storage-ts/skeleton/src/storage/providers/gcs.ts
@@ -84,7 +84,7 @@ class GcsStorageProvider implements StorageProvider {
   async list(prefix?: string, opts?: ListOptions): Promise<ListResult> {
     const bucket = this.storage.bucket(this.bucketName);
 
-    const [files, , apiResponse] = await this.cb.execute(() =>
+    const [files, nextQuery] = await this.cb.execute(() =>
       withRetry(() =>
         bucket.getFiles({
           prefix: prefix ?? undefined,
@@ -106,7 +106,7 @@ class GcsStorageProvider implements StorageProvider {
 
     return {
       objects,
-      nextCursor: apiResponse?.nextPageToken,
+      nextCursor: nextQuery?.pageToken,
     };
   }
 

--- a/templates/multimodal-pipeline/skeleton/src/__tests__/image.test.ts
+++ b/templates/multimodal-pipeline/skeleton/src/__tests__/image.test.ts
@@ -76,7 +76,7 @@ describe("Processor Registry", () => {
   });
 
   it("throws on unknown modality", () => {
-    expect(() => getProcessorByModality("video" as "video")).toThrow(
+    expect(() => getProcessorByModality("video" as const)).toThrow(
       "No processor registered for modality",
     );
   });

--- a/templates/multimodal-pipeline/skeleton/src/processors/image.ts
+++ b/templates/multimodal-pipeline/skeleton/src/processors/image.ts
@@ -29,7 +29,7 @@ class ImageProcessor implements Processor {
     const maxDim = config.image.maxDimension;
 
     const raw = await readFile(filePath);
-    let buffer = raw;
+    let buffer: Buffer = raw;
     let width: number | undefined;
     let height: number | undefined;
 

--- a/templates/multimodal-pipeline/skeleton/src/providers/whisper.ts
+++ b/templates/multimodal-pipeline/skeleton/src/providers/whisper.ts
@@ -8,7 +8,7 @@
  */
 
 import OpenAI, { toFile } from "openai";
-import { readFile, stat } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 

--- a/templates/vscode-ext/skeleton/tsconfig.json
+++ b/templates/vscode-ext/skeleton/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "target": "ES2022",
     "lib": ["ES2022"],
     "outDir": "dist",

--- a/templates/worker-service/skeleton/src/worker/__tests__/health.test.ts
+++ b/templates/worker-service/skeleton/src/worker/__tests__/health.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { Hono } from "hono";
 
+// Shape of the /health and /readyz JSON responses. res.json() returns
+// unknown, so the tests parse into this typed boundary instead of any.
+interface HealthBody {
+  status: string;
+  consumer?: string;
+  scheduler?: string;
+}
+
 // ── Health Endpoint Tests ─────────────────────────────────────────
 //
 // Tests the /health and /readyz responses directly against a Hono
@@ -44,7 +52,7 @@ describe("/health", () => {
     const res = await app.request("/health");
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = (await res.json()) as HealthBody;
     expect(body.status).toBe("alive");
   });
 
@@ -62,7 +70,7 @@ describe("/readyz", () => {
     const res = await app.request("/readyz");
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = (await res.json()) as HealthBody;
     expect(body.status).toBe("ready");
     expect(body.consumer).toBe("polling");
     expect(body.scheduler).toBe("running");
@@ -73,7 +81,7 @@ describe("/readyz", () => {
     const res = await app.request("/readyz");
 
     expect(res.status).toBe(503);
-    const body = await res.json();
+    const body = (await res.json()) as HealthBody;
     expect(body.status).toBe("not_ready");
     expect(body.consumer).toBe("stopped");
   });
@@ -83,7 +91,7 @@ describe("/readyz", () => {
     const res = await app.request("/readyz");
 
     expect(res.status).toBe(503);
-    const body = await res.json();
+    const body = (await res.json()) as HealthBody;
     expect(body.status).toBe("not_ready");
     expect(body.scheduler).toBe("stopped");
   });
@@ -93,7 +101,7 @@ describe("/readyz", () => {
     const res = await app.request("/readyz");
 
     expect(res.status).toBe(503);
-    const body = await res.json();
+    const body = (await res.json()) as HealthBody;
     expect(body.consumer).toBe("stopped");
     expect(body.scheduler).toBe("stopped");
   });

--- a/templates/worker-service/skeleton/src/worker/__tests__/scheduler.test.ts
+++ b/templates/worker-service/skeleton/src/worker/__tests__/scheduler.test.ts
@@ -111,6 +111,12 @@ describe("cronMatches", () => {
 describe("CronScheduler", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // Pin to the top of a minute. Without this, fake timers start at the real
+    // wall-clock time, so a run that happens to begin within a few seconds of a
+    // minute boundary crosses it mid-test and the every-minute job fires twice —
+    // a load-sensitive CI flake. A fixed second-0 base keeps multi-second
+    // advances inside one minute.
+    vi.setSystemTime(new Date(2025, 0, 1, 12, 30, 0, 0));
   });
 
   afterEach(() => {

--- a/templates/worker-service/skeleton/src/worker/consumer/types.ts
+++ b/templates/worker-service/skeleton/src/worker/consumer/types.ts
@@ -34,5 +34,14 @@ export interface QueueProvider {
 /** Function that processes a single dequeued job. */
 export type JobHandler<T = unknown> = (job: JobDefinition<T>) => Promise<void>;
 
-/** Map of job names to their handler functions. */
-export type HandlerMap = Record<string, JobHandler>;
+/**
+ * Map of job names to their handler functions.
+ *
+ * The value is written with method syntax so handlers declared against a
+ * specific payload type (e.g. JobHandler<NotificationPayload>) register
+ * without widening their parameter. The consumer always dispatches a
+ * JobDefinition whose data is unknown until the handler narrows it.
+ */
+export interface HandlerMap {
+  [jobName: string]: { handle(job: JobDefinition): Promise<void> }["handle"];
+}


### PR DESCRIPTION
## What

template-doctor never ran end-to-end — six bugs aborted or short-circuited it, and earlier runs masked the non-zero exit through `tee`/`echo`, so the weekly CI report was effectively empty and **19 TS skeletons silently accumulated `tsc --noEmit` debt** that nothing gated. This repairs the tool, turns the weekly report-only workflow into a real **PR gate**, fixes every broken skeleton, and corrects two packaging defects the now-working sweep exposed.

## template-doctor repairs (6 bugs)

| File | Bug | Fix |
| --- | --- | --- |
| `run.sh` | each sourced check script resets `SCRIPT_DIR` → lookup becomes `checks/checks/X.sh` → every group after the first skipped | capture `CHECKS_DIR` before sourcing; add `--fail-on <sev>` gate (report-only default) |
| `checks/ts.sh`, `checks/python.sh` | `[ cond ] && finding` as a function's last statement returns non-zero on a **clean** skeleton → `set -e` aborts on the first clean template | `if/fi` |
| `checks/ts.sh` | `[ ! -d node_modules ]` install-skip reused a **stale** tree → phantom tsc errors against old dep APIs (and masked a real error in `module-queue-ts`) | reinstall when stale vs `package.json`; drop the lockfile to re-resolve |
| `checks/go.sh` | `_go_build` gated on output presence → a clean build that printed a linker warning was a false failure | gate on exit code |
| `checks/java.sh` | `_java_outdated`'s `grep \| while` returns non-zero under `pipefail` when nothing is outdated → `set -e` aborts **before** python/render/gate, so the gate was always red | swallow grep no-match |

## CI gate

`.github/workflows/template-doctor.yml` ran weekly only (report-only, opens a tracking issue). Added a **path-scoped `pull_request` trigger** that runs `--fail-on error`; the report posts to the job summary even on failure. Weekly report + issue stay report-only.

## Skeleton typecheck debt (19 skeletons, ~218 errors)

The existing "Validate Templates" job only runs each skeleton's `npm test`, never `tsc`. All fixed at the root cause — **no `any`/`as any`/`@ts-ignore`/`@ts-expect-error`/`eslint-disable` silencers, all placeholders preserved, zero dependency-version churn**:

- `verbatimModuleSyntax` vs CommonJS/ESM mismatch (infra-aws, vscode-ext, chrome-ext) — tsconfig module config
- unknown-typed boundary values (module-media, worker-service, module-cache) — proper narrowing + ambient types (e.g. `memjs.d.ts`)
- un-awaited `T | Promise<T>` (eval-harness, module-cache) — `await`
- placeholder inside an import specifier (infra-aws, mcp-server-ts) — typed `Record` barrels + an `isTransportName` type guard
- a genuine **syntax error** in agentic-loop's openai provider
- Redis-client API drift in module-queue-ts (`bullmq` `IRedisClient` no longer exposes `ping()` → `queue.waitUntilReady()`)
- assorted small fixes across module-* + api-gateway (stale `@ts-expect-error`), data/multimodal pipelines

## Packaging

- `.gitignore`: the blanket `bin/` rule (build output) also excluded two template **source** entrypoints — `infra-aws/skeleton/bin/app.ts` (CDK app) and `eval-harness/skeleton/bin/run-evals.ts` (CLI runner) — so those templates shipped incomplete. Re-include `templates/**/bin/`.

## Verification

- `bash scripts/template-doctor/run.sh --fail-on error` → **exit 0** (439 findings · **errors 0** · warnings 277 · info 162).
- Independent `tsc --noEmit` across all previously-flagged skeletons → **0 errors each**.
- No forbidden type-safety shortcuts in the diff (incl. new untracked files).

## Known follow-up (pre-existing, not introduced)

`infra-aws/lib/stack.ts` unconditionally imports the VPC/RDS constructs the renderer drops in feature-off scenarios — a render-time defect needing renderer-level conditionals. tsc is clean.