### PR TITLE
fix(catalog): wire the maintained schema validator + add renderer content-conditionals

### DIFF
--- a/schemas/template.schema.json
+++ b/schemas/template.schema.json
@@ -177,7 +177,7 @@
         "when": {
           "type": "string",
           "minLength": 1,
-          "description": "Variable name that controls inclusion."
+          "description": "Boolean expression over variable names that controls inclusion (e.g. \"IncludeVpc\" or \"IncludeVpc || IncludeRds\"). Supports ||, &&, !, and parentheses."
         }
       }
     },

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -69,11 +69,9 @@ if [ -f "$TEMPLATE_DIR/template.yaml" ]; then
   echo ""
   echo -e "${BOLD}Schema validation:${RESET}"
 
-  if npx ajv validate \
-    -s schemas/template.schema.json \
-    -d "$TEMPLATE_DIR/template.yaml" \
-    --spec=draft2020 \
-    --strict=false 2>&1; then
+  if node scripts/validate-schema.mjs \
+    --schema schemas/template.schema.json \
+    --data "$TEMPLATE_DIR/template.yaml" 2>&1; then
     pass "template.yaml conforms to schema"
   else
     fail "template.yaml does not conform to schema"

--- a/sdk/__tests__/conditions.test.ts
+++ b/sdk/__tests__/conditions.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { applyContentConditionals, evalCondition } from '../src/conditions.js';
+
+describe('evalCondition', () => {
+  const r = { IncludeVpc: 'false', IncludeRds: 'true', IncludeMonitoring: 'true' };
+
+  it('evaluates a bare variable', () => {
+    expect(evalCondition('IncludeRds', r)).toBe(true);
+    expect(evalCondition('IncludeVpc', r)).toBe(false);
+  });
+
+  it('treats unset / empty / 0 as false, anything else as true', () => {
+    expect(evalCondition('Missing', r)).toBe(false);
+    expect(evalCondition('Blank', { Blank: '' })).toBe(false);
+    expect(evalCondition('Zero', { Zero: '0' })).toBe(false);
+    expect(evalCondition('Name', { Name: 'lambda' })).toBe(true);
+  });
+
+  it('evaluates || (RDS-needs-VPC dependency)', () => {
+    expect(evalCondition('IncludeVpc || IncludeRds', r)).toBe(true);
+    expect(evalCondition('IncludeVpc || IncludeRds', { IncludeVpc: 'false', IncludeRds: 'false' })).toBe(
+      false,
+    );
+  });
+
+  it('evaluates &&, !, and parentheses with precedence', () => {
+    expect(evalCondition('IncludeRds && IncludeMonitoring', r)).toBe(true);
+    expect(evalCondition('IncludeRds && IncludeVpc', r)).toBe(false);
+    expect(evalCondition('!IncludeVpc', r)).toBe(true);
+    expect(evalCondition('!IncludeRds', r)).toBe(false);
+    expect(evalCondition('(IncludeVpc || IncludeRds) && IncludeMonitoring', r)).toBe(true);
+    expect(evalCondition('IncludeVpc || IncludeRds && IncludeVpc', r)).toBe(false); // && binds tighter
+  });
+});
+
+describe('applyContentConditionals', () => {
+  const resolved = { IncludeVpc: 'false', IncludeRds: 'true' };
+
+  it('passes content through untouched when there are no markers', () => {
+    const src = 'line a\nline b\n';
+    expect(applyContentConditionals(src, resolved)).toBe(src);
+  });
+
+  it('keeps a block (dropping markers) when the condition is true', () => {
+    const src = ['before', '// #if IncludeRds', 'import { Db } from "./db";', '// #endif', 'after'].join(
+      '\n',
+    );
+    expect(applyContentConditionals(src, resolved)).toBe(['before', 'import { Db } from "./db";', 'after'].join('\n'));
+  });
+
+  it('drops a block entirely when the condition is false', () => {
+    const src = ['before', '// #if IncludeVpc', 'import { Vpc } from "./vpc";', '// #endif', 'after'].join(
+      '\n',
+    );
+    expect(applyContentConditionals(src, resolved)).toBe(['before', 'after'].join('\n'));
+  });
+
+  it('evaluates expression conditions (RDS keeps a VPC import)', () => {
+    const src = ['// #if IncludeVpc || IncludeRds', 'import { Vpc } from "./vpc";', '// #endif'].join('\n');
+    expect(applyContentConditionals(src, resolved)).toBe('import { Vpc } from "./vpc";');
+  });
+
+  it('supports nesting — inner block dropped when outer kept', () => {
+    const src = [
+      '// #if IncludeRds',
+      'outer',
+      '// #if IncludeVpc',
+      'inner',
+      '// #endif',
+      'tail',
+      '// #endif',
+    ].join('\n');
+    expect(applyContentConditionals(src, resolved)).toBe(['outer', 'tail'].join('\n'));
+  });
+
+  it('drops a whole nested region when the outer condition is false', () => {
+    const src = [
+      '// #if IncludeVpc',
+      'outer',
+      '// #if IncludeRds',
+      'inner',
+      '// #endif',
+      '// #endif',
+      'kept',
+    ].join('\n');
+    expect(applyContentConditionals(src, resolved)).toBe('kept');
+  });
+
+  it('recognizes hash-comment markers too', () => {
+    const src = ['# #if IncludeRds', 'rds: true', '# #endif', '# #if IncludeVpc', 'vpc: true', '# #endif'].join(
+      '\n',
+    );
+    expect(applyContentConditionals(src, resolved)).toBe('rds: true');
+  });
+
+  it('leaves #ifdef-style tokens inert', () => {
+    const src = ['// #ifdef FOO', 'kept', '// #endifx'].join('\n');
+    // Neither line is a real marker, so both pass through untouched.
+    expect(applyContentConditionals(src, {})).toBe(src);
+  });
+});
+
+describe('applyContentConditionals — malformed markers fail loud', () => {
+  it('throws on an empty #if condition (instead of leaking the block)', () => {
+    const src = ['// #if', 'body', '// #endif', 'tail'].join('\n');
+    expect(() => applyContentConditionals(src, {})).toThrow("Empty '#if' condition");
+  });
+
+  it('throws on an #endif with no open #if', () => {
+    const src = ['a', '// #endif', 'b'].join('\n');
+    expect(() => applyContentConditionals(src, {})).toThrow("'#endif' without matching '#if'");
+  });
+
+  it('throws on an unclosed #if', () => {
+    const src = ['// #if Flag', 'body'].join('\n');
+    expect(() => applyContentConditionals(src, { Flag: 'true' })).toThrow("Unclosed '#if'");
+  });
+});

