### PR TITLE
Scrub aks-gitops from the catalog, templates, and standards

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/catalog.schema.json",
   "kind": "nanohype/catalog",
   "version": "1",
-  "generated_at": "2026-06-23T01:26:33.000Z",
+  "generated_at": "2026-06-26T00:18:05.000Z",
   "templates": [
     {
       "name": "a2a-agent",
@@ -510,8 +510,8 @@
     },
     {
       "name": "eks-addon",
-      "displayName": "EKS / AKS GitOps Addon (Helm)",
-      "description": "Scaffolds a new Helm-based addon into nanohype/eks-gitops or nanohype/aks-gitops. Produces the addons/<category>/<name>/values.yaml + per-env delta files (values-{dev,staging,production}.yaml) following the eks-gitops Helm values pattern (base + delta-only). The Kustomize variant (used by storage-classes, priority-classes, karpenter-resources) needs a different layout and is not covered here.",
+      "displayName": "EKS GitOps Addon (Helm)",
+      "description": "Scaffolds a new Helm-based addon into nanohype/eks-gitops. Produces the addons/<category>/<name>/values.yaml + per-env delta files (values-{dev,staging,production}.yaml) following the eks-gitops Helm values pattern (base + delta-only). The Kustomize variant (used by storage-classes, priority-classes, karpenter-resources) needs a different layout and is not covered here.",
       "version": "0.1.0",
       "category": "infrastructure",
       "persona": [
@@ -523,7 +523,6 @@
         "argocd",
         "gitops",
         "eks",
-        "aks",
         "nanohype"
       ],
       "kind": "template",
@@ -804,7 +803,7 @@
     {
       "name": "k8s-app-tenant",
       "displayName": "K8s App as Platform Tenant",
-      "description": "Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm chart with per-environment values, an ArgoCD ApplicationSet entry ready to register against nanohype/eks-gitops or nanohype/aks-gitops, and a Platform CR (platform.nanohype.dev/v1alpha1) plus its required BudgetPolicy (governance.nanohype.dev/v1alpha1) declaring the tenant boundary for the eks-agent-platform operator to reconcile. Use this for every k8s-native deliverable unless an explicit escape hatch (aws-lambda, fly, vercel, cloudflare) is justified.",
+      "description": "Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm chart with per-environment values, an ArgoCD ApplicationSet entry ready to register against nanohype/eks-gitops, and a Platform CR (platform.nanohype.dev/v1alpha1) plus its required BudgetPolicy (governance.nanohype.dev/v1alpha1) declaring the tenant boundary for the eks-agent-platform operator to reconcile. Use this for every k8s-native deliverable unless an explicit escape hatch (aws-lambda, fly, vercel, cloudflare) is justified.",
       "version": "0.1.0",
       "category": "infrastructure",
       "persona": [

--- a/docs/platform-reference.md
+++ b/docs/platform-reference.md
@@ -18,14 +18,13 @@ If you're a human reading this looking for "how do I use the templates," skip do
 
 ## The stack
 
-Six public repos form the system. Five are the deploy substrate; the sixth (`fab`) is the reference factory client — open-source so you can clone it, configure your skills overlay, and run your own factory.
+Five public repos form the system. Four are the deploy substrate; the fifth (`fab`) is the reference factory client — open-source so you can clone it, configure your skills overlay, and run your own factory.
 
 | Repo                                                                            | Role                                                                                                                                                                                                                                                                                                                                                                 | Agent entry point              |
 | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | [`nanohype/nanohype`](https://github.com/nanohype/nanohype)                     | Template catalog + SDK + the public Platform Reference itself (this file)                                                                                                                                                                                                                                                                                            | [`AGENTS.md`](../AGENTS.md)    |
 | [`nanohype/landing-zone`](https://github.com/nanohype/landing-zone)             | OpenTofu/Terragrunt monorepo. Cloud substrate: VPC, base IAM, KMS, observability, per-app `<app>-platform` components                                                                                                                                                                                                                                                | `landing-zone/AGENTS.md`       |
 | [`nanohype/eks-gitops`](https://github.com/nanohype/eks-gitops)                 | ArgoCD addon catalog for EKS clusters (App-of-Apps pattern)                                                                                                                                                                                                                                                                                                          | `eks-gitops/AGENTS.md`         |
-| [`nanohype/aks-gitops`](https://github.com/nanohype/aks-gitops)                 | Same for AKS                                                                                                                                                                                                                                                                                                                                                         | `aks-gitops/AGENTS.md`         |
 | [`nanohype/eks-agent-platform`](https://github.com/nanohype/eks-agent-platform) | k8s-native control plane. Owns the `Platform` / `AgentFleet` / `ModelGateway` / `BudgetPolicy` / `EvalSuite` CRDs                                                                                                                                                                                                                                                    | `eks-agent-platform/AGENTS.md` |
 | [`nanohype/kx`](https://github.com/nanohype/kx)                                 | Local kind workspace that mirrors `eks-gitops`. Run the same charts locally before deploying                                                                                                                                                                                                                                                                         | `kx/AGENTS.md`                 |
 | [`nanohype/fab`](https://github.com/nanohype/fab)                               | Reference factory client. Orchestrates 83 Claude agents across Discovery → Design → Build → Verify → Ship → Operate. Dual transports — Managed Agents (default) or `@anthropic-ai/claude-agent-sdk` (local). Ships baseline skills (quality-check, factory-preamble, intake-guide, 31 curator/engineer baselines); overlay your personal recipe via `~/.fab/skills/` | `fab/skills/README.md`         |
@@ -34,7 +33,7 @@ The boundary between layers:
 
 - **Slow-moving cloud infra** (VPC, base IAM, KMS keys, cost pipeline, EventBridge, WAF) → `landing-zone`
 - **Per-tenant fast-moving AWS state** (IRSA roles, KMS grants, S3 bucket policies, Bedrock model-access) → `eks-agent-platform` operator reconciles via AWS SDK
-- **Cluster addons** (cert-manager, external-secrets, Kyverno, observability) → `eks-gitops` / `aks-gitops`
+- **Cluster addons** (cert-manager, external-secrets, Kyverno, observability) → `eks-gitops`
 - **Local development** → `kx` (kind cluster mirroring eks-gitops)
 - **Application logic** → templates from `nanohype/templates/` scaffolded into an `<app>/chart/` + `<app>/platform.yaml`
 
@@ -78,7 +77,7 @@ Each repo in the stack has an `AGENTS.md` at its root — short, agent-facing, a
 1. [`nanohype/AGENTS.md`](../AGENTS.md) — templates + SDK + catalog. The starting point.
 2. `eks-agent-platform/AGENTS.md` — the CRD surface. Platform / AgentFleet / ModelGateway / BudgetPolicy / EvalSuite. How to declare a tenant.
 3. `landing-zone/AGENTS.md` — cloud substrate. The `<app>-platform` per-app component pattern. OIDC trust setup.
-4. `eks-gitops/AGENTS.md` (and `aks-gitops/AGENTS.md`) — addon catalog. ApplicationSet entry shape. Sync waves.
+4. `eks-gitops/AGENTS.md` — addon catalog. ApplicationSet entry shape. Sync waves.
 5. `kx/AGENTS.md` — local kind mirror. When to use it.
 
 If you're skipping straight to delivery, only `eks-agent-platform/AGENTS.md` is mandatory — its Platform CR is what your output must conform to.

--- a/standards/README.md
+++ b/standards/README.md
@@ -41,7 +41,7 @@ Every k8s-native deliverable ships as a **Platform tenant** — a self-contained
 A tenant ships three artifacts:
 
 1. A Helm chart in `<app>/chart/` with per-env values files
-2. An ApplicationSet entry referenced by `nanohype/eks-gitops` or `nanohype/aks-gitops`
+2. An ApplicationSet entry referenced by `nanohype/eks-gitops`
 3. A Platform CR (and any required BudgetPolicy CR) declaring the tenant boundary
 
 The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IRSA role. The chart's own ServiceAccount carries the `eks.amazonaws.com/role-arn` annotation rendered from a per-env Helm value pointing at the landing-zone-owned IRSA role.
@@ -50,7 +50,7 @@ What you must **not** do inside a chart:
 
 - Scaffold IAM roles (the operator + landing-zone own IRSA)
 - Add cloud-substrate tofu (substrate lives in `nanohype/landing-zone`)
-- Add cluster-level addons (addons live in `nanohype/eks-gitops` / `aks-gitops`)
+- Add cluster-level addons (addons live in `nanohype/eks-gitops`)
 - Skip per-env values files (every chart has three, even if some are empty)
 - Hardcode AWS account IDs, region names, or KMS ARNs
 

--- a/standards/platform-tenant-contract.json
+++ b/standards/platform-tenant-contract.json
@@ -36,7 +36,7 @@
       },
       {
         "path": "<app>/gitops/applicationset-entry.yaml",
-        "description": "ApplicationSet entry to be registered with `nanohype/eks-gitops` or `nanohype/aks-gitops`."
+        "description": "ApplicationSet entry to be registered with `nanohype/eks-gitops`."
       },
       {
         "path": "<app>/platform.yaml",
@@ -97,7 +97,7 @@
     "do_not": [
       "Do NOT scaffold IAM roles inside the chart, and do NOT annotate the ServiceAccount with a role ARN. The IAM role is provisioned by the corresponding landing-zone <app>-platform component, which also creates the EKS Pod Identity association that binds the ServiceAccount to it — the chart carries no role ARN.",
       "Do NOT add cloud-substrate tofu (VPCs, base IAM, KMS keys) inside the app. Substrate lives in `nanohype/landing-zone` as a per-app `<app>-platform` component.",
-      "Do NOT add cluster-level addons in the chart (ingress controller, cert-manager, External Secrets, observability stack). Those are gitops-repo concerns in `nanohype/eks-gitops` or `aks-gitops`.",
+      "Do NOT add cluster-level addons in the chart (ingress controller, cert-manager, External Secrets, observability stack). Those are gitops-repo concerns in `nanohype/eks-gitops`.",
       "Do NOT skip per-env `values-{dev,staging,production}.yaml` — every chart has three deltas even if some are empty.",
       "Do NOT hardcode AWS account IDs, region names, or KMS key ARNs in chart values. Per-env values plumb them in from landing-zone outputs at deploy time."
     ]

--- a/templates/eks-addon/README.md
+++ b/templates/eks-addon/README.md
@@ -1,6 +1,6 @@
 # eks-addon
 
-Scaffolds a new Helm-based addon into [`nanohype/eks-gitops`](https://github.com/nanohype/eks-gitops) or [`nanohype/aks-gitops`](https://github.com/nanohype/aks-gitops). Follows the base + delta-only env values pattern that both gitops repos standardize on.
+Scaffolds a new Helm-based addon into [`nanohype/eks-gitops`](https://github.com/nanohype/eks-gitops). Follows the base + delta-only env values pattern eks-gitops standardizes on.
 
 The Kustomize-based addon variant (used by `storage-classes`, `priority-classes`, `karpenter-resources`) needs a different file layout and is not covered by this template — copy from an existing Kustomize addon directly.
 
@@ -40,7 +40,7 @@ Apps land at wave ≥100 (handled by `k8s-app-tenant`).
 ## Project layout
 
 ```text
-eks-gitops/                          # (or aks-gitops/)
+eks-gitops/
   addons/
     __CATEGORY__/
       __ADDON_NAME__/

--- a/templates/eks-addon/skeleton/README.md
+++ b/templates/eks-addon/skeleton/README.md
@@ -1,6 +1,6 @@
 # __ADDON_NAME__ addon
 
-Helm-based addon for `nanohype/eks-gitops` (or `nanohype/aks-gitops`). Uses chart `__CHART_NAME__` from `__CHART_REPO__` pinned to `__CHART_VERSION__`.
+Helm-based addon for `nanohype/eks-gitops`. Uses chart `__CHART_NAME__` from `__CHART_REPO__` pinned to `__CHART_VERSION__`.
 
 ## Files added to the gitops repo
 

--- a/templates/eks-addon/template.yaml
+++ b/templates/eks-addon/template.yaml
@@ -1,10 +1,9 @@
 apiVersion: nanohype/v1
 
 name: eks-addon
-displayName: "EKS / AKS GitOps Addon (Helm)"
+displayName: "EKS GitOps Addon (Helm)"
 description: >
-  Scaffolds a new Helm-based addon into nanohype/eks-gitops or
-  nanohype/aks-gitops. Produces the
+  Scaffolds a new Helm-based addon into nanohype/eks-gitops. Produces the
   addons/<category>/<name>/values.yaml + per-env delta files
   (values-{dev,staging,production}.yaml) following the eks-gitops
   Helm values pattern (base + delta-only). The Kustomize variant
@@ -14,7 +13,7 @@ version: "0.1.0"
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
-tags: [kubernetes, helm, argocd, gitops, eks, aks, nanohype]
+tags: [kubernetes, helm, argocd, gitops, eks, nanohype]
 
 variables:
   - name: AddonName

--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -13,7 +13,7 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
   - `prometheusrule.yaml` — *(on by default)* SLI recording rules + multi-window multi-burn-rate error-budget alerts (the `observability-slo` standard), driven by the `slo.*` values
   - `grafana-dashboard.yaml` + `dashboards/<app>.json` — *(on by default)* a `GrafanaDashboard` CR (grafana-operator → external Amazon Managed Grafana): self-contained SRE board — SLO/error-budget row + traffic + errors + latency p50/p95/p99 + saturation
   - `servicemonitor.yaml` — *(toggle, off by default)* Prometheus scrape for apps that expose `/metrics` instead of pushing via OTLP
-- **ApplicationSet entry** in `gitops/applicationset-entry.yaml` ready to copy into `nanohype/eks-gitops/applicationsets/` (or aks-gitops)
+- **ApplicationSet entry** in `gitops/applicationset-entry.yaml` ready to copy into `nanohype/eks-gitops/applicationsets/`
 - **Platform CR** in `platform.yaml` — a `Platform` (`platform.nanohype.dev/v1alpha1`) plus its required `BudgetPolicy` (`governance.nanohype.dev/v1alpha1`). The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IRSA role (scoped to `spec.identity.allowedModelFamilies`); the BudgetPolicy drives the spend kill-switch
 - **Skeleton README** documenting how to apply the Platform CR, register the ApplicationSet entry, and roll out new versions
 
@@ -81,8 +81,8 @@ Compose with any of the application templates that produce a container-shipped s
 
 Designed to work with these repos already in place on the target cluster:
 
-- `nanohype/landing-zone` — provisions the EKS/AKS cluster, ArgoCD, base IAM, KMS keys, and the per-app `<app>-platform` component (IRSA role + Secrets Manager entries)
-- `nanohype/eks-gitops` (or `aks-gitops`) — supplies cluster addons (cert-manager, external-secrets, ingress-nginx, observability, Kyverno policies) and the ApplicationSet that picks up `gitops/applicationset-entry.yaml`
+- `nanohype/landing-zone` — provisions the EKS cluster, ArgoCD, base IAM, KMS keys, and the per-app `<app>-platform` component (IRSA role + Secrets Manager entries)
+- `nanohype/eks-gitops` — supplies cluster addons (cert-manager, external-secrets, ingress-nginx, observability, Kyverno policies) and the ApplicationSet that picks up `gitops/applicationset-entry.yaml`
 - `nanohype/eks-agent-platform` — runs the operator that reconciles your `platform.yaml`
 
 If any of these are missing on the target cluster, the rendered app's `platform.yaml` won't reconcile and the ApplicationSet entry won't have a parent to register against.

--- a/templates/k8s-app-tenant/template.yaml
+++ b/templates/k8s-app-tenant/template.yaml
@@ -5,7 +5,7 @@ displayName: "K8s App as Platform Tenant"
 description: >
   Primary scaffolding for a nanohype-org k8s-native application. Produces
   a Helm chart with per-environment values, an ArgoCD ApplicationSet entry
-  ready to register against nanohype/eks-gitops or nanohype/aks-gitops,
+  ready to register against nanohype/eks-gitops,
   and a Platform CR (platform.nanohype.dev/v1alpha1) plus its required
   BudgetPolicy (governance.nanohype.dev/v1alpha1) declaring the tenant
   boundary for the eks-agent-platform operator to reconcile. Use this for

--- a/templates/k8s-deploy/README.md
+++ b/templates/k8s-deploy/README.md
@@ -2,7 +2,7 @@
 
 Generic Kubernetes deployment with raw manifests and an optional Helm chart. Works against any cluster. Production-grade defaults with resource limits, health probes, non-root security context, and auto-scaling.
 
-> **Picking between k8s-deploy and k8s-app-tenant:** use `k8s-app-tenant` when targeting nanohype-org clusters (EKS or AKS managed by `eks-agent-platform` + `eks-gitops`/`aks-gitops` + `landing-zone`). That template produces a Helm chart plus an ApplicationSet entry and a Platform CR, and assumes the operator is running. Use `k8s-deploy` when targeting a generic cluster without those operators — bare-bones manifests + Helm, no Platform CR, no opinionated ArgoCD wiring.
+> **Picking between k8s-deploy and k8s-app-tenant:** use `k8s-app-tenant` when targeting nanohype-org clusters (EKS managed by `eks-agent-platform` + `eks-gitops` + `landing-zone`). That template produces a Helm chart plus an ApplicationSet entry and a Platform CR, and assumes the operator is running. Use `k8s-deploy` when targeting a generic cluster without those operators — bare-bones manifests + Helm, no Platform CR, no opinionated ArgoCD wiring.
 
 ## What you get
 


### PR DESCRIPTION
aks-gitops is moving out of the nanohype org (to a personal account), so the docs and template sources that paired it with `eks-gitops` or pointed at `nanohype/aks-gitops` now name only the org-owned EKS catalog.

- **Platform Reference** — dropped the aks-gitops repo row, the addon-layer pairing, and the "read `aks-gitops/AGENTS.md`" onboarding step; the repo count is now five (four substrate + fab).
- **eks-addon template** — displayName "EKS GitOps Addon", description targets only `nanohype/eks-gitops`, dropped the `aks` discovery tag; the README + skeleton README (which ships into every scaffolded addon) drop the aks-gitops pointer.
- **k8s-app-tenant + k8s-deploy** — the ApplicationSet-target and "pairs with" prose name eks-gitops only.
- **standards/README.md + `platform-tenant-contract.json`** — the ApplicationSet-registration artifact and the do-not addon rule reference `nanohype/eks-gitops` only.
- **catalog.json** regenerated from the template sources (`verify:catalog` will match).

Genuine Azure capability (landing-zone azure components, the azure escape-hatch templates) is untouched — this moves the repo, not Azure support. Catalog validation passes.

Part of the aks-gitops divestment.