### PR TITLE
Mark eks-fleet public in the contract surface

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -11,7 +11,7 @@ Use it when you're building an AI client (Bedrock agent, Claude Desktop assistan
 | `nanohype://catalog` | Full `catalog.json` (templates + composites with metadata) | `application/json` |
 | `nanohype://standards` | All five standards files bundled | `application/json` |
 | `nanohype://standards/{name}` | One standards file. `name` ∈ `language-toolchain` / `version-currency` / `platform-tenant-contract` / `llm-policy` / `quality-rubric-dimensions` | `application/json` |
-| `nanohype://contracts/{repo}` | One repo's `AGENTS.md`. `repo` ∈ `nanohype` / `landing-zone` / `eks-gitops` / `eks-agent-platform` / `kx` / `cloudgov` / `fab` / `portal` / `eks-fleet` (private — needs a GitHub token) | `text/markdown` |
+| `nanohype://contracts/{repo}` | One repo's `AGENTS.md`. `repo` ∈ `nanohype` / `landing-zone` / `eks-gitops` / `eks-agent-platform` / `kx` / `cloudgov` / `fab` / `portal` / `eks-fleet` | `text/markdown` |
 | `nanohype://template/{name}` | One template's full manifest (variables, conditionals, hooks, composition) | `application/json` |
 | `nanohype://composite/{name}` | One composite's full manifest (multi-template orchestration) | `application/json` |
 

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -104,7 +104,7 @@ export function listTools(): ToolDescriptor[] {
     {
       name: 'get_contract',
       description:
-        "Fetch a repo's AGENTS.md content. Use this when you need the agent-facing contract surface for a specific repo (what it gives you, how to add a new thing, conventions). Private repos (e.g. eks-fleet) resolve only when the server has a GitHub token; without one they return a not-found error.",
+        "Fetch a repo's AGENTS.md content. Use this when you need the agent-facing contract surface for a specific repo (what it gives you, how to add a new thing, conventions). Every contract repo is public; a future private one would resolve only when the server has a GitHub token.",
       inputSchema: {
         type: 'object',
         properties: {

--- a/sdk/__tests__/contracts.test.ts
+++ b/sdk/__tests__/contracts.test.ts
@@ -36,7 +36,7 @@ describe('loadContract', () => {
 
   it('stamps the repo visibility onto the loaded contract', async () => {
     expect((await loadContract(source, 'eks-gitops')).visibility).toBe('public');
-    expect((await loadContract(source, 'eks-fleet')).visibility).toBe('private');
+    expect((await loadContract(source, 'eks-fleet')).visibility).toBe('public');
   });
 
   it('throws NanohypeError when the repo path does not exist', async () => {
@@ -57,8 +57,9 @@ describe('loadAllContracts', () => {
   });
 
   it('skips a repo that fails to resolve instead of rejecting the whole load', async () => {
-    // A source that resolves everything except eks-fleet — the shape of a private
-    // repo fetched without a token (404). The load must degrade, not throw.
+    // A source that resolves everything except eks-fleet — the shape of a
+    // transient fetch failure, or a future private repo fetched without a token
+    // (404). The load must degrade, not throw.
     const partial = {
       async fetchContract(repo: string) {
         if (repo === 'eks-fleet') throw new NanohypeError('AGENTS.md for repo \'eks-fleet\' not found: 404');

--- a/sdk/src/contracts.ts
+++ b/sdk/src/contracts.ts
@@ -13,7 +13,7 @@ const ALL_REPOS: ContractRepoInfo[] = [
   { repo: 'cloudgov', visibility: 'public' },
   { repo: 'fab', visibility: 'public' },
   { repo: 'portal', visibility: 'public' },
-  { repo: 'eks-fleet', visibility: 'private' },
+  { repo: 'eks-fleet', visibility: 'public' },
 ];
 
 /**


### PR DESCRIPTION
## What

eks-fleet is now a public repo, so its `AGENTS.md` resolves through the contract surface without a GitHub token like every other contract repo. This flips its descriptor and drops the stale token-gated framing.

## Changes

- `sdk/src/contracts.ts` — eks-fleet visibility `private` → `public`.
- `sdk/__tests__/contracts.test.ts` — assert `public`; the skip-on-failure test keeps eks-fleet as its 404 stand-in but reframes the comment as a transient failure / future private repo rather than eks-fleet specifically.
- `mcp-server/src/tools.ts` + `mcp-server/README.md` — the `get_contract` description and the resource-table row no longer single out eks-fleet as private.

The token-resolution machinery is untouched — it just has nothing private to resolve right now. `sdk` and `mcp-server` build + test green.

https://claude.ai/code/session_01R6rXpE1FZAVS14zanDdgb7