--- a/sdk/__tests__/renderer.test.ts
+++ b/sdk/__tests__/renderer.test.ts
@@ -131,4 +131,39 @@ describe('renderTemplate', () => {
     const result = renderTemplate(manifest, files, { Name: 'foo' });
     expect(result.files[0].content).toBe('foo uses foo');
   });
+
+  it('strips inline #if/#endif blocks whose condition is false', () => {
+    const manifest = minimalManifest({
+      variables: [
+        { name: 'IncludeVpc', type: 'bool', placeholder: '__INCLUDE_VPC__', description: 'Vpc' },
+      ],
+    });
+    const files: SkeletonFile[] = [
+      { path: 'stack.ts', content: ['import a;', '// #if IncludeVpc', 'import vpc;', '// #endif', 'use();'].join('\n') },
+    ];
+    const off = renderTemplate(manifest, files, { IncludeVpc: false });
+    expect(off.files[0].content).toBe(['import a;', 'use();'].join('\n'));
+    const on = renderTemplate(manifest, files, { IncludeVpc: true });
+    expect(on.files[0].content).toBe(['import a;', 'import vpc;', 'use();'].join('\n'));
+  });
+
+  it('evaluates expression file-conditionals (A || B)', () => {
+    const manifest = minimalManifest({
+      variables: [
+        { name: 'IncludeVpc', type: 'bool', placeholder: '__INCLUDE_VPC__', description: 'Vpc' },
+        { name: 'IncludeRds', type: 'bool', placeholder: '__INCLUDE_RDS__', description: 'Rds' },
+      ],
+      conditionals: [{ path: 'lib/vpc.ts', when: 'IncludeVpc || IncludeRds' }],
+    });
+    const files: SkeletonFile[] = [
+      { path: 'lib/index.ts', content: 'x' },
+      { path: 'lib/vpc.ts', content: 'vpc' },
+    ];
+    // RDS on, VPC off — VPC file must survive because RDS needs it.
+    const rdsOnly = renderTemplate(manifest, files, { IncludeVpc: false, IncludeRds: true });
+    expect(rdsOnly.files.map((f) => f.path)).toContain('lib/vpc.ts');
+    // Both off — VPC file excluded.
+    const neither = renderTemplate(manifest, files, { IncludeVpc: false, IncludeRds: false });
+    expect(neither.files.map((f) => f.path)).not.toContain('lib/vpc.ts');
+  });
 });

