### PR TITLE
Bound, batch, and fail-loud the GitHub catalog source

### DIFF
--- a/sdk/__tests__/sources/github.test.ts
+++ b/sdk/__tests__/sources/github.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { GitHubSource } from '../../src/sources/github.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubSource } from "../../src/sources/github.js";
 
 const mockFetch = vi.fn();
 
@@ -8,7 +8,7 @@ beforeEach(() => {
   // top-level `vi.fn()` instances — reset between tests explicitly so
   // `mock.calls` and `toHaveBeenCalledTimes` start clean.
   mockFetch.mockReset();
-  vi.stubGlobal('fetch', mockFetch);
+  vi.stubGlobal("fetch", mockFetch);
 });
 
 afterEach(() => {
@@ -18,7 +18,7 @@ afterEach(() => {
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { "Content-Type": "application/json" },
   });
 }
 
@@ -26,43 +26,47 @@ function textResponse(text: string, status = 200): Response {
   return new Response(text, { status });
 }
 
-describe('GitHubSource', () => {
-  describe('constructor defaults', () => {
-    it('uses nanohype/nanohype repo and main ref by default', async () => {
+describe("GitHubSource", () => {
+  describe("constructor defaults", () => {
+    it("uses nanohype/nanohype repo and main ref by default", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
       const source = new GitHubSource();
       await source.listTemplates();
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('repos/nanohype/nanohype/contents/templates?ref=main'),
+        expect.stringContaining(
+          "repos/nanohype/nanohype/contents/templates?ref=main",
+        ),
         expect.any(Object),
       );
     });
 
-    it('accepts custom repo and ref', async () => {
+    it("accepts custom repo and ref", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
-      const source = new GitHubSource({ repo: 'org/repo', ref: 'v1.0.0' });
+      const source = new GitHubSource({ repo: "org/repo", ref: "v1.0.0" });
       await source.listTemplates();
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('repos/org/repo/contents/templates?ref=v1.0.0'),
+        expect.stringContaining("repos/org/repo/contents/templates?ref=v1.0.0"),
         expect.any(Object),
       );
     });
   });
 
-  describe('authorization', () => {
-    it('includes Bearer token when provided', async () => {
+  describe("authorization", () => {
+    it("includes Bearer token when provided", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
-      const source = new GitHubSource({ token: 'ghp_test123' });
+      const source = new GitHubSource({ token: "ghp_test123" });
       await source.listTemplates();
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          headers: expect.objectContaining({ Authorization: 'Bearer ghp_test123' }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer ghp_test123",
+          }),
         }),
       );
     });
 
-    it('omits Authorization header when no token', async () => {
+    it("omits Authorization header when no token", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
       const source = new GitHubSource();
       await source.listTemplates();
@@ -71,13 +75,13 @@ describe('GitHubSource', () => {
     });
   });
 
-  describe('listTemplates', () => {
-    it('parses directory listing and fetches manifests', async () => {
+  describe("listTemplates", () => {
+    it("parses directory listing and fetches manifests", async () => {
       mockFetch
         .mockResolvedValueOnce(
           jsonResponse([
-            { name: 'go-cli', type: 'dir' },
-            { name: 'README.md', type: 'file' },
+            { name: "go-cli", type: "dir" },
+            { name: "README.md", type: "file" },
           ]),
         )
         .mockResolvedValueOnce(
@@ -89,11 +93,11 @@ describe('GitHubSource', () => {
       const source = new GitHubSource();
       const entries = await source.listTemplates();
       expect(entries).toHaveLength(1);
-      expect(entries[0].name).toBe('go-cli');
-      expect(entries[0].displayName).toBe('Go CLI');
+      expect(entries[0].name).toBe("go-cli");
+      expect(entries[0].displayName).toBe("Go CLI");
     });
 
-    it('caches results within TTL', async () => {
+    it("caches results within TTL", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
       const source = new GitHubSource({ cacheTtl: 60_000 });
       await source.listTemplates();
@@ -101,30 +105,72 @@ describe('GitHubSource', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('throws on non-OK response', async () => {
+    it("throws on non-OK response", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({}, 403));
       const source = new GitHubSource();
-      await expect(source.listTemplates()).rejects.toThrow('Failed to list catalog: 403');
+      await expect(source.listTemplates()).rejects.toThrow(
+        "Failed to list catalog: 403",
+      );
+    });
+
+    it("skips directories without a manifest but throws on other manifest failures", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse([{ name: "not-a-template", type: "dir" }]),
+        )
+        .mockResolvedValueOnce(textResponse("Not found", 404));
+      const source = new GitHubSource();
+      await expect(source.listTemplates()).resolves.toEqual([]);
+
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse([{ name: "go-cli", type: "dir" }]))
+        .mockResolvedValueOnce(textResponse("rate limited", 429));
+      const rateLimited = new GitHubSource({ cacheTtl: 0 });
+      await expect(rateLimited.listTemplates()).rejects.toThrow(
+        "Failed to fetch manifest for template 'go-cli': 429",
+      );
+    });
+
+    it("throws on an unparseable manifest instead of dropping the entry", async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse([{ name: "go-cli", type: "dir" }]))
+        .mockResolvedValueOnce(textResponse("{{ not: yaml: at: all"));
+      const source = new GitHubSource();
+      await expect(source.listTemplates()).rejects.toThrow(
+        "Invalid manifest for template 'go-cli'",
+      );
+    });
+
+    it("bounds every request with an abort signal", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+      const source = new GitHubSource();
+      await source.listTemplates();
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
     });
   });
 
-  describe('fetchTemplate', () => {
-    it('throws on missing template', async () => {
-      mockFetch.mockResolvedValueOnce(textResponse('Not found', 404));
+  describe("fetchTemplate", () => {
+    it("throws on missing template", async () => {
+      mockFetch.mockResolvedValueOnce(textResponse("Not found", 404));
       const source = new GitHubSource();
-      await expect(source.fetchTemplate('missing')).rejects.toThrow("Template 'missing' not found");
+      await expect(source.fetchTemplate("missing")).rejects.toThrow(
+        "Template 'missing' not found",
+      );
     });
 
-    it('parses manifest, fetches skeleton tree, and returns files', async () => {
+    it("parses manifest, fetches skeleton tree, and returns files", async () => {
       const manifestYaml = [
-        'apiVersion: nanohype/v1',
-        'name: go-cli',
-        'displayName: Go CLI',
-        'description: A Go CLI starter',
+        "apiVersion: nanohype/v1",
+        "name: go-cli",
+        "displayName: Go CLI",
+        "description: A Go CLI starter",
         'version: "1.0.0"',
-        'tags: [go, cli]',
-        'variables: []',
-      ].join('\n');
+        "tags: [go, cli]",
+        "variables: []",
+      ].join("\n");
 
       mockFetch
         // 1. Manifest YAML fetch
@@ -133,52 +179,112 @@ describe('GitHubSource', () => {
         .mockResolvedValueOnce(
           jsonResponse({
             tree: [
-              { path: 'templates/go-cli/template.yaml', type: 'blob', sha: 'aaa' },
-              { path: 'templates/go-cli/skeleton/main.go', type: 'blob', sha: 'bbb' },
-              { path: 'templates/go-cli/skeleton/pkg/util.go', type: 'blob', sha: 'ccc' },
-              { path: 'templates/other/skeleton/index.ts', type: 'blob', sha: 'ddd' },
-              { path: 'templates/go-cli/skeleton', type: 'tree', sha: 'eee' },
+              {
+                path: "templates/go-cli/template.yaml",
+                type: "blob",
+                sha: "aaa",
+              },
+              {
+                path: "templates/go-cli/skeleton/main.go",
+                type: "blob",
+                sha: "bbb",
+              },
+              {
+                path: "templates/go-cli/skeleton/pkg/util.go",
+                type: "blob",
+                sha: "ccc",
+              },
+              {
+                path: "templates/other/skeleton/index.ts",
+                type: "blob",
+                sha: "ddd",
+              },
+              { path: "templates/go-cli/skeleton", type: "tree", sha: "eee" },
             ],
           }),
         )
         // 3. File content fetches (only the two skeleton blobs matching the prefix)
-        .mockResolvedValueOnce(textResponse('package main\n\nfunc main() {}'))
-        .mockResolvedValueOnce(textResponse('package pkg\n\nfunc Util() {}'));
+        .mockResolvedValueOnce(textResponse("package main\n\nfunc main() {}"))
+        .mockResolvedValueOnce(textResponse("package pkg\n\nfunc Util() {}"));
 
       const source = new GitHubSource();
-      const { manifest, files } = await source.fetchTemplate('go-cli');
+      const { manifest, files } = await source.fetchTemplate("go-cli");
 
       // Manifest is parsed correctly
-      expect(manifest.apiVersion).toBe('nanohype/v1');
-      expect(manifest.name).toBe('go-cli');
-      expect(manifest.displayName).toBe('Go CLI');
-      expect(manifest.description).toBe('A Go CLI starter');
-      expect(manifest.version).toBe('1.0.0');
-      expect(manifest.tags).toEqual(['go', 'cli']);
+      expect(manifest.apiVersion).toBe("nanohype/v1");
+      expect(manifest.name).toBe("go-cli");
+      expect(manifest.displayName).toBe("Go CLI");
+      expect(manifest.description).toBe("A Go CLI starter");
+      expect(manifest.version).toBe("1.0.0");
+      expect(manifest.tags).toEqual(["go", "cli"]);
 
       // Skeleton files have paths relative to the skeleton/ directory
       expect(files).toHaveLength(2);
-      expect(files[0]).toEqual({ path: 'main.go', content: 'package main\n\nfunc main() {}' });
-      expect(files[1]).toEqual({ path: 'pkg/util.go', content: 'package pkg\n\nfunc Util() {}' });
+      expect(files[0]).toEqual({
+        path: "main.go",
+        content: "package main\n\nfunc main() {}",
+      });
+      expect(files[1]).toEqual({
+        path: "pkg/util.go",
+        content: "package pkg\n\nfunc Util() {}",
+      });
 
       // Verify the correct URLs were called
       expect(mockFetch).toHaveBeenCalledTimes(4);
       expect(mockFetch.mock.calls[0][0]).toContain(
-        'raw.githubusercontent.com/nanohype/nanohype/main/templates/go-cli/template.yaml',
+        "raw.githubusercontent.com/nanohype/nanohype/main/templates/go-cli/template.yaml",
       );
       expect(mockFetch.mock.calls[1][0]).toContain(
-        'api.github.com/repos/nanohype/nanohype/git/trees/main?recursive=1',
+        "api.github.com/repos/nanohype/nanohype/git/trees/main?recursive=1",
+      );
+    });
+
+    it("throws when a skeleton file fails to fetch — never renders a partial scaffold", async () => {
+      const manifestYaml = [
+        "apiVersion: nanohype/v1",
+        "name: go-cli",
+        "displayName: Go CLI",
+        "description: A Go CLI starter",
+        'version: "1.0.0"',
+        "tags: [go, cli]",
+        "variables: []",
+      ].join("\n");
+
+      mockFetch
+        .mockResolvedValueOnce(textResponse(manifestYaml))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            tree: [
+              {
+                path: "templates/go-cli/skeleton/main.go",
+                type: "blob",
+                sha: "aaa",
+              },
+              {
+                path: "templates/go-cli/skeleton/pkg/util.go",
+                type: "blob",
+                sha: "bbb",
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(textResponse("package main"))
+        .mockResolvedValueOnce(textResponse("Server error", 500));
+
+      const source = new GitHubSource();
+      await expect(source.fetchTemplate("go-cli")).rejects.toThrow(
+        "Failed to fetch skeleton file 'templates/go-cli/skeleton/pkg/util.go' for template 'go-cli': 500",
       );
     });
   });
 
-  describe('listComposites', () => {
-    it('parses composite directory listing', async () => {
+  describe("listComposites", () => {
+    it("parses composite directory listing", async () => {
       mockFetch
         .mockResolvedValueOnce(
           jsonResponse([
-            { name: 'ai-chatbot.yaml', type: 'file' },
-            { name: 'not-yaml.md', type: 'file' },
+            { name: "ai-chatbot.yaml", type: "file" },
+            { name: "not-yaml.md", type: "file" },
           ]),
         )
         .mockResolvedValueOnce(
@@ -190,66 +296,82 @@ describe('GitHubSource', () => {
       const source = new GitHubSource();
       const entries = await source.listComposites();
       expect(entries).toHaveLength(1);
-      expect(entries[0].name).toBe('ai-chatbot');
+      expect(entries[0].name).toBe("ai-chatbot");
       expect(entries[0].templateCount).toBe(1);
     });
   });
 
-  describe('fetchComposite', () => {
-    it('throws on missing composite', async () => {
-      mockFetch.mockResolvedValueOnce(textResponse('Not found', 404));
+  describe("fetchComposite", () => {
+    it("throws on missing composite", async () => {
+      mockFetch.mockResolvedValueOnce(textResponse("Not found", 404));
       const source = new GitHubSource();
-      await expect(source.fetchComposite('missing')).rejects.toThrow(
+      await expect(source.fetchComposite("missing")).rejects.toThrow(
         "Composite 'missing' not found",
       );
     });
   });
 });
 
-describe('GitHubSource.fetchContract', () => {
-  it('resolves a public repo via raw.githubusercontent when no token is set', async () => {
+describe("GitHubSource.fetchContract", () => {
+  it("resolves a public repo via raw.githubusercontent when no token is set", async () => {
     // The constructor falls back to GITHUB_TOKEN, which CI sets — clear it so this
     // exercises the no-token path.
-    vi.stubEnv('GITHUB_TOKEN', '');
-    mockFetch.mockResolvedValueOnce(textResponse('# eks-gitops — agent entry point'));
+    vi.stubEnv("GITHUB_TOKEN", "");
+    mockFetch.mockResolvedValueOnce(
+      textResponse("# eks-gitops — agent entry point"),
+    );
     const source = new GitHubSource();
-    const md = await source.fetchContract('eks-gitops');
-    expect(md).toContain('# eks-gitops');
+    const md = await source.fetchContract("eks-gitops");
+    expect(md).toContain("# eks-gitops");
     const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain('raw.githubusercontent.com/nanohype/eks-gitops/main/AGENTS.md');
+    expect(url).toContain(
+      "raw.githubusercontent.com/nanohype/eks-gitops/main/AGENTS.md",
+    );
     vi.unstubAllEnvs();
   });
 
-  it('resolves via the authenticated contents API when a token is set', async () => {
-    const md = '# eks-fleet — agent entry point';
+  it("resolves via the authenticated contents API when a token is set", async () => {
+    const md = "# eks-fleet — agent entry point";
     mockFetch.mockResolvedValueOnce(
-      jsonResponse({ content: Buffer.from(md).toString('base64'), encoding: 'base64' }),
+      jsonResponse({
+        content: Buffer.from(md).toString("base64"),
+        encoding: "base64",
+      }),
     );
-    const source = new GitHubSource({ token: 'ghp_x' });
-    const out = await source.fetchContract('eks-fleet');
+    const source = new GitHubSource({ token: "ghp_x" });
+    const out = await source.fetchContract("eks-fleet");
     expect(out).toBe(md);
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain('api.github.com/repos/nanohype/eks-fleet/contents/AGENTS.md?ref=main');
-    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer ghp_x');
+    expect(url).toContain(
+      "api.github.com/repos/nanohype/eks-fleet/contents/AGENTS.md?ref=main",
+    );
+    expect((opts.headers as Record<string, string>).Authorization).toBe(
+      "Bearer ghp_x",
+    );
   });
 
-  it('falls back to GITHUB_TOKEN from the environment for the contents API', async () => {
-    vi.stubEnv('GITHUB_TOKEN', 'env_token');
+  it("falls back to GITHUB_TOKEN from the environment for the contents API", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "env_token");
     mockFetch.mockResolvedValueOnce(
-      jsonResponse({ content: Buffer.from('# kx').toString('base64'), encoding: 'base64' }),
+      jsonResponse({
+        content: Buffer.from("# kx").toString("base64"),
+        encoding: "base64",
+      }),
     );
     const source = new GitHubSource();
-    await source.fetchContract('kx');
+    await source.fetchContract("kx");
     const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer env_token');
+    expect((opts.headers as Record<string, string>).Authorization).toBe(
+      "Bearer env_token",
+    );
     vi.unstubAllEnvs();
   });
 
-  it('throws NanohypeError when the AGENTS.md is missing', async () => {
-    vi.stubEnv('GITHUB_TOKEN', '');
-    mockFetch.mockResolvedValueOnce(textResponse('Not Found', 404));
+  it("throws NanohypeError when the AGENTS.md is missing", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+    mockFetch.mockResolvedValueOnce(textResponse("Not Found", 404));
     const source = new GitHubSource();
-    await expect(source.fetchContract('landing-zone')).rejects.toThrow(
+    await expect(source.fetchContract("landing-zone")).rejects.toThrow(
       "AGENTS.md for repo 'landing-zone' not found",
     );
     vi.unstubAllEnvs();

--- a/sdk/src/source.ts
+++ b/sdk/src/source.ts
@@ -8,11 +8,13 @@ import type {
   StandardName,
   SkeletonFile,
   TemplateManifest,
-} from './types.js';
+} from "./types.js";
 
 export interface CatalogSource {
   listTemplates(): Promise<CatalogEntry[]>;
-  fetchTemplate(name: string): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }>;
+  fetchTemplate(
+    name: string,
+  ): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }>;
   listComposites(): Promise<CompositeCatalogEntry[]>;
   fetchComposite(name: string): Promise<CompositeManifest>;
 
@@ -35,6 +37,8 @@ export interface GitHubSourceOptions {
   ref?: string;
   token?: string;
   cacheTtl?: number;
+  /** Per-request timeout in milliseconds for GitHub API calls. Default 10 000. */
+  requestTimeout?: number;
 }
 
 export interface LocalSourceOptions {

--- a/sdk/src/sources/github.ts
+++ b/sdk/src/sources/github.ts
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import yaml from "js-yaml";
 import type {
   Catalog,
   CatalogEntry,
@@ -9,41 +9,96 @@ import type {
   Standard,
   StandardName,
   TemplateManifest,
-} from '../types.js';
-import type { CatalogSource, GitHubSourceOptions } from '../source.js';
-import { NanohypeError } from '../errors.js';
+} from "../types.js";
+import type { CatalogSource, GitHubSourceOptions } from "../source.js";
+import { NanohypeError } from "../errors.js";
 
 interface CacheEntry<T> {
   data: T;
   fetchedAt: number;
 }
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+// Manifest and skeleton-file fetches fan out per entry; a bounded pool keeps
+// large catalogs fast without hammering the GitHub API into secondary rate
+// limits the way an unbounded Promise.all would.
+const FETCH_CONCURRENCY = 8;
+
+/** Run `fn` over `items` with at most `limit` in flight, preserving result order. */
+async function mapConcurrent<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (next < items.length) {
+        const i = next++;
+        results[i] = await fn(items[i]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 /**
  * Catalog source that reads templates from a GitHub repository via the GitHub API.
- * Uses native fetch and in-memory TTL caching per instance.
+ * Uses native fetch and in-memory TTL caching per instance. Every request carries
+ * a timeout, and fetch failures surface as errors — a scaffold is rendered
+ * complete or not at all, never silently partial.
  */
 export class GitHubSource implements CatalogSource {
   private readonly repo: string;
   private readonly ref: string;
   private readonly token?: string;
   private readonly cacheTtl: number;
+  private readonly requestTimeout: number;
 
   private catalogCache: CacheEntry<CatalogEntry[]> | null = null;
-  private compositeCatalogCache: CacheEntry<CompositeCatalogEntry[]> | null = null;
+  private compositeCatalogCache: CacheEntry<CompositeCatalogEntry[]> | null =
+    null;
 
   constructor(options: GitHubSourceOptions = {}) {
-    this.repo = options.repo ?? 'nanohype/nanohype';
-    this.ref = options.ref ?? 'main';
+    this.repo = options.repo ?? "nanohype/nanohype";
+    this.ref = options.ref ?? "main";
     // Fall back to GITHUB_TOKEN so a private contract repo resolves with no caller
     // config when the env var is present.
     this.token = options.token ?? process.env.GITHUB_TOKEN;
     this.cacheTtl = options.cacheTtl ?? 5 * 60 * 1000;
+    this.requestTimeout = options.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
 
   private headers(): Record<string, string> {
-    const h: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
+    const h: Record<string, string> = {
+      Accept: "application/vnd.github.v3+json",
+    };
     if (this.token) h.Authorization = `Bearer ${this.token}`;
     return h;
+  }
+
+  private async get(url: string): Promise<Response> {
+    try {
+      return await fetch(url, {
+        headers: this.headers(),
+        signal: AbortSignal.timeout(this.requestTimeout),
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === "TimeoutError") {
+        throw new NanohypeError(
+          `GitHub request timed out after ${this.requestTimeout}ms: ${url}`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  private raw(path: string): string {
+    return `https://raw.githubusercontent.com/${this.repo}/${this.ref}/${path}`;
   }
 
   private isFresh<T>(cache: CacheEntry<T> | null): cache is CacheEntry<T> {
@@ -53,25 +108,40 @@ export class GitHubSource implements CatalogSource {
   async listTemplates(): Promise<CatalogEntry[]> {
     if (this.isFresh(this.catalogCache)) return this.catalogCache.data;
 
-    const res = await fetch(
+    const res = await this.get(
       `https://api.github.com/repos/${this.repo}/contents/templates?ref=${this.ref}`,
-      { headers: this.headers() },
     );
-    if (!res.ok) throw new NanohypeError(`Failed to list catalog: ${res.status}`);
+    if (!res.ok)
+      throw new NanohypeError(`Failed to list catalog: ${res.status}`);
 
     const dirs = (await res.json()) as { name: string; type: string }[];
-    const templateDirs = dirs.filter((d) => d.type === 'dir');
+    const templateDirs = dirs.filter((d) => d.type === "dir");
 
-    const entries: CatalogEntry[] = [];
-    for (const dir of templateDirs) {
-      try {
-        const manifestRes = await fetch(
-          `https://raw.githubusercontent.com/${this.repo}/${this.ref}/templates/${dir.name}/template.yaml`,
-          { headers: this.headers() },
+    const fetched = await mapConcurrent(
+      templateDirs,
+      FETCH_CONCURRENCY,
+      async (dir): Promise<CatalogEntry | null> => {
+        const manifestRes = await this.get(
+          this.raw(`templates/${dir.name}/template.yaml`),
         );
-        if (!manifestRes.ok) continue;
-        const manifest = yaml.load(await manifestRes.text()) as TemplateManifest;
-        entries.push({
+        // A directory without a template.yaml is not a template — skip it.
+        // Anything else non-OK (rate limit, outage) must not silently shrink
+        // the catalog.
+        if (manifestRes.status === 404) return null;
+        if (!manifestRes.ok) {
+          throw new NanohypeError(
+            `Failed to fetch manifest for template '${dir.name}': ${manifestRes.status}`,
+          );
+        }
+        let manifest: TemplateManifest;
+        try {
+          manifest = yaml.load(await manifestRes.text()) as TemplateManifest;
+        } catch (err) {
+          throw new NanohypeError(
+            `Invalid manifest for template '${dir.name}': ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        return {
           name: manifest.name,
           displayName: manifest.displayName,
           description: manifest.description,
@@ -80,11 +150,10 @@ export class GitHubSource implements CatalogSource {
           persona: manifest.persona,
           category: manifest.category,
           tags: manifest.tags,
-        });
-      } catch {
-        // Skip templates with invalid manifests
-      }
-    }
+        };
+      },
+    );
+    const entries = fetched.filter((e): e is CatalogEntry => e !== null);
 
     this.catalogCache = { data: entries, fetchedAt: Date.now() };
     return entries;
@@ -94,25 +163,26 @@ export class GitHubSource implements CatalogSource {
     name: string,
   ): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }> {
     // Fetch manifest
-    const manifestRes = await fetch(
-      `https://raw.githubusercontent.com/${this.repo}/${this.ref}/templates/${name}/template.yaml`,
-      { headers: this.headers() },
+    const manifestRes = await this.get(
+      this.raw(`templates/${name}/template.yaml`),
     );
     if (!manifestRes.ok) {
-      throw new NanohypeError(`Template '${name}' not found: ${manifestRes.status}`);
+      throw new NanohypeError(
+        `Template '${name}' not found: ${manifestRes.status}`,
+      );
     }
     const manifest = yaml.load(await manifestRes.text()) as TemplateManifest;
 
-    if (manifest.apiVersion !== 'nanohype/v1') {
+    if (manifest.apiVersion !== "nanohype/v1") {
       throw new NanohypeError(`Unsupported apiVersion: ${manifest.apiVersion}`);
     }
 
     // Fetch skeleton via Git Trees API (recursive, single request)
-    const treeRes = await fetch(
+    const treeRes = await this.get(
       `https://api.github.com/repos/${this.repo}/git/trees/${this.ref}?recursive=1`,
-      { headers: this.headers() },
     );
-    if (!treeRes.ok) throw new NanohypeError(`Failed to fetch repo tree: ${treeRes.status}`);
+    if (!treeRes.ok)
+      throw new NanohypeError(`Failed to fetch repo tree: ${treeRes.status}`);
 
     const tree = (await treeRes.json()) as {
       tree: { path: string; type: string; sha: string }[];
@@ -120,98 +190,115 @@ export class GitHubSource implements CatalogSource {
 
     const skeletonPrefix = `templates/${name}/skeleton/`;
     const skeletonBlobs = tree.tree.filter(
-      (entry) => entry.type === 'blob' && entry.path.startsWith(skeletonPrefix),
+      (entry) => entry.type === "blob" && entry.path.startsWith(skeletonPrefix),
     );
 
-    // Fetch file contents
-    const files: SkeletonFile[] = [];
-    for (const blob of skeletonBlobs) {
-      const fileRes = await fetch(
-        `https://raw.githubusercontent.com/${this.repo}/${this.ref}/${blob.path}`,
-        { headers: this.headers() },
-      );
-      if (!fileRes.ok) continue;
-      files.push({
-        path: blob.path.slice(skeletonPrefix.length),
-        content: await fileRes.text(),
-      });
-    }
+    // Fetch file contents. Any failure aborts the render — a skeleton with
+    // holes is worse than no skeleton.
+    const files = await mapConcurrent(
+      skeletonBlobs,
+      FETCH_CONCURRENCY,
+      async (blob) => {
+        const fileRes = await this.get(this.raw(blob.path));
+        if (!fileRes.ok) {
+          throw new NanohypeError(
+            `Failed to fetch skeleton file '${blob.path}' for template '${name}': ${fileRes.status}`,
+          );
+        }
+        return {
+          path: blob.path.slice(skeletonPrefix.length),
+          content: await fileRes.text(),
+        } satisfies SkeletonFile;
+      },
+    );
 
     return { manifest, files };
   }
 
   async listComposites(): Promise<CompositeCatalogEntry[]> {
-    if (this.isFresh(this.compositeCatalogCache)) return this.compositeCatalogCache.data;
+    if (this.isFresh(this.compositeCatalogCache))
+      return this.compositeCatalogCache.data;
 
-    const res = await fetch(
+    const res = await this.get(
       `https://api.github.com/repos/${this.repo}/contents/composites?ref=${this.ref}`,
-      { headers: this.headers() },
     );
-    if (!res.ok) throw new NanohypeError(`Failed to list composite catalog: ${res.status}`);
+    if (!res.ok)
+      throw new NanohypeError(
+        `Failed to list composite catalog: ${res.status}`,
+      );
 
     const items = (await res.json()) as { name: string; type: string }[];
-    const yamlFiles = items.filter((f) => f.type === 'file' && f.name.endsWith('.yaml'));
+    const yamlFiles = items.filter(
+      (f) => f.type === "file" && f.name.endsWith(".yaml"),
+    );
 
-    const entries: CompositeCatalogEntry[] = [];
-    for (const file of yamlFiles) {
-      try {
-        const manifestRes = await fetch(
-          `https://raw.githubusercontent.com/${this.repo}/${this.ref}/composites/${file.name}`,
-          { headers: this.headers() },
-        );
-        if (!manifestRes.ok) continue;
-        const manifest = yaml.load(await manifestRes.text()) as CompositeManifest;
-        if (manifest.kind !== 'composite') continue;
-        entries.push({
+    const fetched = await mapConcurrent(
+      yamlFiles,
+      FETCH_CONCURRENCY,
+      async (file): Promise<CompositeCatalogEntry | null> => {
+        const manifestRes = await this.get(this.raw(`composites/${file.name}`));
+        if (manifestRes.status === 404) return null;
+        if (!manifestRes.ok) {
+          throw new NanohypeError(
+            `Failed to fetch composite manifest '${file.name}': ${manifestRes.status}`,
+          );
+        }
+        let manifest: CompositeManifest;
+        try {
+          manifest = yaml.load(await manifestRes.text()) as CompositeManifest;
+        } catch (err) {
+          throw new NanohypeError(
+            `Invalid composite manifest '${file.name}': ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        if (manifest.kind !== "composite") return null;
+        return {
           name: manifest.name,
           displayName: manifest.displayName,
           description: manifest.description,
           version: manifest.version,
           tags: manifest.tags,
           templateCount: manifest.templates.length,
-        });
-      } catch {
-        // Skip composites with invalid manifests
-      }
-    }
+        };
+      },
+    );
+    const entries = fetched.filter(
+      (e): e is CompositeCatalogEntry => e !== null,
+    );
 
     this.compositeCatalogCache = { data: entries, fetchedAt: Date.now() };
     return entries;
   }
 
   async fetchComposite(name: string): Promise<CompositeManifest> {
-    const res = await fetch(
-      `https://raw.githubusercontent.com/${this.repo}/${this.ref}/composites/${name}.yaml`,
-      { headers: this.headers() },
-    );
-    if (!res.ok) throw new NanohypeError(`Composite '${name}' not found: ${res.status}`);
+    const res = await this.get(this.raw(`composites/${name}.yaml`));
+    if (!res.ok)
+      throw new NanohypeError(`Composite '${name}' not found: ${res.status}`);
     const manifest = yaml.load(await res.text()) as CompositeManifest;
 
-    if (manifest.apiVersion !== 'nanohype/v1') {
+    if (manifest.apiVersion !== "nanohype/v1") {
       throw new NanohypeError(`Unsupported apiVersion: ${manifest.apiVersion}`);
     }
-    if (manifest.kind !== 'composite') {
-      throw new NanohypeError(`Expected kind 'composite', got '${manifest.kind}'`);
+    if (manifest.kind !== "composite") {
+      throw new NanohypeError(
+        `Expected kind 'composite', got '${manifest.kind}'`,
+      );
     }
 
     return manifest;
   }
 
   async fetchCatalogManifest(): Promise<Catalog> {
-    const res = await fetch(
-      `https://raw.githubusercontent.com/${this.repo}/${this.ref}/catalog.json`,
-      { headers: this.headers() },
-    );
-    if (!res.ok) throw new NanohypeError(`catalog.json not found: ${res.status}`);
+    const res = await this.get(this.raw("catalog.json"));
+    if (!res.ok)
+      throw new NanohypeError(`catalog.json not found: ${res.status}`);
     return (await res.json()) as Catalog;
   }
 
   async fetchStandard(name: StandardName): Promise<Standard> {
-    const res = await fetch(
-      `https://raw.githubusercontent.com/${this.repo}/${this.ref}/standards/${name}.json`,
-      { headers: this.headers() },
-    );
-    if (!res.ok) throw new NanohypeError(`Standard '${name}' not found: ${res.status}`);
+    const res = await this.get(this.raw(`standards/${name}.json`));
+    if (!res.ok)
+      throw new NanohypeError(`Standard '${name}' not found: ${res.status}`);
     return (await res.json()) as Standard;
   }
 
@@ -222,34 +309,41 @@ export class GitHubSource implements CatalogSource {
     // `<org>/<repo>`. Otherwise we still target the configured ref on the
     // explicit repo path (an MCP server pointed at a fork's `nanohype` will
     // pull contracts from the matching forked siblings, which is correct).
-    const [org] = this.repo.split('/');
-    const targetRepo = repo === 'nanohype' ? this.repo : `${org}/${repo}`;
+    const [org] = this.repo.split("/");
+    const targetRepo = repo === "nanohype" ? this.repo : `${org}/${repo}`;
 
     // With a token, resolve via the authenticated contents API — it works for
     // both public and private repos (raw.githubusercontent can't authenticate
     // private content via a Bearer header). Without a token, use the raw host,
     // which is fine for public repos.
     if (this.token) {
-      const res = await fetch(
+      const res = await this.get(
         `https://api.github.com/repos/${targetRepo}/contents/AGENTS.md?ref=${this.ref}`,
-        { headers: this.headers() },
       );
       if (!res.ok) {
-        throw new NanohypeError(`AGENTS.md for repo '${repo}' not found: ${res.status}`);
+        throw new NanohypeError(
+          `AGENTS.md for repo '${repo}' not found: ${res.status}`,
+        );
       }
-      const body = (await res.json()) as { content?: string; encoding?: string };
-      if (body.encoding === 'base64' && body.content) {
-        return Buffer.from(body.content, 'base64').toString('utf-8');
+      const body = (await res.json()) as {
+        content?: string;
+        encoding?: string;
+      };
+      if (body.encoding === "base64" && body.content) {
+        return Buffer.from(body.content, "base64").toString("utf-8");
       }
-      throw new NanohypeError(`AGENTS.md for repo '${repo}' returned an unexpected encoding`);
+      throw new NanohypeError(
+        `AGENTS.md for repo '${repo}' returned an unexpected encoding`,
+      );
     }
 
-    const res = await fetch(
+    const res = await this.get(
       `https://raw.githubusercontent.com/${targetRepo}/${this.ref}/AGENTS.md`,
-      { headers: this.headers() },
     );
     if (!res.ok) {
-      throw new NanohypeError(`AGENTS.md for repo '${repo}' not found: ${res.status}`);
+      throw new NanohypeError(
+        `AGENTS.md for repo '${repo}' not found: ${res.status}`,
+      );
     }
     return await res.text();
   }

--- a/templates/infra-aws/skeleton/test/stack.test.ts
+++ b/templates/infra-aws/skeleton/test/stack.test.ts
@@ -29,9 +29,12 @@ describe("ServiceStack", () => {
 
     const template = Template.fromStack(stack);
 
-    // Validate compute resources exist — the specific resource type
-    // depends on the __COMPUTE_TARGET__ selected at generation time
-    expect(template.toJSON()).toBeDefined();
+    // The concrete resource type depends on the __COMPUTE_TARGET__ selected
+    // at generation time, so assert on the synthesized set: with VPC, RDS,
+    // and monitoring disabled, every resource in the stack belongs to the
+    // compute target — an empty set means it synthesized nothing.
+    const resources: Record<string, unknown> = template.toJSON().Resources ?? {};
+    expect(Object.keys(resources).length).toBeGreaterThan(0);
   });
 
   test("includes monitoring when enabled", () => {

--- a/templates/worker-service/skeleton/src/worker/consumer/jobs/example.ts
+++ b/templates/worker-service/skeleton/src/worker/consumer/jobs/example.ts
@@ -20,7 +20,7 @@ export const sendNotification: JobHandler<NotificationPayload> = async (
 ): Promise<void> => {
   const { recipient, subject, channel } = job.data;
 
-  // TODO: Replace with actual notification delivery
+  // A real handler would deliver the payload, e.g.:
   //
   //   await notificationService.send({
   //     to: recipient,

--- a/templates/worker-service/skeleton/src/worker/scheduler/jobs/example.ts
+++ b/templates/worker-service/skeleton/src/worker/scheduler/jobs/example.ts
@@ -10,12 +10,12 @@ import type { CronJobDefinition } from "../../types.js";
 export const cleanupStaleData: CronJobDefinition = {
   name: "cleanup-stale-data",
   expression: "0 * * * *",
-  description: "Remove stale data older than 30 days",
+  description: "Example job — computes a 30-day cutoff and exits without deleting anything",
 
   async handler(): Promise<void> {
     const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
-    // TODO: Replace with actual cleanup logic
+    // A real handler would act on the cutoff, e.g.:
     //
     //   const deleted = await db
     //     .delete(records)


### PR DESCRIPTION
See commit messages for full details.

## Summary
- Every GitHubSource fetch carries a timeout (configurable, default 10s); manifest/skeleton fan-outs run through a bounded 8-wide pool
- Failure semantics explicit: rate-limit/outage throws instead of silently shrinking the catalog; a failed skeleton file aborts the render — no partial scaffolds
- Template skeleton honesty: infra-aws compute test asserts real synthesis; worker-service example jobs describe exactly what they do