### PR TITLE
Real contract inventory: add fab/portal/eks-fleet, drop aks-gitops, resolve private repos

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -11,7 +11,7 @@ Use it when you're building an AI client (Bedrock agent, Claude Desktop assistan
 | `nanohype://catalog` | Full `catalog.json` (templates + composites with metadata) | `application/json` |
 | `nanohype://standards` | All five standards files bundled | `application/json` |
 | `nanohype://standards/{name}` | One standards file. `name` ∈ `language-toolchain` / `version-currency` / `platform-tenant-contract` / `llm-policy` / `quality-rubric-dimensions` | `application/json` |
-| `nanohype://contracts/{repo}` | One repo's `AGENTS.md`. `repo` ∈ `nanohype` / `landing-zone` / `eks-gitops` / `aks-gitops` / `eks-agent-platform` / `kx` | `text/markdown` |
+| `nanohype://contracts/{repo}` | One repo's `AGENTS.md`. `repo` ∈ `nanohype` / `landing-zone` / `eks-gitops` / `eks-agent-platform` / `kx` / `cloudgov` / `fab` / `portal` / `eks-fleet` (private — needs a GitHub token) | `text/markdown` |
 | `nanohype://template/{name}` | One template's full manifest (variables, conditionals, hooks, composition) | `application/json` |
 | `nanohype://composite/{name}` | One composite's full manifest (multi-template orchestration) | `application/json` |
 

--- a/mcp-server/__tests__/fixtures/contracts/fab/AGENTS.md
+++ b/mcp-server/__tests__/fixtures/contracts/fab/AGENTS.md
@@ -1,0 +1,5 @@
+# fab — agent entry point
+
+Test fixture for the MCP server's contract resolution. Real per-repo AGENTS.md
+files live in their own repos; this fixture lets the resource/tool tests run
+hermetically without sibling checkouts.

--- a/mcp-server/__tests__/fixtures/contracts/portal/AGENTS.md
+++ b/mcp-server/__tests__/fixtures/contracts/portal/AGENTS.md
@@ -1,0 +1,5 @@
+# portal — agent entry point
+
+Test fixture for the MCP server's contract resolution. Real per-repo AGENTS.md
+files live in their own repos; this fixture lets the resource/tool tests run
+hermetically without sibling checkouts.

--- a/mcp-server/__tests__/resources.test.ts
+++ b/mcp-server/__tests__/resources.test.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { LocalSource } from '@nanohype/sdk';
+import { LocalSource, KNOWN_CONTRACT_REPOS } from '@nanohype/sdk';
 import { listResources, readResource } from '../src/resources.js';
 
 const CATALOG_ROOT = resolve(import.meta.dirname, '..', '..');
@@ -25,16 +25,12 @@ describe('listResources', () => {
     ]) {
       expect(uris).toContain(`nanohype://standards/${name}`);
     }