--- a/sdk/__tests__/validator.test.ts
+++ b/sdk/__tests__/validator.test.ts
@@ -68,7 +68,7 @@ describe('validateManifest', () => {
           conditionals: [{ path: 'src/foo.ts', when: 'Missing' }],
         }),
       ),
-    ).toThrow("Conditional references unknown variable 'Missing'");
+    ).toThrow("references unknown variable 'Missing'");
   });
 
   it('rejects conditional referencing non-bool variable', () => {
@@ -86,7 +86,7 @@ describe('validateManifest', () => {
           conditionals: [{ path: 'src/foo.ts', when: 'Name' }],
         }),
       ),
-    ).toThrow("must reference bool variable, got 'string'");
+    ).toThrow("must reference bool variables, got 'string'");
   });
 
   it('accepts conditional referencing bool variable', () => {

--- a/sdk/schemas/template.schema.json
+++ b/sdk/schemas/template.schema.json
@@ -177,7 +177,7 @@
         "when": {
           "type": "string",
           "minLength": 1,
-          "description": "Variable name that controls inclusion."
+          "description": "Boolean expression over variable names that controls inclusion (e.g. \"IncludeVpc\" or \"IncludeVpc || IncludeRds\"). Supports ||, &&, !, and parentheses."
         }
       }
     },

