### PR TITLE
Gate the eks-gitops alert burn-rate constants against the SLO standard

### DIFF
--- a/.github/workflows/slo-constants.yml
+++ b/.github/workflows/slo-constants.yml
@@ -1,0 +1,38 @@
+name: SLO constants
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'standards/observability-slo.json'
+      - 'scripts/check-slo-constants.mjs'
+      - '.github/workflows/slo-constants.yml'
+  pull_request:
+    paths:
+      - 'standards/observability-slo.json'
+      - 'scripts/check-slo-constants.mjs'
+      - '.github/workflows/slo-constants.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Burn-rate constants match the eks-gitops alerts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout nanohype
+        uses: actions/checkout@v6
+
+      # The alert PromQL that inlines the standard's burn-rate factors lives in
+      # eks-gitops (a public repo), so pull just its alerting dir to diff against.
+      - name: Checkout eks-gitops alerting
+        uses: actions/checkout@v6
+        with:
+          repository: nanohype/eks-gitops
+          path: eks-gitops
+          sparse-checkout: dashboards/base/alerting
+          sparse-checkout-cone-mode: false
+
+      - name: Check SLO constants
+        run: node scripts/check-slo-constants.mjs eks-gitops/dashboards/base/alerting

--- a/scripts/check-slo-constants.mjs
+++ b/scripts/check-slo-constants.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+//
+// check-slo-constants.mjs — fail if the burn-rate factors and objective
+// denominators inlined into the eks-gitops alert PromQL drift from
+// standards/observability-slo.json.
+//
+// The standard lives in this repo; its consumers — the GrafanaAlertRuleGroup
+// exprs — live in eks-gitops (inlined because prod has no Prometheus ruler).
+// Neither repo's own CI could otherwise catch the standard changing out from
+// under the alerts. CI sparse-checks-out the eks-gitops alerting dir and runs
+// this so a change here is caught against the live consumers.
+//
+// Usage: node scripts/check-slo-constants.mjs <eks-gitops-alerting-dir>
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const STANDARD = 'standards/observability-slo.json'
+const alertDir = process.argv[2]
+if (!alertDir) {
+  console.error('usage: check-slo-constants.mjs <eks-gitops-alerting-dir>')
+  process.exit(2)
+}
+
+const c = JSON.parse(readFileSync(STANDARD, 'utf-8')).content
+
+// Burn-rate factors from the standard. Page-tier are the ones the prod ruler
+// actually implements; ticket-tier (3, 1) are defined but not alerted in prod.
+const windows = c.burn_rate_alerts.windows
+const allFactors = new Set(windows.map((w) => w.factor))
+const pageFactors = new Set(windows.filter((w) => w.severity === 'page').map((w) => w.factor))
+
+// Objective denominators = 1 - objective, rounded to kill float dust (0.999 -> 0.001).
+const round = (n) => Math.round(n * 1e6) / 1e6
+const denominators = new Set(c.slo.sli_types.map((t) => round(1 - t.default_objective)))
+
+const files = readdirSync(alertDir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+if (files.length === 0) {
+  console.error(`no alert files under ${alertDir}`)
+  process.exit(2)
+}
+
+const errors = []
+const usedFactors = new Set()
+
+for (const f of files) {
+  const text = readFileSync(join(alertDir, f), 'utf-8')
+  // "> bool <factor>" is the multi-window/multi-burn-rate comparison.
+  for (const m of text.matchAll(/> bool ([0-9]+(?:\.[0-9]+)?)/g)) {
+    const factor = Number(m[1])
+    usedFactors.add(factor)
+    if (!allFactors.has(factor)) {
+      errors.push(
+        `${f}: burn-rate factor ${factor} ("> bool ${m[1]}") is not a factor in ${STANDARD} (defined: ${[...allFactors].sort((a, b) => a - b).join(', ')})`,
+      )
+    }
+  }
+  // "/ 0.0xx" is the error ratio divided by (1 - objective) to get the burn rate.
+  for (const m of text.matchAll(/\/ (0\.0[0-9]+)/g)) {
+    const denom = round(Number(m[1]))
+    if (!denominators.has(denom)) {
+      errors.push(
+        `${f}: objective denominator ${m[1]} is not (1 - objective) for any SLI in ${STANDARD} (defined: ${[...denominators].sort((a, b) => a - b).join(', ')})`,
+      )
+    }
+  }
+}
+
+// Every page-tier factor must be implemented by at least one alert.
+for (const pf of pageFactors) {
+  if (!usedFactors.has(pf)) {
+    errors.push(`page-tier burn-rate factor ${pf} from ${STANDARD} is not used in any alert expr`)
+  }
+}
+
+if (errors.length) {
+  console.error('SLO-constants drift detected:')
+  for (const e of errors) console.error(`  - ${e}`)
+  console.error(
+    `\nThe alert PromQL inlines the burn-rate factors + objective denominators from ${STANDARD}.`,
+  )
+  console.error('When the standard changes, update the eks-gitops alert exprs to match (or vice versa).')
+  process.exit(1)
+}
+
+console.log(
+  `SLO-constants OK: alert factors {${[...usedFactors].sort((a, b) => a - b).join(', ')}} and objective denominators all match ${STANDARD}.`,
+)


### PR DESCRIPTION
`standards/observability-slo.json` defines the multi-window/multi-burn-rate factors (page-tier 14.4 + 6, ticket-tier 3 + 1) and the SLI objectives. The `GrafanaAlertRuleGroup` PromQL that consumes them lives in eks-gitops and inlines the values literally (`> bool 14.4`, `/ 0.001`) because prod has no Prometheus ruler — so neither repo's own CI could catch the standard changing out from under the alerts.

- **`scripts/check-slo-constants.mjs`** parses the standard's burn-rate factors and objective denominators (`1 - objective`) and asserts every factor and denominator inlined in the eks-gitops alert exprs is one the standard defines, and that each **page-tier** factor is actually implemented by an alert (ticket-tier 3/1 are defined but intentionally not alerted in prod).
- The **`slo-constants`** workflow runs it on any change to the standard or the script, sparse-checking-out the eks-gitops alerting dir (a public repo) to diff against the live consumers.

Verified: passes against the current alerts (factors `{6, 14.4}`, denominators `{0.001, 0.01}`); a corrupted standard factor is caught.

Closes #125.