-    for (const repo of [
-      'nanohype',
-      'landing-zone',
-      'eks-gitops',
-      'aks-gitops',
-      'eks-agent-platform',
-      'kx',
-    ]) {
+    // Assert against the SDK's canonical list so this never drifts as the
+    // contract surface changes.
+    for (const repo of KNOWN_CONTRACT_REPOS) {
       expect(uris).toContain(`nanohype://contracts/${repo}`);
     }
+    expect(uris).not.toContain('nanohype://contracts/aks-gitops');
   });
 
   it('every resource carries a name, description, and mimeType', () => {

--- a/mcp-server/__tests__/tools.test.ts
+++ b/mcp-server/__tests__/tools.test.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { LocalSource, type CatalogTemplate } from '@nanohype/sdk';
+import { LocalSource, KNOWN_CONTRACT_REPOS, type CatalogTemplate } from '@nanohype/sdk';
 import { callTool, listTools, searchTemplates } from '../src/tools.js';
 
 const CATALOG_ROOT = resolve(import.meta.dirname, '..', '..');
@@ -21,6 +21,14 @@ describe('listTools', () => {
       'get_standard',
       'get_contract',
     ]);
+  });
+
+  it('get_contract enum reflects the current contract surface', () => {
+    const tool = listTools().find((t) => t.name === 'get_contract')!;
+    const repoEnum = (tool.inputSchema.properties as { repo: { enum: string[] } }).repo.enum;
+    expect(repoEnum).toEqual([...KNOWN_CONTRACT_REPOS]);
+    expect(repoEnum).not.toContain('aks-gitops');
+    expect(repoEnum).toEqual(expect.arrayContaining(['fab', 'portal', 'eks-fleet']));
   });
 
   it('every tool has a non-empty description and JSON-schema input', () => {
@@ -145,6 +153,11 @@ describe('callTool', () => {
   it('get_contract resolves cloudgov', async () => {
     const result = await callTool(contractSource, 'get_contract', { repo: 'cloudgov' });
     expect(result.content[0].text).toContain('# cloudgov');
+  });
+
+  it('get_contract resolves fab (newly added repo)', async () => {
+    const result = await callTool(contractSource, 'get_contract', { repo: 'fab' });
+    expect(result.content[0].text).toContain('# fab');
   });
 
   it('rejects unknown tools', async () => {

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -5,6 +5,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import {
   CatalogSource,
+  CONTRACT_REPOS,
   KNOWN_CONTRACT_REPOS,
   loadAllContracts,
   loadCatalog,
@@ -63,11 +64,12 @@ export function listResources(): StaticResource[] {
     });
   }
 
-  for (const repo of KNOWN_CONTRACT_REPOS) {
+  for (const { repo, visibility } of CONTRACT_REPOS) {
+    const access = visibility === 'private' ? ' (private — requires a GitHub token to resolve)' : '';
     resources.push({
       uri: `nanohype://contracts/${repo}`,
       name: `contract: ${repo}`,
-      description: `The agent-facing AGENTS.md for the '${repo}' repo. Five-minute orientation: what the repo gives you, contract surface, how to add a new thing, conventions, pointers.`,
+      description: `The agent-facing AGENTS.md for the '${repo}' repo${access}. Five-minute orientation: what the repo gives you, contract surface, how to add a new thing, conventions, pointers.`,
       mimeType: 'text/markdown',
     });
   }

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -114,7 +114,7 @@ export function listTools(): ToolDescriptor[] {
     {
       name: 'get_contract',
       description:
-        "Fetch a repo's AGENTS.md content. Use this when you need the agent-facing contract surface for a specific repo (what it gives you, how to add a new thing, conventions).",
+        "Fetch a repo's AGENTS.md content. Use this when you need the agent-facing contract surface for a specific repo (what it gives you, how to add a new thing, conventions). Private repos (e.g. eks-fleet) resolve only when the server has a GitHub token; without one they return a not-found error.",
       inputSchema: {
         type: 'object',
         properties: {

--- a/sdk/__tests__/contracts.test.ts
+++ b/sdk/__tests__/contracts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { LocalSource } from '../src/sources/local.js';
 import { loadAllContracts, loadContract, KNOWN_CONTRACT_REPOS } from '../src/contracts.js';
 import { NanohypeError } from '../src/errors.js';
+import type { CatalogSource } from '../src/source.js';
 
 // Fixture mirrors the org layout (a nanohype/ dir with sibling repo dirs)
 // so the contract loader is exercised without a real sibling checkout.
@@ -17,15 +18,26 @@ describe('loadContract', () => {
     expect(c.content).toContain('# nanohype — agent entry point');
   });
 
-  it.each(['landing-zone', 'eks-gitops', 'aks-gitops', 'eks-agent-platform', 'kx', 'cloudgov'] as const)(
-    "loads the AGENTS.md from the sibling '%s' repo",
-    async (repo) => {
-      const c = await loadContract(source, repo);
-      expect(c.repo).toBe(repo);
-      expect(c.content).toContain(`# ${repo}`);
-      expect(c.content).toContain('agent entry point');
-    },
-  );
+  it.each([
+    'landing-zone',
+    'eks-gitops',
+    'eks-agent-platform',
+    'kx',
+    'cloudgov',
+    'fab',
+    'portal',
+    'eks-fleet',
+  ] as const)("loads the AGENTS.md from the sibling '%s' repo", async (repo) => {
+    const c = await loadContract(source, repo);
+    expect(c.repo).toBe(repo);
+    expect(c.content).toContain(`# ${repo}`);
+    expect(c.content).toContain('agent entry point');
+  });
+
+  it('stamps the repo visibility onto the loaded contract', async () => {
+    expect((await loadContract(source, 'eks-gitops')).visibility).toBe('public');
+    expect((await loadContract(source, 'eks-fleet')).visibility).toBe('private');
+  });
 
   it('throws NanohypeError when the repo path does not exist', async () => {
     const broken = new LocalSource({ rootDir: '/tmp/nonexistent-nanohype-contracts' });
@@ -42,5 +54,32 @@ describe('loadAllContracts', () => {
     for (const c of all) {
       expect(c.content.length).toBeGreaterThan(100);
     }
+  });
+
+  it('skips a repo that fails to resolve instead of rejecting the whole load', async () => {
+    // A source that resolves everything except eks-fleet — the shape of a private
+    // repo fetched without a token (404). The load must degrade, not throw.
+    const partial = {
+      async fetchContract(repo: string) {
+        if (repo === 'eks-fleet') throw new NanohypeError('AGENTS.md for repo \'eks-fleet\' not found: 404');
+        return `# ${repo} — agent entry point\n\n${'x'.repeat(150)}`;
+      },
+    } as unknown as CatalogSource;
+
+    const all = await loadAllContracts(partial);
+    const repos = all.map((c) => c.repo);
+    expect(repos).not.toContain('eks-fleet');
+    expect(repos).toContain('nanohype');
+    expect(repos).toContain('fab');
+    expect(all.length).toBe(KNOWN_CONTRACT_REPOS.length - 1);
+  });
+});
+
+describe('KNOWN_CONTRACT_REPOS', () => {
+  it('reflects the current contract surface', () => {
+    expect(KNOWN_CONTRACT_REPOS).not.toContain('aks-gitops');
+    expect(KNOWN_CONTRACT_REPOS).toContain('fab');
+    expect(KNOWN_CONTRACT_REPOS).toContain('portal');
+    expect(KNOWN_CONTRACT_REPOS).toContain('eks-fleet');
   });
 });

--- a/sdk/__tests__/fixtures/contracts/eks-fleet/AGENTS.md
+++ b/sdk/__tests__/fixtures/contracts/eks-fleet/AGENTS.md
@@ -1,0 +1,5 @@
+# eks-fleet — agent entry point
+
+Test fixture for the SDK contract loader. Real per-repo AGENTS.md files
+live in their own repos; this fixture lets the loader tests run without a
+sibling checkout.

--- a/sdk/__tests__/fixtures/contracts/fab/AGENTS.md
+++ b/sdk/__tests__/fixtures/contracts/fab/AGENTS.md
@@ -1,4 +1,4 @@
-# aks-gitops — agent entry point
+# fab — agent entry point
 
 Test fixture for the SDK contract loader. Real per-repo AGENTS.md files
 live in their own repos; this fixture lets the loader tests run without a

--- a/sdk/__tests__/fixtures/contracts/portal/AGENTS.md
+++ b/sdk/__tests__/fixtures/contracts/portal/AGENTS.md
@@ -1,0 +1,5 @@
+# portal — agent entry point
+
+Test fixture for the SDK contract loader. Real per-repo AGENTS.md files
+live in their own repos; this fixture lets the loader tests run without a
+sibling checkout.

--- a/sdk/__tests__/sources/github.test.ts
+++ b/sdk/__tests__/sources/github.test.ts
@@ -205,3 +205,53 @@ describe('GitHubSource', () => {
     });
   });
 });
+
+describe('GitHubSource.fetchContract', () => {
+  it('resolves a public repo via raw.githubusercontent when no token is set', async () => {
+    // The constructor falls back to GITHUB_TOKEN, which CI sets — clear it so this
+    // exercises the no-token path.
+    vi.stubEnv('GITHUB_TOKEN', '');
+    mockFetch.mockResolvedValueOnce(textResponse('# eks-gitops — agent entry point'));
+    const source = new GitHubSource();
+    const md = await source.fetchContract('eks-gitops');
+    expect(md).toContain('# eks-gitops');
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('raw.githubusercontent.com/nanohype/eks-gitops/main/AGENTS.md');
+    vi.unstubAllEnvs();
+  });
+
+  it('resolves via the authenticated contents API when a token is set', async () => {
+    const md = '# eks-fleet — agent entry point';
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ content: Buffer.from(md).toString('base64'), encoding: 'base64' }),
+    );
+    const source = new GitHubSource({ token: 'ghp_x' });
+    const out = await source.fetchContract('eks-fleet');
+    expect(out).toBe(md);
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('api.github.com/repos/nanohype/eks-fleet/contents/AGENTS.md?ref=main');
+    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer ghp_x');
+  });
+
+  it('falls back to GITHUB_TOKEN from the environment for the contents API', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'env_token');
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ content: Buffer.from('# kx').toString('base64'), encoding: 'base64' }),
+    );
+    const source = new GitHubSource();
+    await source.fetchContract('kx');
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer env_token');
+    vi.unstubAllEnvs();
+  });
+
+  it('throws NanohypeError when the AGENTS.md is missing', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '');
+    mockFetch.mockResolvedValueOnce(textResponse('Not Found', 404));
+    const source = new GitHubSource();
+    await expect(source.fetchContract('landing-zone')).rejects.toThrow(
+      "AGENTS.md for repo 'landing-zone' not found",
+    );
+    vi.unstubAllEnvs();
+  });
+});