--- a/sdk/src/conditions.ts
+++ b/sdk/src/conditions.ts
@@ -1,0 +1,136 @@
+/**
+ * Boolean conditions for template rendering.
+ *
+ * Conditions appear in two places, both sharing one tiny boolean grammar over
+ * variable names:
+ *   - manifest `conditionals[].when` — file-level inclusion
+ *   - inline `#if <expr> ... #endif` comment markers — content-level inclusion
+ *
+ *   expr  := or
+ *   or    := and ('||' and)*
+ *   and   := unary ('&&' unary)*
+ *   unary := '!' unary | primary
+ *   prim  := '(' expr ')' | IDENT
+ *
+ * A variable is truthy unless its resolved value is '', 'false', or '0' (or it
+ * is unset). Bool variables resolve to 'true' / 'false', so the common single
+ * name case (`when: IncludeVpc`) behaves as expected, and richer dependencies
+ * such as `IncludeVpc || IncludeRds` are expressible.
+ */
+
+import { TemplateRenderError } from './errors.js';
+
+const FALSY = new Set(['', 'false', '0']);
+
+function isTruthy(value: string | undefined): boolean {
+  return value !== undefined && !FALSY.has(value);
+}
+
+/** Evaluate a boolean expression over resolved variable values. */
+export function evalCondition(expr: string, resolved: Record<string, string>): boolean {
+  const tokens = expr.match(/\|\||&&|!|\(|\)|[A-Za-z_]\w*/g) ?? [];
+  let pos = 0;
+  const peek = (): string | undefined => tokens[pos];
+
+  function parseOr(): boolean {
+    let v = parseAnd();
+    while (peek() === '||') {
+      pos++;
+      const r = parseAnd();
+      v = v || r;
+    }
+    return v;
+  }
+  function parseAnd(): boolean {
+    let v = parseUnary();
+    while (peek() === '&&') {
+      pos++;
+      const r = parseUnary();
+      v = v && r;
+    }
+    return v;
+  }
+  function parseUnary(): boolean {
+    if (peek() === '!') {
+      pos++;
+      return !parseUnary();
+    }
+    return parsePrimary();
+  }
+  function parsePrimary(): boolean {
+    const t = peek();
+    if (t === '(') {
+      pos++;
+      const v = parseOr();
+      if (peek() === ')') pos++;
+      return v;
+    }
+    pos++; // consume identifier / literal (or undefined at end of input)
+    if (t === 'true') return true;
+    if (t === 'false') return false;
+    return isTruthy(t === undefined ? undefined : resolved[t]);
+  }
+
+  return parseOr();
+}
+
+const LITERALS = new Set(['true', 'false']);
+
+/** The distinct variable identifiers referenced by a condition expression. */
+export function conditionVariables(expr: string): string[] {
+  return [...new Set(expr.match(/[A-Za-z_]\w*/g) ?? [])].filter((id) => !LITERALS.has(id));
+}
+
+// `#if\b(.*)` (not `#if\s+(.+)`) so a missing condition is recognized as a
+// malformed marker rather than slipping through as ordinary content — otherwise
+// its `#endif` would still be consumed and over-pop the block stack, silently
+// leaking the rest of the block into the output. `\b` keeps `#ifdef` etc. inert.
+const IF_RE = /^[ \t]*(?:\/\/|#)\s*#if\b(.*)$/;
+const ENDIF_RE = /^[ \t]*(?:\/\/|#)\s*#endif\s*$/;
+
+/**
+ * Strip inline `#if <expr> ... #endif` comment blocks whose condition is false,
+ * and remove the marker lines from blocks that are kept. Markers are ordinary
+ * line comments (`// #if` for C-style sources, `# #if` for hash-comment sources)
+ * so the unrendered skeleton still parses and type-checks with every block
+ * present. Nesting is supported. Malformed markers (empty condition, an `#endif`
+ * with no open `#if`, or an unclosed `#if`) throw rather than silently misrender.
+ */
+export function applyContentConditionals(
+  content: string,
+  resolved: Record<string, string>,
+): string {
+  if (!content.includes('#if') && !content.includes('#endif')) return content;
+
+  const out: string[] = [];
+  const keepStack: boolean[] = [];
+  const keeping = (): boolean => keepStack.every(Boolean);
+  let lineNo = 0;
+
+  for (const line of content.split('\n')) {
+    lineNo += 1;
+    const ifMatch = IF_RE.exec(line);
+    if (ifMatch) {
+      const expr = ifMatch[1].trim();
+      if (expr === '') {
+        throw new TemplateRenderError(`Empty '#if' condition at line ${lineNo}`);
+      }
+      keepStack.push(keeping() && evalCondition(expr, resolved));
+      continue;
+    }
+    if (ENDIF_RE.test(line)) {
+      if (keepStack.length === 0) {
+        throw new TemplateRenderError(`'#endif' without matching '#if' at line ${lineNo}`);
+      }
+      keepStack.pop();
+      continue;
+    }
+    if (keeping()) out.push(line);
+  }
+
+  if (keepStack.length > 0) {
+    throw new TemplateRenderError(`Unclosed '#if' block (${keepStack.length} still open)`);
+  }
+
+  return out.join('\n');
+}

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -18,3 +18,10 @@ export class VariableResolutionError extends NanohypeError {
     this.name = 'VariableResolutionError';
   }
 }
+
+export class TemplateRenderError extends NanohypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TemplateRenderError';
+  }
+}

--- a/sdk/src/renderer.ts
+++ b/sdk/src/renderer.ts
@@ -1,3 +1,4 @@
+import { applyContentConditionals, evalCondition } from './conditions.js';
 import { resolveVariables } from './resolver.js';
 import type { RenderResult, SkeletonFile, TemplateHook, TemplateManifest } from './types.js';
 import { validateManifest } from './validator.js';
