### PR TITLE
Add the render-assert composite action — a render-time placeholder gate

### DIFF
--- a/.github/actions/render-assert/README.md
+++ b/.github/actions/render-assert/README.md
@@ -1,0 +1,62 @@
+# render-assert
+
+A composite GitHub Action that asserts **rendered** Kubernetes manifests carry no
+unfilled sentinels. It's the render-time complement to a source-file
+no-placeholders gate: a source scan catches sentinels you can see in the repo,
+this catches the ones that only appear *after* templating — chart defaults,
+vendored charts, or an ARN a template builds from a value it never received.
+
+## What it flags
+
+In any `*.yaml` / `*.yml` under the rendered directory:
+
+- `000000000000` — the zero AWS account id
+- `PLACEHOLDER`, `g-PLACEHOLDER`, `REPLACE_ME`/`REPLACEME`, `CHANGE_ME`/`CHANGEME` — unfilled placeholder tokens
+- `arn:aws:iam:::…` — an IAM ARN whose account segment is empty
+
+## What it deliberately does NOT flag
+
+Empty `*RoleArn` / annotation fields (`roleArn: ""`). When a value is injected at
+sync time — an ArgoCD cluster Secret, EKS Pod Identity — it is legitimately empty
+at render time. An empty field is not a placeholder bug. An account-less ARN is,
+and the empty-field case never produces one. The org example account ids
+`111111111111` / `222222222222` are intentional and are not sentinels.
+
+## Usage
+
+Render first (each repo renders its own charts/overlays its own way), then call the
+action against the output:
+
+```yaml
+- name: Render manifests
+  run: |
+    mkdir -p rendered
+    # e.g. kustomize build --enable-helm path/overlays/production > rendered/prod.yaml
+    # or   helm template <chart> -f values.yaml -f values-production.yaml > rendered/x.yaml
+
+- name: Assert no unfilled sentinels in rendered output
+  uses: nanohype/nanohype/.github/actions/render-assert@main
+  with:
+    manifests: rendered
+    # optional: drop known-legitimate hits by an ERE over "file:line:match" lines
+    exclude: 'mcp-tunnel'
+```
+
+## Inputs
+
+| input | default | description |
+|-------|---------|-------------|
+| `manifests` | `rendered` | Directory of rendered manifests to scan. |
+| `exclude` | `''` | Extended-regex matched against `file:line:match` result lines, to drop known-legitimate hits. |
+
+An empty manifests directory fails the action (a render step that produced nothing
+is a misconfiguration, not a pass).
+
+## Local use
+
+The logic lives in `assert.sh` and is self-tested by `test.sh`:
+
+```sh
+bash .github/actions/render-assert/assert.sh <rendered-dir> [exclude-regex]
+bash .github/actions/render-assert/test.sh   # fixtures: clean pass, dirty caught
+```