--- a/sdk/src/contracts.ts
+++ b/sdk/src/contracts.ts
@@ -1,36 +1,61 @@
 import type { CatalogSource } from './source.js';
-import type { Contract, ContractRepo } from './types.js';
+import type { Contract, ContractRepo, ContractRepoInfo } from './types.js';
 
-const ALL_REPOS: ContractRepo[] = [
-  'nanohype',
-  'landing-zone',
-  'eks-gitops',
-  'aks-gitops',
-  'eks-agent-platform',
-  'kx',
-  'cloudgov',
+// The single source of truth for the contract surface: every nanohype repo that
+// ships an AGENTS.md, plus whether it's public or private. KNOWN_CONTRACT_REPOS
+// (names) and CONTRACT_REPOS (descriptors) are derived from this.
+const ALL_REPOS: ContractRepoInfo[] = [
+  { repo: 'nanohype', visibility: 'public' },
+  { repo: 'landing-zone', visibility: 'public' },
+  { repo: 'eks-gitops', visibility: 'public' },
+  { repo: 'eks-agent-platform', visibility: 'public' },
+  { repo: 'kx', visibility: 'public' },
+  { repo: 'cloudgov', visibility: 'public' },
+  { repo: 'fab', visibility: 'public' },
+  { repo: 'portal', visibility: 'public' },
+  { repo: 'eks-fleet', visibility: 'private' },
 ];
 
 /**
  * Load a single repo's AGENTS.md content. The catalog source resolves the
  * right filesystem or GitHub path per repo — see `LocalSource.fetchContract`
- * and `GitHubSource.fetchContract` for the resolution rules.
+ * and `GitHubSource.fetchContract` for the resolution rules. The repo's
+ * visibility is stamped onto the result when it's a known descriptor.
  */
 export async function loadContract(
   source: CatalogSource,
   repo: ContractRepo,
 ): Promise<Contract> {
   const content = await source.fetchContract(repo);
-  return { repo, content };
+  const visibility = ALL_REPOS.find((r) => r.repo === repo)?.visibility;
+  return visibility ? { repo, content, visibility } : { repo, content };
 }
 
 /**
- * Load every repo's AGENTS.md in parallel. Useful for an MCP server that
- * wants to expose the full set of contracts as resources up-front.
+ * Load every repo's AGENTS.md. Best-effort: a repo that can't be resolved — a
+ * private repo with no token, or a transient fetch error — is skipped with a
+ * warning instead of failing the whole load, so an MCP server still serves every
+ * public contract. The single-repo `loadContract` / `get_contract` path still
+ * surfaces the underlying error, which is the honest signal for a direct request.
  */
 export async function loadAllContracts(source: CatalogSource): Promise<Contract[]> {
-  return Promise.all(ALL_REPOS.map((repo) => loadContract(source, repo)));
+  const settled = await Promise.allSettled(
+    ALL_REPOS.map(async (r) => loadContract(source, r.repo)),
+  );
+  const loaded: Contract[] = [];
+  settled.forEach((result, i) => {
+    if (result.status === 'fulfilled') {
+      loaded.push(result.value);
+    } else {
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      console.warn(`[contracts] skipping ${ALL_REPOS[i].repo}: ${reason}`);
+    }
+  });
+  return loaded;
 }
 
-/** The canonical list of supporting repos that ship an AGENTS.md. */
-export const KNOWN_CONTRACT_REPOS: readonly ContractRepo[] = ALL_REPOS;
+/** The canonical list of supporting repos that ship an AGENTS.md (names only). */
+export const KNOWN_CONTRACT_REPOS: readonly ContractRepo[] = ALL_REPOS.map((r) => r.repo);
+
+/** The contract repos with their visibility — for callers that label or gate on it. */
+export const CONTRACT_REPOS: readonly ContractRepoInfo[] = ALL_REPOS;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -18,6 +18,8 @@ export type {
   CatalogComposite,
   Contract,
   ContractRepo,
+  ContractRepoInfo,
+  RepoVisibility,
   LanguageToolchainStandard,
   LLMPolicyStandard,
   PlatformTenantContractStandard,
@@ -55,4 +57,4 @@ export { renderComposite } from './composite.js';
 // Platform Reference loaders
 export { loadCatalog } from './catalog.js';
 export { loadStandard, loadStandards } from './standards.js';
-export { loadContract, loadAllContracts, KNOWN_CONTRACT_REPOS } from './contracts.js';
+export { loadContract, loadAllContracts, KNOWN_CONTRACT_REPOS, CONTRACT_REPOS } from './contracts.js';

--- a/sdk/src/sources/github.ts
+++ b/sdk/src/sources/github.ts
@@ -34,7 +34,9 @@ export class GitHubSource implements CatalogSource {
   constructor(options: GitHubSourceOptions = {}) {
     this.repo = options.repo ?? 'nanohype/nanohype';
     this.ref = options.ref ?? 'main';
-    this.token = options.token;
+    // Fall back to GITHUB_TOKEN so a private contract repo resolves with no caller
+    // config when the env var is present.
+    this.token = options.token ?? process.env.GITHUB_TOKEN;
     this.cacheTtl = options.cacheTtl ?? 5 * 60 * 1000;
   }
 
@@ -222,6 +224,26 @@ export class GitHubSource implements CatalogSource {
     // pull contracts from the matching forked siblings, which is correct).
     const [org] = this.repo.split('/');
     const targetRepo = repo === 'nanohype' ? this.repo : `${org}/${repo}`;
+
+    // With a token, resolve via the authenticated contents API — it works for
+    // both public and private repos (raw.githubusercontent can't authenticate
+    // private content via a Bearer header). Without a token, use the raw host,
+    // which is fine for public repos.
+    if (this.token) {
+      const res = await fetch(
+        `https://api.github.com/repos/${targetRepo}/contents/AGENTS.md?ref=${this.ref}`,
+        { headers: this.headers() },
+      );
+      if (!res.ok) {
+        throw new NanohypeError(`AGENTS.md for repo '${repo}' not found: ${res.status}`);
+      }
+      const body = (await res.json()) as { content?: string; encoding?: string };
+      if (body.encoding === 'base64' && body.content) {
+        return Buffer.from(body.content, 'base64').toString('utf-8');
+      }
+      throw new NanohypeError(`AGENTS.md for repo '${repo}' returned an unexpected encoding`);
+    }
+
     const res = await fetch(
       `https://raw.githubusercontent.com/${targetRepo}/${this.ref}/AGENTS.md`,
       { headers: this.headers() },

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -117,10 +117,21 @@ export type ContractRepo =
   | 'nanohype'
   | 'landing-zone'
   | 'eks-gitops'
-  | 'aks-gitops'
   | 'eks-agent-platform'
   | 'kx'
-  | 'cloudgov';
+  | 'cloudgov'
+  | 'fab'
+  | 'portal'
+  | 'eks-fleet';
+
+/** Whether a contract repo is publicly readable or needs an authenticated token. */
+export type RepoVisibility = 'public' | 'private';
+
+/** A contract repo plus its visibility — the descriptor the loader resolves against. */
+export interface ContractRepoInfo {
+  repo: ContractRepo;
+  visibility: RepoVisibility;
+}
 
 /** One entry in catalog.json's `templates` array — a single template's discovery metadata. */
 export interface CatalogTemplate {
@@ -371,4 +382,6 @@ export interface Standards {
 export interface Contract {
   repo: ContractRepo;
   content: string;
+  /** Stamped from the repo descriptor so consumers can label without a second lookup. */
+  visibility?: RepoVisibility;
 }


### PR DESCRIPTION
The contract surface — the per-repo `AGENTS.md` the SDK and `@nanohype/mcp` expose via `get_contract` — was a stale subset: it listed `aks-gitops` (now divested out of the org) and omitted `fab`, `portal`, and `eks-fleet`. This makes it the real inventory and teaches the loader to resolve private repos.

## The surface

- `ContractRepo` / `ALL_REPOS` drop `aks-gitops` and add `fab` + `portal` (public) and `eks-fleet` (private).
- `ALL_REPOS` becomes a visibility-aware descriptor list (`ContractRepoInfo {repo, visibility}`). `KNOWN_CONTRACT_REPOS` (names — the enum) and `CONTRACT_REPOS` (descriptors) derive from it, so the MCP `get_contract` enum and the contracts resource update from one source of truth.
- `loadContract` stamps the repo's `visibility` onto the returned `Contract`.

## Private resolution + resilience

- `GitHubSource.fetchContract` is token-aware: with a token it resolves via the authenticated GitHub contents API (works for public **and** private repos), falling back to `raw.githubusercontent` for the public/no-token path. The constructor falls back to `GITHUB_TOKEN`, so a private repo resolves with no caller config when the env var is present.
- `loadAllContracts` switches `Promise.all` → `Promise.allSettled`: a repo that can't be resolved (a private repo with no token, or a transient error) is **skipped with a warning** instead of failing the whole load, so the server still serves every public contract. The single `get_contract` path still surfaces the error — the honest signal for a direct request.
- The MCP contracts resource marks `eks-fleet` *(private — requires a GitHub token)*; the tool description says so too.

## Tests

- **SDK**: the fixture tree drops aks-gitops and adds fab/portal/eks-fleet; the loader suite covers the new repos, the visibility stamp, and an `allSettled` skip; a new `fetchContract` suite covers the raw path, the authenticated contents-API path, the `GITHUB_TOKEN` env fallback, and the not-found error.
- **MCP**: the resource + enum assertions are pinned to `KNOWN_CONTRACT_REPOS` so they can't drift again, plus a `get_contract` resolve for fab.
- SDK 110 tests, MCP 29 tests green.

Closes #129.