@@ -43,10 +44,12 @@ export function renderTemplate(
 
   // Step 8: render
 
-  // Build conditional exclusion set
+  // Build conditional exclusion set. `when` is a boolean expression over
+  // variable names (a bare name is the common case), so RDS-needs-VPC style
+  // dependencies are expressible as `IncludeVpc || IncludeRds`.
   const excludedPaths = new Set<string>();
   for (const cond of manifest.conditionals ?? []) {
-    if (resolved[cond.when] === 'false') {
+    if (!evalCondition(cond.when, resolved)) {
       excludedPaths.add(cond.path);
     }
   }
@@ -66,8 +69,9 @@ export function renderTemplate(
       renderedPath = renderedPath.replaceAll(v.placeholder, resolved[v.name]);
     }
 
-    // Replace placeholders in content
-    let renderedContent = file.content;
+    // Strip inline #if/#endif blocks first, then replace placeholders in the
+    // surviving content.
+    let renderedContent = applyContentConditionals(file.content, resolved);
     for (const v of manifest.variables) {
       renderedContent = renderedContent.replaceAll(v.placeholder, resolved[v.name]);
     }

--- a/sdk/src/validator.ts
+++ b/sdk/src/validator.ts
@@ -1,3 +1,4 @@
+import { conditionVariables } from './conditions.js';
 import { ManifestValidationError } from './errors.js';
 import type { CompositeManifest, TemplateManifest } from './types.js';
 
@@ -17,18 +18,21 @@ export function validateManifest(manifest: TemplateManifest): void {
     }
   }
 
-  // Conditionals must reference bool variables
+  // Conditionals' `when` is a boolean expression; every variable it references
+  // must exist and be a bool.
   for (const cond of manifest.conditionals ?? []) {
-    const ref = manifest.variables.find((v) => v.name === cond.when);
-    if (!ref) {
-      throw new ManifestValidationError(
-        `Conditional references unknown variable '${cond.when}'`,
-      );
-    }
-    if (ref.type !== 'bool') {
-      throw new ManifestValidationError(
-        `Conditional 'when' must reference bool variable, got '${ref.type}' for '${cond.when}'`,
-      );
+    for (const name of conditionVariables(cond.when)) {
+      const ref = manifest.variables.find((v) => v.name === name);
+      if (!ref) {
+        throw new ManifestValidationError(
+          `Conditional 'when' references unknown variable '${name}' (in '${cond.when}')`,
+        );
+      }
+      if (ref.type !== 'bool') {
+        throw new ManifestValidationError(
+          `Conditional 'when' must reference bool variables, got '${ref.type}' for '${name}'`,
+        );
+      }
     }
   }
 

--- a/templates/infra-aws/skeleton/lib/stack.ts
+++ b/templates/infra-aws/skeleton/lib/stack.ts
@@ -1,10 +1,17 @@
 import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { ComputeConstruct } from "./constructs/compute";
 import { ApiConstruct } from "./constructs/api";
+// #if IncludeVpc || IncludeRds
 import { VpcConstruct } from "./constructs/vpc";
+// #endif
+// #if IncludeRds
 import { DatabaseConstruct } from "./constructs/database";
+// #endif
+// #if IncludeMonitoring
 import { MonitoringConstruct } from "./constructs/monitoring";
+// #endif
 
 export interface ServiceStackProps extends cdk.StackProps {
   readonly includeVpc: boolean;
@@ -16,38 +23,46 @@ export class ServiceStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ServiceStackProps) {
     super(scope, id, props);
 
-    // VPC — created when includeVpc is true, or when RDS requires it
-    let vpc: VpcConstruct | undefined;
+    // VPC — created when includeVpc is true, or when RDS requires it. Held as the
+    // underlying IVpc so the compute/api wiring below stays valid even when the
+    // VpcConstruct import is conditionally rendered out.
+    let vpc: ec2.IVpc | undefined;
+    // #if IncludeVpc || IncludeRds
     if (props.includeVpc || props.includeRds) {
-      vpc = new VpcConstruct(this, "Vpc");
+      vpc = new VpcConstruct(this, "Vpc").vpc;
     }
+    // #endif
 
     // Compute — Lambda function or ECS Fargate service
     const compute = new ComputeConstruct(this, "Compute", {
-      vpc: vpc?.vpc,
+      vpc,
     });
 
     // API — API Gateway (Lambda) or ALB (ECS)
     const api = new ApiConstruct(this, "Api", {
       compute,
-      vpc: vpc?.vpc,
+      vpc,
     });
 
     // Database — RDS PostgreSQL when includeRds is true
+    // #if IncludeRds
     if (props.includeRds && vpc) {
       new DatabaseConstruct(this, "Database", {
-        vpc: vpc.vpc,
+        vpc,
         computeSecurityGroup: "securityGroup" in compute ? compute.securityGroup : undefined,
       });
     }
+    // #endif
 
     // Monitoring — CloudWatch dashboard and alarms when includeMonitoring is true
+    // #if IncludeMonitoring
     if (props.includeMonitoring) {
       new MonitoringConstruct(this, "Monitoring", {
         compute,
         api,
       });
     }
+    // #endif
 
     // Stack outputs
     new cdk.CfnOutput(this, "ApiEndpointUrl", {

--- a/templates/infra-aws/template.yaml
+++ b/templates/infra-aws/template.yaml
@@ -75,7 +75,7 @@ variables:
 
 conditionals:
   - path: "lib/constructs/vpc.ts"
-    when: IncludeVpc
+    when: IncludeVpc || IncludeRds
   - path: "lib/constructs/database.ts"
     when: IncludeRds
   - path: "lib/constructs/monitoring.ts"


### PR DESCRIPTION
Closes the two deferred items from the template-doctor work (#121).

## 1 — Schema validation CI was red (ajv-cli)

`scripts/validate.sh` still invoked `npx ajv validate`, but ajv-cli was removed (its pinned js-yaml@3 transitive carried an unpatched DoS advisory) in favour of `scripts/validate-schema.mjs`, which drives the `ajv` library directly. Only the npm `validate:*` scripts were migrated — `validate.sh` (the per-template loop the **"Validate template catalog"** job runs) was missed, so every run failed with `could not determine executable to run`.

**Fix:** point `validate.sh` at `validate-schema.mjs`. All 95 `template.yaml` files validate; the job goes green.

## 2 — infra-aws render-time defect (renderer content-conditionals)

The renderer only supported **file-level** conditionals. `infra-aws/lib/stack.ts` imported `VpcConstruct`/`DatabaseConstruct`/`MonitoringConstruct` unconditionally, but those files are dropped when their feature is off — so feature-off renders didn't compile. Latent bug too: `vpc.ts` dropped `when IncludeVpc`, yet RDS also needs a VPC.

- **`sdk/src/conditions.ts`** (new): a small boolean-expression evaluator over variable names (`||`, `&&`, `!`, parens, `true`/`false`) + `applyContentConditionals`, which strips inline `// #if <expr> … // #endif` (and `# #if`) comment blocks. Markers are ordinary comments, so the **unrendered skeleton still type-checks** with every block present (keeps the template-doctor gate green). Malformed markers (empty condition, unbalanced `#if`/`#endif`) **throw** rather than silently leaking content.
- **`renderer.ts`**: file-conditionals evaluate `when` as an expression; content runs through `applyContentConditionals` before placeholder replacement.
- **`validator.ts`**: a conditional's `when` is validated as an expression — every referenced variable must exist and be a bool.
- **`infra-aws/template.yaml`**: `vpc.ts` → `when: IncludeVpc || IncludeRds`.
- **`infra-aws/.../stack.ts`**: VPC/RDS/monitoring imports + instantiations wrapped in `#if` blocks; local `vpc` held as `ec2.IVpc | undefined` so the always-present compute/api wiring survives when the VpcConstruct import is rendered out.

## Verification

- **99 SDK tests** pass (incl. a new `conditions.test.ts`: evaluator precedence, nesting, hash-comment markers, malformed-marker throws).
- infra-aws renders to **tsc=0 across all 8 feature combos × 2 compute targets**, including RDS-on/VPC-off (VPC correctly retained).
- Unrendered skeleton stays **tsc=0**; no other skeleton contains `#if` markers (so nothing else is affected).
- Adversarial review (3 lenses: evaluator / blast-radius / infra-semantics) returned **sound, 0 actionable findings** — the two low/nit findings about malformed markers are addressed by the fail-loud hardening above.