### PR TITLE
Validate MCP tool args; contain catalog paths in both sources

### DIFF
--- a/mcp-server/__tests__/resources.test.ts
+++ b/mcp-server/__tests__/resources.test.ts
@@ -100,4 +100,28 @@ describe('readResource', () => {
       /Unrecognized resource URI/,
     );
   });
+
+  it('rejects template names that violate the catalog naming rule', async () => {
+    await expect(readResource(source, 'nanohype://template/../../etc/passwd')).rejects.toThrow(
+      /Invalid template name/,
+    );
+    await expect(readResource(source, 'nanohype://template/go-cli\0evil')).rejects.toThrow(
+      /Invalid template name/,
+    );
+  });
+
+  it('rejects composite names that violate the catalog naming rule', async () => {
+    await expect(readResource(source, 'nanohype://composite/../secrets')).rejects.toThrow(
+      /Invalid composite name/,
+    );
+  });
+
+  it('rejects traversal in standard and contract URIs', async () => {
+    await expect(readResource(source, 'nanohype://standards/../package')).rejects.toThrow(
+      /Unknown standard/,
+    );
+    await expect(readResource(source, 'nanohype://contracts/../../etc')).rejects.toThrow(
+      /Unknown repo/,
+    );
+  });
 });

--- a/mcp-server/__tests__/tools.test.ts
+++ b/mcp-server/__tests__/tools.test.ts
@@ -160,7 +160,123 @@ describe('callTool', () => {
     expect(result.content[0].text).toContain('# fab');
   });
 
