### PR TITLE
Add cloudgov to the contract front door and gate the MCP server in CI

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -1,0 +1,57 @@
+name: MCP Server
+
+on:
+  push:
+    branches: [main]
+    paths: ['mcp-server/**', 'sdk/**', 'schemas/**']
+  pull_request:
+    paths: ['mcp-server/**', 'sdk/**', 'schemas/**']
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test MCP server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: |
+            sdk/package-lock.json
+            mcp-server/package-lock.json
+
+      # The MCP server depends on @nanohype/sdk via file:../sdk, so the sibling
+      # package must be installed and built before the MCP package resolves it.
+      - name: Build the linked SDK
+        working-directory: sdk
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install dependencies
+        working-directory: mcp-server
+        run: npm ci
+
+      - name: Audit dependencies
+        working-directory: mcp-server
+        run: npm audit --audit-level=high --omit=dev
+
+      - name: Typecheck
+        working-directory: mcp-server
+        run: npm run typecheck
+
+      - name: Build
+        working-directory: mcp-server
+        run: npm run build
+
+      - name: Test
+        working-directory: mcp-server
+        run: npm test

--- a/mcp-server/__tests__/fixtures/contracts/cloudgov/AGENTS.md
+++ b/mcp-server/__tests__/fixtures/contracts/cloudgov/AGENTS.md
@@ -1,0 +1,5 @@
+# cloudgov — agent entry point
+
+Test fixture for the MCP server's contract resolution. Real per-repo AGENTS.md
+files live in their own repos; this fixture lets the resource/tool tests run
+hermetically without sibling checkouts.

--- a/mcp-server/__tests__/fixtures/contracts/kx/AGENTS.md
+++ b/mcp-server/__tests__/fixtures/contracts/kx/AGENTS.md
@@ -1,0 +1,5 @@
+# kx — agent entry point
+
+Test fixture for the MCP server's contract resolution. Real per-repo AGENTS.md
+files live in their own repos; this fixture lets the resource/tool tests run
+hermetically without sibling checkouts.

--- a/mcp-server/__tests__/fixtures/contracts/landing-zone/AGENTS.md
+++ b/mcp-server/__tests__/fixtures/contracts/landing-zone/AGENTS.md
@@ -1,0 +1,5 @@
+# landing-zone — agent entry point
+
+Test fixture for the MCP server's contract resolution. Real per-repo AGENTS.md
+files live in their own repos; this fixture lets the resource/tool tests run
+hermetically without sibling checkouts.

--- a/mcp-server/__tests__/fixtures/contracts/nanohype/AGENTS.md
+++ b/mcp-server/__tests__/fixtures/contracts/nanohype/AGENTS.md
@@ -1,0 +1,5 @@
+# nanohype — agent entry point
+
+Test fixture for the MCP server's contract resolution. Real per-repo AGENTS.md
+files live in their own repos; this fixture lets the resource/tool tests run
+hermetically without sibling checkouts.

--- a/mcp-server/__tests__/resources.test.ts
+++ b/mcp-server/__tests__/resources.test.ts
@@ -5,6 +5,11 @@ import { listResources, readResource } from '../src/resources.js';
 
 const CATALOG_ROOT = resolve(import.meta.dirname, '..', '..');
 