--- a/.github/actions/render-assert/action.yml
+++ b/.github/actions/render-assert/action.yml
@@ -1,0 +1,23 @@
+name: render-assert
+description: >-
+  Assert that rendered Kubernetes manifests carry no unfilled sentinels — the
+  zero AWS account id, literal placeholder tokens, or account-less IAM ARNs.
+  The render-time complement to a source-file no-placeholders gate.
+
+inputs:
+  manifests:
+    description: Directory of rendered manifests to scan (helm template / kustomize build output).
+    required: false
+    default: rendered
+  exclude:
+    description: >-
+      Optional extended-regex matched against "file:line:match" result lines, used
+      to drop known-legitimate hits (e.g. an opt-in addon's own placeholders).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: ${{ github.action_path }}/assert.sh "${{ inputs.manifests }}" "${{ inputs.exclude }}"

--- a/.github/actions/render-assert/assert.sh
+++ b/.github/actions/render-assert/assert.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# assert.sh — fail if RENDERED Kubernetes manifests carry unfilled sentinels.
+#
+# Scans a directory of rendered manifests (helm template / kustomize build output)
+# for values that must never reach a real cluster: the zero AWS account id, literal
+# placeholder tokens, and account-less IAM ARNs. This is the render-time complement
+# to a source-file no-placeholders gate — it catches sentinels that only appear
+# after templating: chart defaults, vendored charts, or ARNs a template builds from
+# a value it never received.
+#
+# It deliberately does NOT flag empty `*RoleArn` / annotation fields. Those are
+# legitimately empty at render time when the value is injected at sync time (an
+# ArgoCD cluster Secret, EKS Pod Identity). An empty field is not a placeholder
+# bug; an account-less ARN (arn:aws:iam:::role/...) is — a template that built an
+# ARN from a missing account, which the empty-field case never produces.
+#
+# Usage: assert.sh <manifests-dir> [exclude-regex]
+#   exclude-regex — optional ERE matched against "file:line:match" lines to drop
+#                   known-legitimate hits (e.g. an opt-in addon's own placeholders).
+set -euo pipefail
+
+DIR="${1:-rendered}"
+EXCLUDE="${2:-}"
+
+[ -d "$DIR" ] || {
+  echo "render-assert: manifests dir '$DIR' not found" >&2
+  exit 2
+}
+
+# A rendered-but-empty tree means the render step produced nothing — treat that as
+# a misconfiguration, not a silent pass.
+count=$(find "$DIR" -type f \( -name '*.yaml' -o -name '*.yml' \) | wc -l | tr -d ' ')
+[ "$count" -gt 0 ] || {
+  echo "render-assert: no rendered manifests (*.yaml/*.yml) under '$DIR' to scan" >&2
+  exit 2
+}
+
+# Sentinels that must never appear in a rendered manifest:
+#   000000000000     — the zero AWS account id
+#   PLACEHOLDER / g-PLACEHOLDER / REPLACE_ME family — unfilled placeholder tokens
+#   arn:aws:iam:::   — an IAM ARN whose account segment is empty
+# 111111111111 / 222222222222 are the org's intentional example account ids and
+# are NOT sentinels (kept consistent with the source no-placeholders gate).
+PATTERN='000000000000|PLACEHOLDER|g-PLACEHOLDER|REPLACE_ME|REPLACEME|CHANGE_ME|CHANGEME|arn:aws:iam:::'
+
+hits=$(grep -rnEH --include='*.yaml' --include='*.yml' "$PATTERN" "$DIR" || true)
+
+if [ -n "$hits" ] && [ -n "$EXCLUDE" ]; then
+  hits=$(printf '%s\n' "$hits" | grep -vE "$EXCLUDE" || true)
+fi
+
+if [ -n "$hits" ]; then
+  echo "render-assert: FAILED — unfilled sentinels in rendered output:" >&2
+  printf '%s\n' "$hits" >&2
+  echo "" >&2
+  echo "These values must never reach a cluster. A value injected at sync time should" >&2
+  echo "be absent/empty at render — not a literal sentinel, zero account id, or an" >&2
+  echo "ARN missing its account." >&2
+  exit 1
+fi
+
+echo "render-assert: OK — scanned $count rendered manifest(s), no sentinels."

--- a/.github/actions/render-assert/test.sh
+++ b/.github/actions/render-assert/test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# test.sh — self-test for assert.sh. The clean fixtures must pass; each dirty
+# fixture must be caught in isolation. Run by the render-assert CI workflow.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+fail=0
+
+# Clean fixtures must be accepted (empty fields, example account id, well-formed ARNs).
+if bash "$HERE/assert.sh" "$HERE/testdata/clean" >/dev/null 2>&1; then
+  echo "PASS: clean fixtures accepted"
+else
+  echo "FAIL: clean fixtures rejected"
+  fail=1
+fi
+
+# Each dirty fixture must be caught on its own (scan a temp dir holding just it).
+for f in zero-account placeholder empty-arn; do
+  tmp="$(mktemp -d)"
+  cp "$HERE/testdata/dirty/$f.yaml" "$tmp/"
+  if bash "$HERE/assert.sh" "$tmp" >/dev/null 2>&1; then
+    echo "FAIL: dirty fixture '$f' was not caught"
+    fail=1
+  else
+    echo "PASS: dirty fixture '$f' caught"
+  fi
+  rm -rf "$tmp"
+done
+
+# An empty manifests dir is a misconfiguration (exit 2), not a silent pass.
+empty="$(mktemp -d)"
+if bash "$HERE/assert.sh" "$empty" >/dev/null 2>&1; then
+  echo "FAIL: empty manifests dir was accepted"
+  fail=1
+else
+  echo "PASS: empty manifests dir rejected"
+fi
+rm -rf "$empty"
+
+[ "$fail" -eq 0 ] && echo "render-assert self-test: OK" || echo "render-assert self-test: FAILED" >&2
+exit "$fail"

--- a/.github/actions/render-assert/testdata/clean/serviceaccount.yaml
+++ b/.github/actions/render-assert/testdata/clean/serviceaccount.yaml
@@ -1,0 +1,20 @@
+# A normal rendered manifest. Sync-time-injected fields are empty (legitimate),
+# the example account id 111111111111 is allowed, and a well-formed ARN carries
+# its account — none of these is a sentinel.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-runtime
+  namespace: tenants-demo
+  annotations:
+    # Empty at render time — injected at sync time. Not flagged.
+    eks.amazonaws.com/role-arn: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+  namespace: tenants-demo
+data:
+  exampleRoleArn: arn:aws:iam::111111111111:role/example
+  region: us-west-2

--- a/.github/actions/render-assert/testdata/dirty/empty-arn.yaml
+++ b/.github/actions/render-assert/testdata/dirty/empty-arn.yaml
@@ -1,0 +1,8 @@
+# An IAM ARN whose account segment is empty — a template that built an ARN from a
+# value it never received. Must be caught (the empty-field case never produces this).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bad-arn
+data:
+  roleArn: arn:aws:iam:::role/no-account

--- a/.github/actions/render-assert/testdata/dirty/placeholder.yaml
+++ b/.github/actions/render-assert/testdata/dirty/placeholder.yaml
@@ -1,0 +1,8 @@
+# A literal placeholder token that survived into rendered output — must be caught.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bad-placeholder
+data:
+  gatewayHost: PLACEHOLDER
+  token: REPLACE_ME

--- a/.github/actions/render-assert/testdata/dirty/zero-account.yaml
+++ b/.github/actions/render-assert/testdata/dirty/zero-account.yaml
@@ -1,0 +1,7 @@
+# A role ARN built with the zero AWS account id — must be caught.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bad-account
+data:
+  roleArn: arn:aws:iam::000000000000:role/leaked

--- a/.github/workflows/render-assert.yml
+++ b/.github/workflows/render-assert.yml
@@ -1,0 +1,29 @@
+name: render-assert action
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/actions/render-assert/**', '.github/workflows/render-assert.yml']
+  pull_request:
+    paths: ['.github/actions/render-assert/**', '.github/workflows/render-assert.yml']
+
+permissions:
+  contents: read
+
+jobs:
+  self-test:
+    name: render-assert self-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Unit self-test (clean accepted, dirty caught, empty rejected)
+        run: bash .github/actions/render-assert/test.sh
+
+      # Dogfood the composite-action interface (inputs → assert.sh) against the
+      # clean fixtures, which must pass.
+      - name: Action interface accepts clean fixtures
+        uses: ./.github/actions/render-assert
+        with:
+          manifests: .github/actions/render-assert/testdata/clean


### PR DESCRIPTION
A source-file no-placeholders gate catches sentinels you can see in the repo. It can't catch the ones that only appear *after* templating: a chart default, a vendored chart, or an ARN a template builds from a value it never received. This adds the render-time complement, homed here so every gitops/chart repo references one source of truth.

## What it flags

In any rendered `*.yaml` / `*.yml`:

- `000000000000` — the zero AWS account id
- `PLACEHOLDER` / `g-PLACEHOLDER` / `REPLACE_ME` / `CHANGEME` — unfilled placeholder tokens
- `arn:aws:iam:::…` — an IAM ARN whose account segment is empty

## What it deliberately does NOT flag

Empty `*RoleArn` / annotation fields. When a value is injected at sync time (an ArgoCD cluster Secret, EKS Pod Identity) it is legitimately empty at render — an empty field is not a placeholder bug, and the account-less ARN the gate *does* catch is something the empty-field case never produces. The org example account ids `111111111111` / `222222222222` are intentional and aren't sentinels (consistent with the source gate).

## Shape

A composite action so a consumer renders its own charts its own way, then calls the action against the output:

```yaml
- uses: nanohype/nanohype/.github/actions/render-assert@main
  with:
    manifests: rendered
```

Includes `assert.sh` (the logic), `test.sh` (fixtures: clean accepted, each dirty kind caught, empty dir rejected), and a workflow that runs the self-test and dogfoods the action interface against the clean fixtures.

This is the foundation for adopting the gate across the catalog repos, portal, and the tenants. Self-test green locally.