-  it('rejects unknown tools', async () => {
+  it('rejects unknown tools as a protocol error (throw, not isError result)', async () => {
     await expect(callTool(source, 'bogus_tool', {})).rejects.toThrow(/Unknown tool/);
+  });
+
+  it('happy-path results carry no isError flag', async () => {
+    const result = await callTool(source, 'get_template', { name: 'agentic-loop' });
+    expect(result.isError).toBeUndefined();
+  });
+});
+
+describe('callTool argument validation', () => {
+  const source = new LocalSource({ rootDir: CATALOG_ROOT });
+
+  async function expectToolError(
+    name: string,
+    args: Record<string, unknown>,
+    match: string | RegExp,
+  ): Promise<void> {
+    const result = await callTool(source, name, args);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(match);
+  }
+
+  describe('get_template / get_composite names', () => {
+    it('rejects path traversal', async () => {
+      await expectToolError('get_template', { name: '../../../etc/passwd' }, /not a valid catalog name/);
+      await expectToolError('get_composite', { name: '../secrets' }, /not a valid catalog name/);
+    });
+
+    it('rejects absolute paths', async () => {
+      await expectToolError('get_template', { name: '/etc/passwd' }, /not a valid catalog name/);
+    });
+
+    it('rejects null bytes', async () => {
+      await expectToolError('get_template', { name: 'go-cli\0evil' }, /not a valid catalog name/);
+    });
+
+    it('rejects URL metacharacters', async () => {
+      await expectToolError('get_template', { name: 'go-cli?ref=evil' }, /not a valid catalog name/);
+      await expectToolError('get_composite', { name: 'a/b' }, /not a valid catalog name/);
+    });
+
+    it('rejects missing and non-string names', async () => {
+      await expectToolError('get_template', {}, /'name': expected a string, got undefined/);
+      await expectToolError('get_template', { name: 42 }, /'name': expected a string/);
+      await expectToolError('get_composite', { name: null }, /'name': expected a string/);
+    });
+  });
+
+  describe('get_standard names', () => {
+    it('rejects names outside the published set', async () => {
+      await expectToolError('get_standard', { name: 'bogus' }, /not a known standard/);
+    });
+
+    it('rejects traversal attempts', async () => {
+      await expectToolError('get_standard', { name: '../../package' }, /not a known standard/);
+    });
+
+    it('rejects non-string names', async () => {
+      await expectToolError('get_standard', { name: 42 }, /'name': expected a string/);
+    });
+  });
+
+  describe('get_contract repos', () => {
+    it('rejects repos outside the known set', async () => {
+      await expectToolError('get_contract', { repo: 'not-a-repo' }, /not a known contract repo/);
+    });
+
+    it('rejects traversal attempts', async () => {
+      await expectToolError('get_contract', { repo: '../../etc' }, /not a known contract repo/);
+      await expectToolError('get_contract', { repo: 'nanohype/../evil' }, /not a known contract repo/);
+    });
+
+    it('rejects missing repos', async () => {
+      await expectToolError('get_contract', {}, /'repo': expected a string, got undefined/);
+    });
+  });
+
+  describe('search_templates filters', () => {
+    it('rejects a missing query (declared required)', async () => {
+      await expectToolError('search_templates', {}, /'query': expected a string, got undefined/);
+    });
+
+    it('rejects non-string filters', async () => {
+      await expectToolError('search_templates', { query: '', category: 3 }, /'category': expected a string/);
+      await expectToolError('search_templates', { query: '', persona: {} }, /'persona': expected a string/);
+    });
+
+    it('rejects kind values outside the enum', async () => {
+      await expectToolError('search_templates', { query: '', kind: 'bogus' }, /'kind'.*expected 'template' or 'brief'/);
+    });
+
+    it('still accepts the full valid filter set', async () => {
+      const result = await callTool(source, 'search_templates', {
+        query: '',
+        category: 'ai-systems',
+        persona: 'engineering',
+        kind: 'template',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0].text).length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('callTool error semantics', () => {
+  const source = new LocalSource({ rootDir: CATALOG_ROOT });
+
+  it('a well-formed but missing template is an isError result, not a throw', async () => {
+    const result = await callTool(source, 'get_template', { name: 'no-such-template' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Template 'no-such-template' not found");
+  });
+
+  it('a well-formed but missing composite is an isError result, not a throw', async () => {
+    const result = await callTool(source, 'get_composite', { name: 'no-such-composite' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Composite 'no-such-composite' not found");
   });
 });

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -6,13 +6,13 @@ import {
 import {
   CatalogSource,
   CONTRACT_REPOS,
-  KNOWN_CONTRACT_REPOS,
+  isCatalogName,
+  isContractRepo,
+  isStandardName,
   loadCatalog,
   loadStandard,
   loadStandards,
   STANDARD_NAMES,
-  type ContractRepo,
-  type StandardName,
 } from '@nanohype/sdk';
 
 interface StaticResource {
@@ -104,8 +104,8 @@ export async function readResource(
 
   const standardMatch = /^nanohype:\/\/standards\/(.+)$/.exec(uri);
   if (standardMatch) {
-    const name = standardMatch[1] as StandardName;
-    if (!STANDARD_NAMES.includes(name)) {
+    const name = standardMatch[1];
+    if (!isStandardName(name)) {
       throw new Error(`Unknown standard: ${name}`);
     }
     const standard = await loadStandard(source, name);
@@ -122,8 +122,8 @@ export async function readResource(
 
   const contractMatch = /^nanohype:\/\/contracts\/(.+)$/.exec(uri);
   if (contractMatch) {
-    const repo = contractMatch[1] as ContractRepo;
-    if (!KNOWN_CONTRACT_REPOS.includes(repo)) {
+    const repo = contractMatch[1];
+    if (!isContractRepo(repo)) {
       throw new Error(`Unknown repo: ${repo}`);
     }
     const content = await source.fetchContract(repo);
@@ -141,6 +141,11 @@ export async function readResource(
   const templateMatch = /^nanohype:\/\/template\/(.+)$/.exec(uri);
   if (templateMatch) {
     const name = templateMatch[1];
+    // LLM-constructed URI — hold the name to the catalog naming rule before
+    // it reaches a source (which interpolates it into paths/URLs).
+    if (!isCatalogName(name)) {
+      throw new Error(`Invalid template name: ${name}`);
+    }
     const { manifest } = await source.fetchTemplate(name);
     return {
       contents: [
@@ -156,6 +161,9 @@ export async function readResource(
   const compositeMatch = /^nanohype:\/\/composite\/(.+)$/.exec(uri);
   if (compositeMatch) {
     const name = compositeMatch[1];
+    if (!isCatalogName(name)) {
+      throw new Error(`Invalid composite name: ${name}`);
+    }
     const manifest = await source.fetchComposite(name);
     return {
       contents: [

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,7 +1,11 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import {
+  CATALOG_NAME_PATTERN,
   CatalogSource,
+  isCatalogName,
+  isContractRepo,
+  isStandardName,
   KNOWN_CONTRACT_REPOS,
   loadCatalog,
   loadStandard,
@@ -141,47 +145,147 @@ export function searchTemplates(
 }
 
 /**
+ * The MCP tool-result shape. `isError: true` marks a tool-level failure.
+ * A type alias (not an interface) so it carries an implicit index signature
+ * and stays assignable to the MCP SDK's `ServerResult` union.
+ */
+export type ToolResult = {
+  content: { type: 'text'; text: string }[];
+  isError?: true;
+};
+
+/**
+ * Marker for a tool name the server never advertised. Per the MCP spec an
+ * unknown tool is a protocol error, not a tool result — so this is the one
+ * failure `callTool` re-throws instead of folding into `isError: true`.
+ */
+class UnknownToolError extends Error {}
+
+// ── Argument validation ─────────────────────────────────────────────────────
+// Tool arguments arrive from an LLM client and the declared inputSchema is
+// advisory — nothing in the protocol enforces it. Every argument is
+// re-validated here before it reaches a source: names against the catalog
+// naming rule, standards and contract repos against their closed sets.
+// Violations throw plain Errors, which `callTool` converts into `isError`
+// results with the message intact so the calling LLM can self-correct.
+
+function describeValue(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (value === undefined) return 'undefined';
+  return `${JSON.stringify(value)} (${typeof value})`;
+}
+
+function stringArg(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid argument '${key}': expected a string, got ${describeValue(value)}`);
+  }
+  return value;
+}
+
+function optionalStringArg(args: Record<string, unknown>, key: string): string | undefined {
+  if (args[key] === undefined) return undefined;
+  return stringArg(args, key);
+}
+
+function catalogNameArg(args: Record<string, unknown>): string {
+  const value = stringArg(args, 'name');
+  if (!isCatalogName(value)) {
+    throw new Error(
+      `Invalid argument 'name': ${describeValue(value)} is not a valid catalog name (must match ${CATALOG_NAME_PATTERN})`,
+    );
+  }
+  return value;
+}
+
+function standardNameArg(args: Record<string, unknown>): StandardName {
+  const value = stringArg(args, 'name');
+  if (!isStandardName(value)) {
+    throw new Error(
+      `Invalid argument 'name': ${describeValue(value)} is not a known standard (expected one of: ${STANDARD_NAMES.join(', ')})`,
+    );
+  }
+  return value;
+}
+
+function contractRepoArg(args: Record<string, unknown>): ContractRepo {
+  const value = stringArg(args, 'repo');
+  if (!isContractRepo(value)) {
+    throw new Error(
+      `Invalid argument 'repo': ${describeValue(value)} is not a known contract repo (expected one of: ${KNOWN_CONTRACT_REPOS.join(', ')})`,
+    );
+  }
+  return value;
+}
+
+function kindArg(args: Record<string, unknown>): 'template' | 'brief' | undefined {
+  const value = optionalStringArg(args, 'kind');
+  if (value === undefined || value === 'template' || value === 'brief') return value;
+  throw new Error(
+    `Invalid argument 'kind': ${describeValue(value)} (expected 'template' or 'brief')`,
+  );
+}
+
+/**
  * Pure helper exposed for tests. Dispatch a tool call to the right handler.
- * Returns the MCP tool-result shape (`{ content: [{ type, text }] }`).
+ * Unknown tools throw (a protocol error — the client called something the
+ * server never advertised). Everything a known tool does wrong — bad
+ * arguments, a missing template, an upstream fetch failure — comes back as
+ * an `isError: true` result so MCP clients handle it as a tool failure
+ * instead of a broken connection.
  */
 export async function callTool(
   source: CatalogSource,
   name: string,
   args: Record<string, unknown> = {},
-): Promise<{ content: { type: 'text'; text: string }[] }> {
+): Promise<ToolResult> {
+  try {
+    return await dispatchTool(source, name, args);
+  } catch (err) {
+    if (err instanceof UnknownToolError) throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    return { isError: true, content: [{ type: 'text', text: message }] };
+  }
+}
+
+async function dispatchTool(
+  source: CatalogSource,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
   switch (name) {
     case 'search_templates': {
+      const criteria = {
+        query: stringArg(args, 'query'),
+        category: optionalStringArg(args, 'category'),
+        persona: optionalStringArg(args, 'persona'),
+        kind: kindArg(args),
+      };
       const catalog = await loadCatalog(source);
-      const results = searchTemplates(catalog.templates, {
-        query: String(args.query ?? ''),
-        category: args.category as string | undefined,
-        persona: args.persona as string | undefined,
-        kind: args.kind as string | undefined,
-      });
+      const results = searchTemplates(catalog.templates, criteria);
       return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
     }
     case 'get_template': {
-      const { manifest } = await source.fetchTemplate(String(args.name));
+      const { manifest } = await source.fetchTemplate(catalogNameArg(args));
       return { content: [{ type: 'text', text: JSON.stringify(manifest, null, 2) }] };
     }
     case 'get_composite': {
-      const manifest = await source.fetchComposite(String(args.name));
+      const manifest = await source.fetchComposite(catalogNameArg(args));
       return { content: [{ type: 'text', text: JSON.stringify(manifest, null, 2) }] };
     }
     case 'list_standards': {
       return { content: [{ type: 'text', text: JSON.stringify(STANDARD_NAMES, null, 2) }] };
     }
     case 'get_standard': {
-      const standard = await loadStandard(source, args.name as StandardName);
+      const standard = await loadStandard(source, standardNameArg(args));
       return { content: [{ type: 'text', text: JSON.stringify(standard, null, 2) }] };
     }
     case 'get_contract': {
-      const repo = args.repo as ContractRepo;
-      const content = await source.fetchContract(repo);
+      const content = await source.fetchContract(contractRepoArg(args));
       return { content: [{ type: 'text', text: content }] };
     }
     default:
-      throw new Error(`Unknown tool: ${name}`);
+      throw new UnknownToolError(`Unknown tool: ${name}`);
   }
 }
 

--- a/sdk/__tests__/contracts.test.ts
+++ b/sdk/__tests__/contracts.test.ts
@@ -1,7 +1,12 @@
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { LocalSource } from '../src/sources/local.js';
-import { loadAllContracts, loadContract, KNOWN_CONTRACT_REPOS } from '../src/contracts.js';
+import {
+  isContractRepo,
+  loadAllContracts,
+  loadContract,
+  KNOWN_CONTRACT_REPOS,
+} from '../src/contracts.js';
 import { NanohypeError } from '../src/errors.js';
 import type { CatalogSource } from '../src/source.js';
 
@@ -82,5 +87,21 @@ describe('KNOWN_CONTRACT_REPOS', () => {
     expect(KNOWN_CONTRACT_REPOS).toContain('fab');
     expect(KNOWN_CONTRACT_REPOS).toContain('portal');
     expect(KNOWN_CONTRACT_REPOS).toContain('eks-fleet');
+  });
+});
+
+describe('isContractRepo', () => {
+  it('accepts every known contract repo', () => {
+    for (const repo of KNOWN_CONTRACT_REPOS) {
+      expect(isContractRepo(repo)).toBe(true);
+    }
+  });
+
+  it('rejects anything outside the known set', () => {
+    expect(isContractRepo('aks-gitops')).toBe(false);
+    expect(isContractRepo('../nanohype')).toBe(false);
+    expect(isContractRepo('nanohype/main/evil')).toBe(false);
+    expect(isContractRepo(42)).toBe(false);
+    expect(isContractRepo(undefined)).toBe(false);
   });
 });

--- a/sdk/__tests__/sources/github.test.ts
+++ b/sdk/__tests__/sources/github.test.ts
@@ -310,6 +310,56 @@ describe("GitHubSource", () => {
       );
     });
   });
+
+  describe('name shape guards', () => {
+    // Names are interpolated into request paths — a malformed one must be
+    // rejected before any request is issued.
+    it('rejects traversal in template names without fetching', async () => {
+      const source = new GitHubSource();
+      await expect(source.fetchTemplate('../evil')).rejects.toThrow('Invalid template name');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects path separators and URL metacharacters in template names', async () => {
+      const source = new GitHubSource();
+      await expect(source.fetchTemplate('a/b')).rejects.toThrow('Invalid template name');
+      await expect(source.fetchTemplate('name?ref=evil')).rejects.toThrow('Invalid template name');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects null bytes and empty template names', async () => {
+      const source = new GitHubSource();
+      await expect(source.fetchTemplate('go-cli\0evil')).rejects.toThrow('Invalid template name');
+      await expect(source.fetchTemplate('')).rejects.toThrow('Invalid template name');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed composite names without fetching', async () => {
+      const source = new GitHubSource();
+      await expect(source.fetchComposite('../../secrets')).rejects.toThrow(
+        'Invalid composite name',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects standards outside the published set without fetching', async () => {
+      const source = new GitHubSource();
+      await expect(
+        source.fetchStandard('../package' as Parameters<typeof source.fetchStandard>[0]),
+      ).rejects.toThrow('Unknown standard');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects contract repos outside the known set without fetching', async () => {
+      const source = new GitHubSource();
+      await expect(
+        source.fetchContract(
+          'nanohype/main/evil' as Parameters<typeof source.fetchContract>[0],
+        ),
+      ).rejects.toThrow('Unknown contract repo');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("GitHubSource.fetchContract", () => {

--- a/sdk/__tests__/sources/local.test.ts
+++ b/sdk/__tests__/sources/local.test.ts
@@ -55,6 +55,40 @@ describe('LocalSource', () => {
     });
   });
 
+  describe('path containment', () => {
+    it('rejects template names that traverse out of templates/', async () => {
+      await expect(source.fetchTemplate('../sdk')).rejects.toThrow(/escapes/);
+    });
+
+    it('rejects template names that traverse to a sibling catalog directory', async () => {
+      await expect(source.fetchTemplate('../composites')).rejects.toThrow(/escapes/);
+    });
+
+    it('rejects absolute template names', async () => {
+      await expect(source.fetchTemplate('/etc/passwd')).rejects.toThrow(/escapes/);
+    });
+
+    it('rejects template names containing null bytes', async () => {
+      await expect(source.fetchTemplate('go-cli\0evil')).rejects.toThrow(/null byte/);
+    });
+
+    it('rejects composite names that traverse out of composites/', async () => {
+      await expect(source.fetchComposite('../../outside/secret')).rejects.toThrow(/escapes/);
+    });
+
+    it('rejects standard names that traverse out of standards/', async () => {
+      await expect(
+        source.fetchStandard('../package' as Parameters<typeof source.fetchStandard>[0]),
+      ).rejects.toThrow(/escapes/);
+    });
+
+    it('rejects contract repo names that traverse out of the workspace parent', async () => {
+      await expect(
+        source.fetchContract('../../etc' as Parameters<typeof source.fetchContract>[0]),
+      ).rejects.toThrow(/escapes/);
+    });
+  });
+
   describe('listComposites', () => {
     it('discovers composites from the real catalog', async () => {
       const entries = await source.listComposites();

--- a/sdk/__tests__/standards.test.ts
+++ b/sdk/__tests__/standards.test.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { LocalSource } from '../src/sources/local.js';
-import { loadStandard, loadStandards } from '../src/standards.js';
+import { isStandardName, loadStandard, loadStandards, STANDARD_NAMES } from '../src/standards.js';
 import { NanohypeError } from '../src/errors.js';
 import type { Standards } from '../src/types.js';
 
@@ -107,5 +107,20 @@ describe('loadStandards (bundle)', () => {
     );
     expect(bundle['testing-rubric'].kind).toBe('nanohype/standards/testing-rubric');
     expect(bundle['observability-slo'].kind).toBe('nanohype/standards/observability-slo');
+  });
+});
+
+describe('isStandardName', () => {
+  it('accepts every published standard name', () => {
+    for (const name of STANDARD_NAMES) {
+      expect(isStandardName(name)).toBe(true);
+    }
+  });
+
+  it('rejects anything outside the published set', () => {
+    expect(isStandardName('bogus')).toBe(false);
+    expect(isStandardName('../package')).toBe(false);
+    expect(isStandardName(42)).toBe(false);
+    expect(isStandardName(undefined)).toBe(false);
   });
 });

--- a/sdk/__tests__/validator.test.ts
+++ b/sdk/__tests__/validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { validateManifest, validateCompositeManifest } from '../src/validator.js';
+import { isCatalogName, validateManifest, validateCompositeManifest } from '../src/validator.js';
 import type { TemplateManifest, CompositeManifest } from '../src/types.js';
 
 function minimalManifest(overrides?: Partial<TemplateManifest>): TemplateManifest {
@@ -286,5 +286,30 @@ describe('validateCompositeManifest', () => {
       templates: [],
     };
     expect(() => validateCompositeManifest(manifest)).toThrow("Expected kind 'composite'");
+  });
+});
+
+describe('isCatalogName', () => {
+  it('accepts kebab-case catalog names', () => {
+    expect(isCatalogName('go-cli')).toBe(true);
+    expect(isCatalogName('module-auth-ts')).toBe(true);
+    expect(isCatalogName('a2a-agent')).toBe(true);
+  });
+
+  it('rejects traversal, separators, and metacharacters', () => {
+    expect(isCatalogName('../evil')).toBe(false);
+    expect(isCatalogName('a/b')).toBe(false);
+    expect(isCatalogName('/etc/passwd')).toBe(false);
+    expect(isCatalogName('name?ref=evil')).toBe(false);
+    expect(isCatalogName('go-cli\0')).toBe(false);
+  });
+
+  it('rejects empty strings, leading digits/dashes, uppercase, and non-strings', () => {
+    expect(isCatalogName('')).toBe(false);
+    expect(isCatalogName('1template')).toBe(false);
+    expect(isCatalogName('-template')).toBe(false);
+    expect(isCatalogName('Go-Cli')).toBe(false);
+    expect(isCatalogName(42)).toBe(false);
+    expect(isCatalogName(undefined)).toBe(false);
   });
 });

--- a/sdk/src/contracts.ts
+++ b/sdk/src/contracts.ts
@@ -57,5 +57,10 @@ export async function loadAllContracts(source: CatalogSource): Promise<Contract[
 /** The canonical list of supporting repos that ship an AGENTS.md (names only). */
 export const KNOWN_CONTRACT_REPOS: readonly ContractRepo[] = ALL_REPOS.map((r) => r.repo);
 
+/** True when `value` names a known contract repo. */
+export function isContractRepo(value: unknown): value is ContractRepo {
+  return typeof value === 'string' && ALL_REPOS.some((r) => r.repo === value);
+}
+
 /** The contract repos with their visibility — for callers that label or gate on it. */
 export const CONTRACT_REPOS: readonly ContractRepoInfo[] = ALL_REPOS;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -49,12 +49,23 @@ export {
 } from './errors.js';
 
 // Functions
-export { validateManifest, validateCompositeManifest } from './validator.js';
+export {
+  CATALOG_NAME_PATTERN,
+  isCatalogName,
+  validateManifest,
+  validateCompositeManifest,
+} from './validator.js';
 export { resolveVariables } from './resolver.js';
 export { renderTemplate } from './renderer.js';
 export { renderComposite } from './composite.js';
 
 // Platform Reference loaders
 export { loadCatalog } from './catalog.js';
-export { loadStandard, loadStandards, STANDARD_NAMES } from './standards.js';
-export { loadContract, loadAllContracts, KNOWN_CONTRACT_REPOS, CONTRACT_REPOS } from './contracts.js';
+export { isStandardName, loadStandard, loadStandards, STANDARD_NAMES } from './standards.js';
+export {
+  isContractRepo,
+  loadContract,
+  loadAllContracts,
+  KNOWN_CONTRACT_REPOS,
+  CONTRACT_REPOS,
+} from './contracts.js';

--- a/sdk/src/sources/github.ts
+++ b/sdk/src/sources/github.ts
@@ -12,6 +12,9 @@ import type {
 } from "../types.js";
 import type { CatalogSource, GitHubSourceOptions } from "../source.js";
 import { NanohypeError } from "../errors.js";
+import { isContractRepo } from "../contracts.js";
+import { isStandardName } from "../standards.js";
+import { isCatalogName } from "../validator.js";
 
 interface CacheEntry<T> {
   data: T;
@@ -162,6 +165,12 @@ export class GitHubSource implements CatalogSource {
   async fetchTemplate(
     name: string,
   ): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }> {
+    // `name` is interpolated into request paths — reject anything that isn't
+    // a well-formed catalog name before it can reshape the URL.
+    if (!isCatalogName(name)) {
+      throw new NanohypeError(`Invalid template name: ${JSON.stringify(name)}`);
+    }
+
     // Fetch manifest
     const manifestRes = await this.get(
       this.raw(`templates/${name}/template.yaml`),
@@ -271,6 +280,11 @@ export class GitHubSource implements CatalogSource {
   }
 
   async fetchComposite(name: string): Promise<CompositeManifest> {
+    if (!isCatalogName(name)) {
+      throw new NanohypeError(
+        `Invalid composite name: ${JSON.stringify(name)}`,
+      );
+    }
     const res = await this.get(this.raw(`composites/${name}.yaml`));
     if (!res.ok)
       throw new NanohypeError(`Composite '${name}' not found: ${res.status}`);
@@ -296,6 +310,10 @@ export class GitHubSource implements CatalogSource {
   }
 
   async fetchStandard(name: StandardName): Promise<Standard> {
+    // Typed as StandardName, but callers cast LLM-supplied strings — hold the line at runtime.
+    if (!isStandardName(name)) {
+      throw new NanohypeError(`Unknown standard: ${JSON.stringify(name)}`);
+    }
     const res = await this.get(this.raw(`standards/${name}.json`));
     if (!res.ok)
       throw new NanohypeError(`Standard '${name}' not found: ${res.status}`);
@@ -303,6 +321,12 @@ export class GitHubSource implements CatalogSource {
   }
 
   async fetchContract(repo: ContractRepo): Promise<string> {
+    // Typed as ContractRepo, but callers cast LLM-supplied strings — a raw
+    // value like `x/main/evil?` would otherwise reshape the request path.
+    if (!isContractRepo(repo)) {
+      throw new NanohypeError(`Unknown contract repo: ${JSON.stringify(repo)}`);
+    }
+
     // The nanohype repo's AGENTS.md lives in `this.repo`; each other repo
     // is a sibling under the same GitHub org (`<org>/<repo>`). When the
     // configured `this.repo` is `<org>/nanohype` we resolve siblings as

--- a/sdk/src/sources/local.ts
+++ b/sdk/src/sources/local.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import yaml from 'js-yaml';
 import type {
   Catalog,
@@ -25,6 +25,26 @@ export class LocalSource implements CatalogSource {
 
   constructor(options: LocalSourceOptions) {
     this.rootDir = options.rootDir;
+  }
+
+  /**
+   * Resolve caller-influenced path segments against a base directory and
+   * assert the result stays inside it. Names ultimately arrive from LLM
+   * tool arguments, so a crafted `../`, absolute, or null-byte segment
+   * must never resolve to a file outside the catalog tree.
+   */
+  private resolveWithin(baseDir: string, ...segments: string[]): string {
+    for (const segment of segments) {
+      if (segment.includes('\0')) {
+        throw new NanohypeError(`Invalid path segment: contains a null byte`);
+      }
+    }
+    const base = resolve(baseDir);
+    const resolved = resolve(base, ...segments);
+    if (resolved !== base && !resolved.startsWith(base + sep)) {
+      throw new NanohypeError(`Path '${segments.join('/')}' escapes '${base}'`);
+    }
+    return resolved;
   }
 
   async listTemplates(): Promise<CatalogEntry[]> {
@@ -63,7 +83,7 @@ export class LocalSource implements CatalogSource {
   async fetchTemplate(
     name: string,
   ): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }> {
-    const templateDir = join(this.rootDir, 'templates', name);
+    const templateDir = this.resolveWithin(join(this.rootDir, 'templates'), name);
     const manifestPath = join(templateDir, 'template.yaml');
 
     let manifestText: string;
@@ -117,7 +137,7 @@ export class LocalSource implements CatalogSource {
   }
 
   async fetchComposite(name: string): Promise<CompositeManifest> {
-    const compositePath = join(this.rootDir, 'composites', `${name}.yaml`);
+    const compositePath = this.resolveWithin(join(this.rootDir, 'composites'), `${name}.yaml`);
 
     let text: string;
     try {
@@ -149,7 +169,7 @@ export class LocalSource implements CatalogSource {
   }
 
   async fetchStandard(name: StandardName): Promise<Standard> {
-    const path = join(this.rootDir, 'standards', `${name}.json`);
+    const path = this.resolveWithin(join(this.rootDir, 'standards'), `${name}.json`);
     let text: string;
     try {
       text = await readFile(path, 'utf-8');
@@ -163,11 +183,12 @@ export class LocalSource implements CatalogSource {
     // `rootDir` points at the nanohype repo; sibling repos live alongside it
     // in the same parent (the local workspace mirrors the github org layout).
     // For the `nanohype` repo itself the AGENTS.md is at rootDir/AGENTS.md;
-    // for the others it's at ../<repo>/AGENTS.md.
+    // for the others it's at ../<repo>/AGENTS.md — contained to the workspace
+    // parent so a crafted `repo` can't walk to arbitrary AGENTS.md files.
     const path =
       repo === 'nanohype'
         ? join(this.rootDir, 'AGENTS.md')
-        : resolve(dirname(this.rootDir), repo, 'AGENTS.md');
+        : this.resolveWithin(dirname(resolve(this.rootDir)), repo, 'AGENTS.md');
     try {
       return await readFile(path, 'utf-8');
     } catch {

--- a/sdk/src/standards.ts
+++ b/sdk/src/standards.ts
@@ -28,6 +28,11 @@ const ALL_STANDARDS: StandardName[] = [
 /** The canonical list of published standards file names. */
 export const STANDARD_NAMES: readonly StandardName[] = ALL_STANDARDS;
 
+/** True when `value` names a published standard. */
+export function isStandardName(value: unknown): value is StandardName {
+  return typeof value === 'string' && (STANDARD_NAMES as readonly string[]).includes(value);
+}
+
 const EXPECTED_KIND: Record<StandardName, Standard['kind']> = {
   'language-toolchain': 'nanohype/standards/language-toolchain',
   'version-currency': 'nanohype/standards/version-currency',

--- a/sdk/src/validator.ts
+++ b/sdk/src/validator.ts
@@ -3,6 +3,20 @@ import { ManifestValidationError } from './errors.js';
 import type { CompositeManifest, TemplateManifest } from './types.js';
 
 /**
+ * The kebab-case shape every catalog entry name (template or composite)
+ * must satisfy — the same pattern `schemas/template.schema.json` and the
+ * template contract enforce on `name`. Sources interpolate these names
+ * into filesystem paths and request URLs, so the shape check doubles as
+ * an injection guard: it admits no `/`, `.`, null bytes, or uppercase.
+ */
+export const CATALOG_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/** True when `value` is a well-formed kebab-case catalog (template/composite) name. */
+export function isCatalogName(value: unknown): value is string {
+  return typeof value === 'string' && CATALOG_NAME_PATTERN.test(value);
+}
+
+/**
  * Validate a template manifest's structural invariants.
  * Throws ManifestValidationError on the first violation found.
  */


### PR DESCRIPTION
See commit messages for full details.

## Summary
- Every MCP tool argument is runtime-validated at the boundary: catalog-name pattern for template/composite names, closed sets for standards + contract repos; resource URIs validated too
- SDK defense in depth: LocalSource containment (resolve + prefix check, null-byte reject) per subdir; GitHubSource shape-validates names before any URL is built
- Tool-level failures return isError results per MCP spec; unknown tool stays a protocol error
- sdk 130 tests, mcp-server 50 tests, verify:catalog + verify:library green