### PR TITLE
Bind tenant pods to their IAM role via EKS Pod Identity

### DIFF
--- a/standards/platform-tenant-contract.json
+++ b/standards/platform-tenant-contract.json
@@ -28,7 +28,7 @@
       },
       {
         "path": "<app>/chart/templates/serviceaccount.yaml",
-        "description": "ServiceAccount used by the pod. `eks.amazonaws.com/role-arn` annotation is rendered from `aws.platformRoleArn` per-env value, pointing at the landing-zone-owned IRSA role."
+        "description": "ServiceAccount used by the pod. It carries no role-arn annotation: the landing-zone <app>-platform component creates an EKS Pod Identity association binding this ServiceAccount to its IAM role. `serviceAccount.name` must be pinned to the app name so it matches the association's `service_account`."
       },
       {
         "path": "<app>/chart/templates/networkpolicy.yaml",
@@ -95,7 +95,7 @@
       }
     ],
     "do_not": [
-      "Do NOT scaffold IAM roles inside the chart. The IRSA role is provisioned by the corresponding landing-zone <app>-platform component; the chart's ServiceAccount annotates with its ARN via `aws.platformRoleArn`.",
+      "Do NOT scaffold IAM roles inside the chart, and do NOT annotate the ServiceAccount with a role ARN. The IAM role is provisioned by the corresponding landing-zone <app>-platform component, which also creates the EKS Pod Identity association that binds the ServiceAccount to it — the chart carries no role ARN.",
       "Do NOT add cloud-substrate tofu (VPCs, base IAM, KMS keys) inside the app. Substrate lives in `nanohype/landing-zone` as a per-app `<app>-platform` component.",
       "Do NOT add cluster-level addons in the chart (ingress controller, cert-manager, External Secrets, observability stack). Those are gitops-repo concerns in `nanohype/eks-gitops` or `aks-gitops`.",
       "Do NOT skip per-env `values-{dev,staging,production}.yaml` — every chart has three deltas even if some are empty.",

--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -7,7 +7,7 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
 - **Helm chart** in `chart/` with `Chart.yaml`, `values.yaml`, per-env deltas (`values-dev.yaml`, `values-staging.yaml`, `values-production.yaml`), and templates for:
   - `deployment.yaml` — non-root, read-only rootfs, distinct `/healthz` + `/readyz` probes, OTel resource attrs + OTLP wiring (`:4318`, `http/protobuf`), `terminationGracePeriodSeconds` headroom
   - `service.yaml` — ClusterIP
-  - `serviceaccount.yaml` — `eks.amazonaws.com/role-arn` rendered from `aws.platformRoleArn` (the landing-zone-owned IRSA role), never inline IAM
+  - `serviceaccount.yaml` — pod ServiceAccount, name pinned to the app name; bound to its IAM role by a landing-zone EKS Pod Identity association, so no role-arn annotation and never inline IAM
   - `networkpolicy.yaml` — default-deny + explicit egress allow-list (DNS + `:443`, IMDS blocked)
   - `externalsecret.yaml` — *(toggle, off by default)* AWS Secrets Manager → k8s Secret via External Secrets Operator, mounted `envFrom`
   - `prometheusrule.yaml` — *(on by default)* SLI recording rules + multi-window multi-burn-rate error-budget alerts (the `observability-slo` standard), driven by the `slo.*` values
@@ -47,7 +47,7 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
     templates/
       deployment.yaml
       service.yaml
-      serviceaccount.yaml          # role-arn from aws.platformRoleArn (landing-zone IRSA role)
+      serviceaccount.yaml          # name pinned to app; role bound via landing-zone Pod Identity association
       networkpolicy.yaml           # default-deny + egress allow-list
       externalsecret.yaml          # toggle: Secrets Manager → k8s Secret (off by default)
       prometheusrule.yaml          # SLO recording rules + burn-rate alerts (on by default)
@@ -92,7 +92,7 @@ If any of these are missing on the target cluster, the rendered app's `platform.
 1. Render: `helm template chart/ -f chart/values-dev.yaml` (sanity)
 2. Apply the Platform + BudgetPolicy CRs: `kubectl apply -f platform.yaml`
 3. Wait for `Platform.status.phase = Ready`
-4. Set `aws.platformRoleArn` (and any per-env secret paths) in `values-{env}.yaml` from the landing-zone `<app>-platform` component outputs
+4. Set any per-env secret paths in `values-{env}.yaml`; the pod's IAM role is bound by the landing-zone `<app>-platform` component's EKS Pod Identity association (no role ARN in the chart)
 5. Copy `gitops/applicationset-entry.yaml` into the gitops repo as a new entry in the appropriate ApplicationSet
 6. ArgoCD picks up the entry on next sync and rolls out the chart
 7. For new image tags: update `values-{env}.yaml` `image.tag`, commit, ArgoCD reconciles

--- a/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_serviceaccount.tpl
+++ b/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_serviceaccount.tpl
@@ -1,7 +1,10 @@
 {{/*
-ServiceAccount with the tenant's IRSA role annotation. The role itself is
-provisioned by landing-zone's <app>-platform component; this only references its
-ARN via `aws.platformRoleArn`. No inline IAM is defined here.
+ServiceAccount for the tenant's pods. Its AWS identity is bound out of band by
+an EKS Pod Identity association (namespace + ServiceAccount -> IAM role) created
+by landing-zone's <app>-platform component, so the pod assumes its role without
+any role-arn annotation and no inline IAM is defined here. The ServiceAccount
+name must match the association's `service_account`, so set `serviceAccount.name`
+to the app name (see values.yaml).
 
 Usage (consumer templates/serviceaccount.yaml):
   {{ include "tenant-chart-base.serviceaccount" . }}
@@ -14,14 +17,9 @@ metadata:
   name: {{ include "tenant-chart-base.serviceAccountName" . }}
   labels:
     {{- include "tenant-chart-base.labels" . | nindent 4 }}
-  {{- if or .Values.aws.platformRoleArn .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- if .Values.aws.platformRoleArn }}
-    eks.amazonaws.com/role-arn: {{ .Values.aws.platformRoleArn | quote }}
-    {{- end }}
-    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/templates/k8s-app-tenant/skeleton/chart/values-dev.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-dev.yaml
@@ -7,11 +7,6 @@ replicaCount: 1
 commonLabels:
   platform.nanohype.dev/environment: dev
 
-# Set from landing-zone's __APP_NAME__-platform component (dev):
-#   terraform output -raw irsa_role_arn
-# aws:
-#   platformRoleArn: ""
-
 resources:
   requests:
     cpu: 50m

--- a/templates/k8s-app-tenant/skeleton/chart/values-production.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-production.yaml
@@ -15,9 +15,5 @@ resources:
     cpu: 1000m
     memory: 1Gi
 
-# Set from landing-zone's __APP_NAME__-platform component (production):
-#   terraform output -raw irsa_role_arn
-# aws:
-#   platformRoleArn: ""
 # externalSecret:
 #   remoteRefSecret: __APP_NAME__/production/app-secrets

--- a/templates/k8s-app-tenant/skeleton/chart/values-staging.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values-staging.yaml
@@ -7,9 +7,5 @@ replicaCount: 2
 commonLabels:
   platform.nanohype.dev/environment: staging
 
-# Set from landing-zone's __APP_NAME__-platform component (staging):
-#   terraform output -raw irsa_role_arn
-# aws:
-#   platformRoleArn: ""
 # externalSecret:
 #   remoteRefSecret: __APP_NAME__/staging/app-secrets

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -14,17 +14,13 @@ service:
 
 serviceAccount:
   create: true
-  # Extra annotations merged onto the ServiceAccount. The IRSA role ARN itself
-  # comes from `aws.platformRoleArn` (below) — set it per-env from the landing-zone
-  # <app>-platform component's `irsa_role_arn` output.
+  # Pinned to the app name so it matches the `service_account` of the EKS Pod
+  # Identity association that landing-zone's __APP_NAME__-platform component
+  # creates — that association binds this ServiceAccount to its IAM role, so the
+  # pod needs no role-arn annotation and the chart carries no AWS account values.
+  name: __APP_NAME__
+  # Extra annotations merged onto the ServiceAccount.
   annotations: {}
-
-# AWS wiring. platformRoleArn is the IRSA role the pod's ServiceAccount assumes.
-# landing-zone's <app>-platform component owns it; set it per-env in
-# values-{env}.yaml from `terraform output -raw irsa_role_arn`. Empty → no
-# role-arn annotation is rendered (fine until the substrate exists).
-aws:
-  platformRoleArn: ""
 
 resources:
   requests:

--- a/templates/k8s-app-tenant/skeleton/platform.yaml
+++ b/templates/k8s-app-tenant/skeleton/platform.yaml
@@ -13,9 +13,9 @@
 # BudgetPolicy drives the spend kill-switch (fires at 120% of monthlyUsd when
 # killSwitchEnabled).
 #
-# The chart's OWN ServiceAccount role-arn is separate: it comes from the
-# landing-zone __APP_NAME__-platform component via aws.platformRoleArn in per-env
-# values — NOT from this CR.
+# The chart's pod identity is separate from this CR: the landing-zone
+# __APP_NAME__-platform component creates an EKS Pod Identity association binding
+# the chart's ServiceAccount to its IAM role, so the chart carries no role ARN.
 #
 # Once Platform.status.phase is Ready, the ApplicationSet entry in __GITOPS_REPO__
 # takes over reconciling the chart.

--- a/templates/tenant-chart-base/README.md
+++ b/templates/tenant-chart-base/README.md
@@ -6,7 +6,7 @@ A Helm **library chart** (`type: library`) holding the named templates every nan
 
 A `chart/` directory containing a library chart with these named templates (all in `templates/_*.tpl`):
 
-- `tenant-chart-base.serviceaccount` — ServiceAccount with the tenant's IRSA role annotation (`aws.platformRoleArn`). No inline IAM — it only references the role landing-zone provisions.
+- `tenant-chart-base.serviceaccount` — the pod's ServiceAccount. No role-arn annotation and no inline IAM: landing-zone binds it to its IAM role with an EKS Pod Identity association, so `serviceAccount.name` is pinned to the app name to match.
 - `tenant-chart-base.networkpolicy` — the NetworkPolicy CR scaffold with values-driven `ingress` (varies by workload topology) and `egress` (the DNS + HTTPS-out baseline).
 - `tenant-chart-base.prometheusrule` — the PrometheusRule CR scaffold. Per the `observability-slo` standard it renders SLI recording rules over the burn-rate windows plus multi-window multi-burn-rate error-budget alerts (2 page, 2 ticket) from the `slo.*` values. `prometheusRule.groups` overrides it verbatim for latency or custom-shaped SLOs.
 - `tenant-chart-base.serviceMonitor` — an optional ServiceMonitor for apps that expose a Prometheus `/metrics` endpoint. Off by default (the baseline pushes metrics via OTLP to the cluster collector — the standard's equivalent scrape config).

--- a/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
@@ -1,7 +1,10 @@
 {{/*
-ServiceAccount with the tenant's IRSA role annotation. The role itself is
-provisioned by landing-zone's <app>-platform component; this only references its
-ARN via `aws.platformRoleArn`. No inline IAM is defined here.
+ServiceAccount for the tenant's pods. Its AWS identity is bound out of band by
+an EKS Pod Identity association (namespace + ServiceAccount -> IAM role) created
+by landing-zone's <app>-platform component, so the pod assumes its role without
+any role-arn annotation and no inline IAM is defined here. The ServiceAccount
+name must match the association's `service_account`, so set `serviceAccount.name`
+to the app name (see values.yaml).
 
 Usage (consumer templates/serviceaccount.yaml):
   {{ include "tenant-chart-base.serviceaccount" . }}
@@ -14,14 +17,9 @@ metadata:
   name: {{ include "tenant-chart-base.serviceAccountName" . }}
   labels:
     {{- include "tenant-chart-base.labels" . | nindent 4 }}
-  {{- if or .Values.aws.platformRoleArn .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- if .Values.aws.platformRoleArn }}
-    eks.amazonaws.com/role-arn: {{ .Values.aws.platformRoleArn | quote }}
-    {{- end }}
-    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Moves the tenant chart off the IRSA `eks.amazonaws.com/role-arn` annotation and onto EKS Pod Identity, which binds a `(namespace, ServiceAccount)` pair to an IAM role through the EKS API — no annotation, no role ARN in the cluster.

- The `tenant-chart-base` ServiceAccount template drops the role-arn annotation.
- `serviceAccount.name` is pinned to the app name so it matches the `service_account` of the landing-zone-owned Pod Identity association deterministically (the old default was the env-suffixed Helm fullname, which did not match the role's trust subject).
- `aws.platformRoleArn` and its per-env wiring comments are removed — the chart now carries no AWS identity value.
- The platform-tenant contract and template READMEs describe the Pod Identity binding.

The landing-zone side (trust principal + the association resource) and the eks-gitops addon annotations follow in their own changes; the placeholder-free state is locked by a zero-tolerance CI check once those land.

Validated: vendored `tenant-chart-base` regenerated and in sync, `helm template` renders a clean annotation-free ServiceAccount, standards schema + catalog + SDK suite pass.