+// Contract resolution reads sibling repos' AGENTS.md (../<repo>/AGENTS.md), which
+// aren't checked out in CI. Point those tests at a self-contained fixture tree so
+// they're hermetic; the catalog/template/standard tests still use the real repo.
+const CONTRACTS_ROOT = resolve(import.meta.dirname, 'fixtures', 'contracts', 'nanohype');
+
 describe('listResources', () => {
   it('advertises catalog, standards bundle, every standard, every contract', () => {
     const resources = listResources();
@@ -43,6 +48,7 @@ describe('listResources', () => {
 
 describe('readResource', () => {
   const source = new LocalSource({ rootDir: CATALOG_ROOT });
+  const contractSource = new LocalSource({ rootDir: CONTRACTS_ROOT });
 
   it('resolves nanohype://catalog to the parsed catalog JSON', async () => {
     const result = await readResource(source, 'nanohype://catalog');
@@ -68,7 +74,7 @@ describe('readResource', () => {
   });
 
   it('resolves nanohype://contracts/{repo} to the AGENTS.md content', async () => {
-    const result = await readResource(source, 'nanohype://contracts/landing-zone');
+    const result = await readResource(contractSource, 'nanohype://contracts/landing-zone');
     expect(result.contents[0].mimeType).toBe('text/markdown');
     expect(result.contents[0].text).toContain('# landing-zone');
   });

--- a/mcp-server/__tests__/tools.test.ts
+++ b/mcp-server/__tests__/tools.test.ts
@@ -5,6 +5,11 @@ import { callTool, listTools, searchTemplates } from '../src/tools.js';
 
 const CATALOG_ROOT = resolve(import.meta.dirname, '..', '..');
 
+// get_contract reads sibling repos' AGENTS.md (../<repo>/AGENTS.md), which aren't
+// checked out in CI. Point those tests at a self-contained fixture tree so they're
+// hermetic; the other tools still dispatch against the real catalog.
+const CONTRACTS_ROOT = resolve(import.meta.dirname, 'fixtures', 'contracts', 'nanohype');
+
 describe('listTools', () => {
   it('advertises the canonical tool set', () => {
     const names = listTools().map((t) => t.name);
@@ -98,6 +103,7 @@ describe('searchTemplates (pure)', () => {
 
 describe('callTool', () => {
   const source = new LocalSource({ rootDir: CATALOG_ROOT });
+  const contractSource = new LocalSource({ rootDir: CONTRACTS_ROOT });
 
   it('search_templates dispatches to the real catalog', async () => {
     const result = await callTool(source, 'search_templates', { query: 'mcp' });
@@ -132,8 +138,13 @@ describe('callTool', () => {
   });
 
   it('get_contract returns the markdown content', async () => {
-    const result = await callTool(source, 'get_contract', { repo: 'kx' });
+    const result = await callTool(contractSource, 'get_contract', { repo: 'kx' });
     expect(result.content[0].text).toContain('# kx');
+  });
+
+  it('get_contract resolves cloudgov', async () => {
+    const result = await callTool(contractSource, 'get_contract', { repo: 'cloudgov' });
+    expect(result.content[0].text).toContain('# cloudgov');
   });
 
   it('rejects unknown tools', async () => {

--- a/sdk/__tests__/contracts.test.ts
+++ b/sdk/__tests__/contracts.test.ts
@@ -17,7 +17,7 @@ describe('loadContract', () => {
     expect(c.content).toContain('# nanohype — agent entry point');
   });
 
-  it.each(['landing-zone', 'eks-gitops', 'aks-gitops', 'eks-agent-platform', 'kx'] as const)(
+  it.each(['landing-zone', 'eks-gitops', 'aks-gitops', 'eks-agent-platform', 'kx', 'cloudgov'] as const)(
     "loads the AGENTS.md from the sibling '%s' repo",
     async (repo) => {
       const c = await loadContract(source, repo);

--- a/sdk/__tests__/fixtures/contracts/cloudgov/AGENTS.md
+++ b/sdk/__tests__/fixtures/contracts/cloudgov/AGENTS.md
@@ -1,0 +1,5 @@
+# cloudgov — agent entry point
+
+Test fixture for the SDK contract loader. Real per-repo AGENTS.md files
+live in their own repos; this fixture lets the loader tests run without a
+sibling checkout.

--- a/sdk/src/contracts.ts
+++ b/sdk/src/contracts.ts
@@ -8,6 +8,7 @@ const ALL_REPOS: ContractRepo[] = [
   'aks-gitops',
   'eks-agent-platform',
   'kx',
+  'cloudgov',
 ];
 
 /**

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -119,7 +119,8 @@ export type ContractRepo =
   | 'eks-gitops'
   | 'aks-gitops'
   | 'eks-agent-platform'
-  | 'kx';
+  | 'kx'
+  | 'cloudgov';
 
 /** One entry in catalog.json's `templates` array — a single template's discovery metadata. */
 export interface CatalogTemplate {


### PR DESCRIPTION
Two gaps in the agent-facing front door — the per-repo `AGENTS.md` surface the SDK and `@nanohype/mcp` expose.

## Real inventory

`cloudgov` ships an `AGENTS.md` (the MCP-server invocation guide for the governance CLI) but wasn't in the contract list, so neither `get_contract` nor `loadAllContracts` could reach it. Added to the `ContractRepo` union and `ALL_REPOS`. The MCP tool enum and resource list are driven off that list, so the new repo flows through both with no further wiring. A loader fixture + the table-driven test cover it like the other siblings.

## MCP server CI

`@nanohype/mcp` had `build`, `typecheck`, and `test` scripts but no workflow ran them — the published front door could break between SDK changes and a release with nothing to catch it. New `.github/workflows/mcp-server.yml` builds the linked `@nanohype/sdk` first (the MCP package consumes it via `file:../sdk`), then audits, typechecks, builds, and tests the MCP server on any change under `mcp-server/`, `sdk/`, or `schemas/`. Mirrors the SDK workflow's shape.

## Not included (tracked separately)

The other org repos can't join the public contract surface yet: **fab** and **portal** are public but ship no `AGENTS.md`; **eks-fleet** and the four tenant repos are private, so `raw.githubusercontent.com` would 404 for external consumers. Filing a follow-up issue rather than forcing broken menu entries into a public tool.

## Verification

SDK typecheck/lint/build/test and MCP server typecheck/build/test all green locally; the new workflow's SDK-first sequence reproduces what CI will run.