### PR TITLE
Make the tenant PrometheusRule opt-in, not on by default

### DIFF
--- a/standards/observability-slo.json
+++ b/standards/observability-slo.json
@@ -61,7 +61,7 @@
       }
     },
     "do": [
-      "Ship the dashboard, the ServiceMonitor/PodMonitor, and the PrometheusRule together — observability is on by default, not opt-in.",
+      "Ship the dashboard and a metric scrape on by default (pod scrape annotations, or a ServiceMonitor where a Prometheus Operator runs) — metrics and the board are not opt-in. Ship SLO alerting in the form the cluster evaluates: a Grafana-managed alert group on a managed-Prometheus stack (grafana-agent + AMP/AMG), or a PrometheusRule where a Prometheus Operator runs. A PrometheusRule alone is inert without an operator.",
       "Declare at least one availability SLO per system; add a latency SLO for latency-sensitive paths.",
       "Show latency as p50/p95/p99 from a histogram.",
       "Reference recording rules from burn-rate alerts so alert evaluation is cheap and consistent."
@@ -70,7 +70,7 @@
       "Ship a board that only embeds community grafanaCom/gnetId infra dashboards and call the system observed.",
       "Alert on instantaneous error ratio in place of a multi-window burn rate.",
       "Show latency as an average or a single gauge.",
-      "Leave dashboards/PrometheusRule disabled by default in a template."
+      "Leave the dashboard or the metric scrape disabled by default. (A PrometheusRule/ServiceMonitor may default off — they are inert without a Prometheus Operator, which the managed-Prometheus stack doesn't run; SLO alerting then lives in a Grafana-managed alert group instead.)"
     ]
   }
 }

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -111,8 +111,14 @@ externalSecret:
 # error-budget alerts keyed on `__APP_NAME___requests_total` /
 # `__APP_NAME___errors_total`. Supply latency or custom-shaped SLOs via `groups`
 # (set it to a non-empty list and it is emitted verbatim instead of the SLO default).
+#
+# Off by default: a PrometheusRule is inert without a Prometheus Operator to
+# evaluate it, and the managed-Prometheus stack this platform runs (grafana-agent
+# scraping pod annotations into Amazon Managed Prometheus, alerting in Amazon
+# Managed Grafana) doesn't run one. Set `enabled: true` on a cluster that does —
+# e.g. the local kx workspace with kube-prometheus-stack.
 prometheusRule:
-  enabled: true
+  enabled: false
   selector:
     release: kube-prometheus-stack
   groups: []


### PR DESCRIPTION
The tenant chart shipped a `PrometheusRule` **on by default**, selecting `release: kube-prometheus-stack`. The platform doesn't run a Prometheus Operator — metrics are scraped by grafana-agent (pod annotations) into Amazon Managed Prometheus and alerted on in Amazon Managed Grafana — so that PrometheusRule has no controller to evaluate it. The result is inert recording rules and alerts on every tenant.

- **k8s-app-tenant skeleton**: `prometheusRule.enabled` defaults to `false`, with a comment explaining it's opt-in for clusters that run a Prometheus Operator (e.g. the local kx workspace).
- **observability-slo standard**: reframed so the dashboard and the metric scrape stay on by default (the parts the stack consumes), while SLO alerting ships in the form the cluster evaluates — a Grafana-managed alert group on the managed-Prometheus stack, or a PrometheusRule where an operator runs. The `do_not` no longer forbids a template defaulting the PrometheusRule off.

The propagation to the four live tenant charts and the operator chart's `slo.enabled` follows separately. `validate:catalog` passes (0 errors).