### PR TITLE
Catalog currency + library/runtime: one source of truth for fleet primitives

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -1,0 +1,39 @@
+name: Runtime Library
+
+on:
+  push:
+    branches: [main]
+    paths: ['library/runtime/**']
+  pull_request:
+    paths: ['library/runtime/**']
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck-and-test:
+    name: Typecheck and test runtime library
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: library/runtime
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: library/runtime/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/library/runtime/README.md
+++ b/library/runtime/README.md
@@ -1,0 +1,67 @@
+# @nanohype/runtime
+
+Zero-dependency TypeScript runtime primitives, maintained here as the single
+source of truth and **vendored** into consumers — the same consumption model
+as the `tenant-chart-base` library chart.
+
+## Modules
+
+| Module | What it is |
+| --- | --- |
+| `src/circuit-breaker.ts` | Pure, timer-less sliding-window circuit breaker with an injectable `now()` clock, single half-open probe, `onOpen` trip hook, and operator `reset()` |
+| `src/resilience.ts` | `withTimeout` (deadline race → `TimeoutError`) and `withRetry` (jittered exponential backoff, injectable sleep) |
+| `src/registry.ts` | `createRegistry<T>` — the provider-registry convention for pluggable seams (LLM, embeddings, vector stores, aggregators) |
+| `src/workos-directory.ts` | Typed WorkOS Directory Sync client: port-injected `fetch`, bounded cursor pagination, find-by-email / custom-attribute / group / created-since |
+| `src/pii.ts` | PII redaction over the union category set: secrets and tokens, SSN and cards, compensation, HR cases, health, DOB, contact info, AWS accounts, customer and infrastructure identifiers |
+
+Every module is dependency-free (native `fetch` types only) and side-effect
+free at import time. Observability is deliberately left to the consumer: the
+breaker exposes `onOpen`, the redactor returns structured findings — wire
+them into whatever logger and metrics surface the consuming app has.
+
+## Consumption model: vendor and sync
+
+Consumers do not install this as a package. They **copy the module files they
+need** into their own source tree (tests optionally alongside), because
+standalone templates and tenant apps must stay self-contained — there is no
+shared package registry between them at runtime.
+
+The contract, mirroring `tenant-chart-base`:
+
+1. **This directory is the single source of truth.** Behavior changes land
+   here first, with their tests.
+2. **Copies are byte-identical to their source module.** A vendored copy
+   carries the module header intact so its provenance is greppable.
+3. **Fixes propagate outward, never inward.** If a bug is found in a vendored
+   copy, fix it here and re-copy — a copy that drifts from the source is the
+   defect, exactly as `scripts/sync-library.mjs --check` treats a drifted
+   chart copy.
+
+When in-repo templates adopt these modules, extend `scripts/sync-library.mjs`
+so CI enforces the copies the same way it enforces the vendored chart.
+
+## Development
+
+```sh
+cd library/runtime
+npm install
+npm run typecheck    # tsc --noEmit, strict + exactOptionalPropertyTypes
+npm test             # vitest — full coverage colocated per module (src/*.test.ts)
+```
+
+## Design notes
+
+- **Breaker semantics.** Sliding-window failure accounting was chosen over
+  consecutive-counter and timer-driven designs: old failures decay naturally,
+  no timers are held, and every time read goes through the injected `now()`
+  so tests tick a fake clock synchronously. See the header of
+  `src/circuit-breaker.ts`.
+- **PII catalog.** Patterns are ordered most-specific first, replacements are
+  typed per label (`[JWT]`, `[SSN]`, `[COMPENSATION]`, …), and non-dashed
+  9-digit SSNs are deliberately not matched — the false-positive rate against
+  legitimate account numbers is unacceptable for a raw regex. See the header
+  of `src/pii.ts`.
+- **WorkOS pagination.** `/directory_users` does not support server-side
+  filtering by email or custom attribute, so the finders paginate and scan
+  client-side, bounded at `maxPages` (default 50). Caching is the caller's
+  concern — fleet consumers front the client with their own TTL caches.

--- a/library/runtime/package-lock.json
+++ b/library/runtime/package-lock.json
@@ -1,0 +1,1331 @@
+{
+  "name": "@nanohype/runtime",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nanohype/runtime",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^24.13.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/library/runtime/package.json
+++ b/library/runtime/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@nanohype/runtime",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Zero-dependency TypeScript runtime primitives — the vendorable source of truth for circuit breaking, resilience, provider registries, WorkOS Directory access, and PII redaction",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/library/runtime/src/circuit-breaker.test.ts
+++ b/library/runtime/src/circuit-breaker.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from "vitest";
+import { createCircuitBreaker, CircuitOpenError } from "./circuit-breaker.js";
+
+/** Synchronous fake clock — the breaker reads time only through `now()`. */
+function makeClock(start = 1_000) {
+  let t = start;
+  return {
+    now: () => t,
+    tick: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+const fail = () => Promise.reject(new Error("boom"));
+const ok = () => Promise.resolve("ok");
+
+const baseConfig = { name: "test", failureThreshold: 3, windowMs: 60_000, halfOpenAfterMs: 30_000 };
+
+describe("circuit breaker", () => {
+  it("passes results through while closed", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, now: clock.now });
+
+    await expect(cb.exec(ok)).resolves.toBe("ok");
+    expect(cb.state()).toBe("closed");
+  });
+
+  it("opens after failureThreshold failures within the window", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, now: clock.now });
+
+    for (let i = 0; i < 3; i++) {
+      await expect(cb.exec(fail)).rejects.toThrow("boom");
+    }
+    expect(cb.state()).toBe("open");
+  });
+
+  it("fast-fails with CircuitOpenError while open, without invoking the function", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
+
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("open");
+
+    const probe = vi.fn(ok);
+    await expect(cb.exec(probe)).rejects.toBeInstanceOf(CircuitOpenError);
+    await expect(cb.exec(probe)).rejects.toThrow("circuit open: test");
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("decays failures that age out of the sliding window", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, now: clock.now });
+
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("closed");
+
+    // Age the first two failures out of the window.
+    clock.tick(61_000);
+
+    // Two more failures — only 2 in the current window, still under threshold.
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("closed");
+
+    // Third within the window trips it.
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("open");
+  });
+
+  it("allows a half-open probe after the cooldown; success closes and clears the window", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
+
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("open");
+
+    clock.tick(30_000);
+    await expect(cb.exec(ok)).resolves.toBe("ok");
+    expect(cb.state()).toBe("closed");
+
+    // Window was cleared — a single new failure trips again only because
+    // threshold is 1; with a higher threshold the slate is clean.
+    const cb2 = createCircuitBreaker({ ...baseConfig, now: clock.now });
+    for (let i = 0; i < 3; i++) await expect(cb2.exec(fail)).rejects.toThrow("boom");
+    clock.tick(30_000);
+    await expect(cb2.exec(ok)).resolves.toBe("ok");
+    await expect(cb2.exec(fail)).rejects.toThrow("boom");
+    await expect(cb2.exec(fail)).rejects.toThrow("boom");
+    expect(cb2.state()).toBe("closed"); // 2 of 3 — clean slate after recovery
+  });
+
+  it("re-opens with a fresh openedAt when the probe fails", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
+
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    clock.tick(30_000);
+
+    // Probe fails — straight back to open.
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("open");
+
+    // The cooldown restarted: half the cooldown later it is still open.
+    clock.tick(15_000);
+    await expect(cb.exec(ok)).rejects.toBeInstanceOf(CircuitOpenError);
+
+    // Full cooldown elapsed — probe allowed again.
+    clock.tick(15_000);
+    await expect(cb.exec(ok)).resolves.toBe("ok");
+    expect(cb.state()).toBe("closed");
+  });
+
+  it("rejects concurrent calls while a half-open probe is in flight", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
+
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    clock.tick(30_000);
+
+    let release!: (v: string) => void;
+    const gate = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+
+    const probe = cb.exec(() => gate);
+    await expect(cb.exec(ok)).rejects.toBeInstanceOf(CircuitOpenError);
+
+    release("recovered");
+    await expect(probe).resolves.toBe("recovered");
+    expect(cb.state()).toBe("closed");
+  });
+
+  it("fires onOpen exactly once per closed→open transition", async () => {
+    const clock = makeClock();
+    const onOpen = vi.fn();
+    const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now, onOpen });
+
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith("test");
+
+    // Rejections while already open do not re-fire.
+    await expect(cb.exec(ok)).rejects.toBeInstanceOf(CircuitOpenError);
+    await expect(cb.exec(ok)).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    // A failed probe is a fresh trip.
+    clock.tick(30_000);
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  it("reset() force-closes and clears failure history", async () => {
+    const clock = makeClock();
+    const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
+
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("open");
+
+    cb.reset();
+    expect(cb.state()).toBe("closed");
+    await expect(cb.exec(ok)).resolves.toBe("ok");
+  });
+
+  it("defaults to Date.now when no clock is injected", async () => {
+    const cb = createCircuitBreaker({ name: "wall-clock", failureThreshold: 1, windowMs: 60_000, halfOpenAfterMs: 30_000 });
+    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    expect(cb.state()).toBe("open");
+  });
+});

--- a/library/runtime/src/circuit-breaker.ts
+++ b/library/runtime/src/circuit-breaker.ts
@@ -1,0 +1,147 @@
+/**
+ * Circuit breaker for external-IO calls.
+ *
+ * Design choice: of the three breaker semantics in the fleet —
+ * consecutive-failure counter, timer-driven window, and sliding-window —
+ * this module adopts the sliding-window design because it is the most
+ * accurate account of downstream health (old failures decay naturally
+ * instead of counting forever or resetting on a single success) and the
+ * only one that is fully deterministic in tests: it holds no timers and
+ * reads time exclusively through the injected `now()`, so a test ticks a
+ * fake clock synchronously instead of racing the wall clock.
+ *
+ * State machine: closed → open → half_open → closed.
+ *
+ * - closed: calls pass through; each failure is stamped with `now()` and
+ *   pruned from the log once it falls outside `windowMs`. When the count
+ *   within the window reaches `failureThreshold`, the breaker opens.
+ * - open: calls fail fast with `CircuitOpenError` until a cooldown of
+ *   `halfOpenAfterMs` elapses.
+ * - half_open: exactly ONE probe at a time — success closes the breaker
+ *   and clears the window; failure (or a concurrent call while the probe
+ *   is in flight) goes straight back to open with a fresh `openedAt`.
+ *
+ * `onOpen` fires once per closed→open transition (not on every rejection
+ * while already open), so a counter wired here matches the number of
+ * trips, not the blast radius. `reset()` is an operator override that
+ * force-closes and clears failure history.
+ *
+ * Zero dependencies. Observability is the caller's concern — wire
+ * `onOpen` into whatever metrics surface the consumer has.
+ */
+
+export type CircuitState = "closed" | "open" | "half_open";
+
+export class CircuitOpenError extends Error {
+  constructor(name: string) {
+    super(`circuit open: ${name}`);
+    this.name = "CircuitOpenError";
+  }
+}
+
+export interface CircuitBreaker {
+  exec<T>(fn: () => Promise<T>): Promise<T>;
+  state(): CircuitState;
+  /** Force-close (operator override). Clears failure history. */
+  reset(): void;
+}
+
+export interface CircuitBreakerConfig {
+  /** Identifier used in errors and the `onOpen` callback. */
+  name: string;
+  /** Failures within `windowMs` to trip the breaker (closed → open). */
+  failureThreshold: number;
+  /** Rolling-window size for failure accounting, in ms. */
+  windowMs: number;
+  /** Cooldown after opening before a single half-open probe is allowed, in ms. */
+  halfOpenAfterMs: number;
+  /** Clock override. Defaults to `Date.now`. Tests inject a fake clock. */
+  now?: () => number;
+  /** Emitted once per closed→open transition. */
+  onOpen?: (name: string) => void;
+}
+
+export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker {
+  const now = cfg.now ?? (() => Date.now());
+
+  let state: CircuitState = "closed";
+  let failures: number[] = [];
+  let openedAt = 0;
+  let halfOpenInFlight = false;
+
+  function pruneFailures(t: number): void {
+    const cutoff = t - cfg.windowMs;
+    if (failures.length === 0) return;
+    if (failures[0] >= cutoff) return;
+    failures = failures.filter((ts) => ts >= cutoff);
+  }
+
+  function tripOpen(t: number): void {
+    state = "open";
+    openedAt = t;
+    failures = [];
+    cfg.onOpen?.(cfg.name);
+  }
+
+  function maybeEnterHalfOpen(t: number): void {
+    if (state !== "open") return;
+    if (t - openedAt >= cfg.halfOpenAfterMs) {
+      state = "half_open";
+      halfOpenInFlight = false;
+    }
+  }
+
+  return {
+    state: () => state,
+
+    reset(): void {
+      state = "closed";
+      failures = [];
+      halfOpenInFlight = false;
+    },
+
+    async exec<T>(fn: () => Promise<T>): Promise<T> {
+      const t = now();
+
+      if (state === "open") {
+        maybeEnterHalfOpen(t);
+        if (state === "open") {
+          throw new CircuitOpenError(cfg.name);
+        }
+      }
+
+      if (state === "half_open") {
+        if (halfOpenInFlight) {
+          // Only one probe at a time — reject fast so we don't pile on the
+          // downstream while waiting for the canary to resolve.
+          throw new CircuitOpenError(cfg.name);
+        }
+        halfOpenInFlight = true;
+        try {
+          const result = await fn();
+          state = "closed";
+          failures = [];
+          halfOpenInFlight = false;
+          return result;
+        } catch (err) {
+          halfOpenInFlight = false;
+          tripOpen(now());
+          throw err;
+        }
+      }
+
+      // closed
+      try {
+        return await fn();
+      } catch (err) {
+        const failedAt = now();
+        pruneFailures(failedAt);
+        failures.push(failedAt);
+        if (failures.length >= cfg.failureThreshold) {
+          tripOpen(failedAt);
+        }
+        throw err;
+      }
+    },
+  };
+}

--- a/library/runtime/src/pii.test.ts
+++ b/library/runtime/src/pii.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from "vitest";
+import { redact, scan, assertNoPii, PiiDetectedError, REDACTION_PATTERNS } from "./pii.js";
+
+describe("secrets", () => {
+  it("redacts JWTs", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    expect(redact(`token ${jwt} leaked`)).toBe("token [JWT] leaked");
+  });
+
+  it("redacts AWS access key ids (AKIA and ASIA)", () => {
+    expect(redact("key AKIAIOSFODNN7EXAMPLE in logs")).toBe("key [AWS_KEY] in logs");
+    expect(redact("sts key ASIAIOSFODNN7EXAMPLE")).toBe("sts key [AWS_KEY]");
+  });
+
+  it("redacts GitHub PATs", () => {
+    expect(redact("ghp_abcdefghijklmnopqrstuvwxyz0123456789")).toBe("[GITHUB_PAT]");
+  });
+
+  it("redacts Slack tokens", () => {
+    expect(redact("xoxb-123456789012-abcdefGHIJKL")).toBe("[SLACK_TOKEN]");
+  });
+
+  it("redacts generic API keys (sk-, pk_live_, Bearer)", () => {
+    expect(redact("sk-abcdefghijklmnopqrstuvwxyz")).toBe("[API_KEY]");
+    expect(redact("pk_live_abcdefghijklmnopqrst")).toBe("[API_KEY]");
+    expect(redact("Authorization: Bearer abcdefghijklmnopqrstuv")).toBe("Authorization: [API_KEY]");
+  });
+});
+
+describe("financial identifiers", () => {
+  it("redacts dashed SSNs", () => {
+    expect(redact("ssn 123-45-6789 on file")).toBe("ssn [SSN] on file");
+  });
+
+  it("does NOT redact non-dashed 9-digit runs (deliberate false-positive guard)", () => {
+    expect(redact("order 123456789 shipped")).toBe("order 123456789 shipped");
+  });
+
+  it("redacts scheme-valid card numbers", () => {
+    expect(redact("visa 4111111111111111")).toBe("visa [PAYMENT]");
+    expect(redact("mc 5500005555555559")).toBe("mc [PAYMENT]");
+    expect(redact("amex 340000000000009")).toBe("amex [PAYMENT]");
+  });
+
+  it("redacts separator-grouped card numbers", () => {
+    expect(redact("card 4111 1111 1111 1111 charged")).toBe("card [PAYMENT] charged");
+    expect(redact("card 4111-1111-1111-1111 charged")).toBe("card [PAYMENT] charged");
+  });
+});
+
+describe("compensation", () => {
+  it("redacts currency amounts adjacent to comp keywords (both orders)", () => {
+    expect(redact("her $150,000 base")).toContain("[COMPENSATION]");
+    expect(redact("salary of £80,000 agreed")).toContain("[COMPENSATION]");
+    expect(redact("€90k bonus this year")).toContain("[COMPENSATION]");
+  });
+
+  it("redacts bare-number amounts adjacent to comp keywords", () => {
+    expect(redact("base 95k for the role")).toContain("[COMPENSATION]");
+    expect(redact("bonus 12000 approved")).toContain("[COMPENSATION]");
+  });
+
+  it("redacts annual-cadence amounts regardless of keyword", () => {
+    expect(redact("she makes 120k annually")).toContain("[COMPENSATION]");
+    expect(redact("£80,000 per year offer")).toContain("[COMPENSATION]");
+  });
+
+  it("redacts comp phrases", () => {
+    expect(redact("discussed total comp at the offsite")).toContain("[COMPENSATION]");
+  });
+});
+
+describe("performance / HR", () => {
+  it("redacts PIP mentions (uppercase only)", () => {
+    expect(redact("moved to a PIP last month")).toBe("moved to a [HR] last month");
+    expect(redact("pipeline pip install")).toBe("pipeline pip install");
+  });
+
+  it("redacts performance-process phrases", () => {
+    expect(redact("on a performance improvement plan")).toContain("[HR]");
+    expect(redact("pending disciplinary action")).toContain("[HR]");
+    expect(redact("issued a written warning")).toContain("[HR]");
+    expect(redact("sent the termination notice")).toContain("[HR]");
+    expect(redact("performance corrective steps")).toContain("[HR]");
+  });
+
+  it("redacts HR case, case-number, and ticket identifiers", () => {
+    expect(redact("see HR-4821 for details")).toBe("see [HR_CASE] for details");
+    expect(redact("escalated case #1234")).toBe("escalated [HR_CASE]");
+    expect(redact("tracked in ticket #ABC123")).toBe("tracked in [HR_CASE]");
+  });
+});
+
+describe("health", () => {
+  it("redacts strong standalone signals", () => {
+    expect(redact("approved FMLA request")).toBe("approved [HEALTH] request");
+    expect(redact("she was diagnosed recently")).toBe("she was [HEALTH] recently");
+  });
+
+  it("redacts medical/health phrases", () => {
+    expect(redact("out on medical leave")).toContain("[HEALTH]");
+    expect(redact("a mental health day")).toContain("[HEALTH]");
+    expect(redact("ongoing health condition")).toContain("[HEALTH]");
+    expect(redact("short-term disability paperwork")).toContain("[HEALTH]");
+    expect(redact("disability accommodation approved")).toContain("[HEALTH]");
+    expect(redact("accommodation request filed")).toContain("[HEALTH]");
+    expect(redact("on parental leave until June")).toContain("[HEALTH]");
+    expect(redact("took a leave of absence")).toContain("[HEALTH]");
+    expect(redact("workers comp claim filed")).toContain("[HEALTH]");
+    expect(redact("in therapy for burnout")).toContain("[HEALTH]");
+  });
+
+  it("leaves benign words alone", () => {
+    expect(redact("the health of the service improved")).toBe("the health of the service improved");
+    expect(redact("please leave feedback")).toBe("please leave feedback");
+  });
+});
+
+describe("date of birth", () => {
+  it("redacts labeled DOB values", () => {
+    expect(redact("DOB: 01/02/1990")).toBe("[DOB]");
+    expect(redact("date of birth 1-2-90 confirmed")).toBe("[DOB] confirmed");
+    expect(redact("born on 12/31/1985")).toBe("[DOB]");
+  });
+
+  it("leaves unlabeled dates alone", () => {
+    expect(redact("shipped on 01/02/2026")).toBe("shipped on 01/02/2026");
+  });
+});
+
+describe("contact info", () => {
+  it("redacts emails", () => {
+    expect(redact("ping alice@example.com please")).toBe("ping [EMAIL] please");
+  });
+
+  it("redacts US phone numbers", () => {
+    expect(redact("call 415-555-1234 now")).toBe("call [PHONE] now");
+    expect(redact("call (415) 555-1234 now")).toBe("call ([PHONE] now");
+  });
+
+  it("redacts international phone numbers", () => {
+    expect(redact("mobile +44 20 7946 0958")).toBe("mobile [PHONE]");
+    expect(redact("or +919876543210")).toBe("or [PHONE]");
+  });
+
+  it("redacts street addresses", () => {
+    expect(redact("lives at 742 Evergreen Way")).toBe("lives at [ADDRESS]");
+  });
+});
+
+describe("aws account ids", () => {
+  it("redacts 12-digit runs followed by aws/account context", () => {
+    expect(redact("123456789012 aws")).toBe("[AWS_ACCOUNT] aws");
+    expect(redact("in 123456789012 account")).toBe("in [AWS_ACCOUNT] account");
+  });
+
+  it("leaves context-free 12-digit runs alone", () => {
+    expect(redact("tracking 123456789012 arrived")).toBe("tracking 123456789012 arrived");
+  });
+});
+
+describe("customer / infrastructure identifiers", () => {
+  it("redacts customer ids", () => {
+    expect(redact("affects cust-99231 only")).toBe("affects [CUSTOMER_ID] only");
+  });
+
+  it("redacts account-id fields", () => {
+    expect(redact("account_id:ac-4451 flagged")).toBe("[ACCOUNT_ID] flagged");
+    expect(redact("account-id=xyz9")).toBe("[ACCOUNT_ID]");
+  });
+
+  it("redacts RFC1918 addresses and leaves public ones", () => {
+    expect(redact("pod at 10.0.12.5 crashed")).toBe("pod at [INTERNAL_IP] crashed");
+    expect(redact("node 172.20.1.9 drained")).toBe("node [INTERNAL_IP] drained");
+    expect(redact("gw 192.168.1.1 up")).toBe("gw [INTERNAL_IP] up");
+    expect(redact("resolver 8.8.8.8 fine")).toBe("resolver 8.8.8.8 fine");
+    expect(redact("host 172.15.0.1 is public")).toBe("host 172.15.0.1 is public");
+  });
+
+  it("redacts prod hostnames and db identifiers", () => {
+    expect(redact("on prod-api-7.internal now")).toBe("on [INTERNAL_HOST] now");
+    expect(redact("failing over db-orders-primary")).toBe("failing over [INTERNAL_HOST]");
+  });
+});
+
+describe("redact", () => {
+  it("handles mixed text in one pass", () => {
+    const input =
+      "IC update: cust-441 (contact bob@example.com, +1 415-555-0100) hit by db-users-3 at 10.1.2.3; " +
+      "key AKIAIOSFODNN7EXAMPLE rotated, see HR-77 and case #12";
+    const output = redact(input);
+
+    expect(output).not.toContain("bob@example.com");
+    expect(output).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(output).not.toContain("cust-441");
+    expect(output).not.toContain("10.1.2.3");
+    expect(output).toContain("[EMAIL]");
+    expect(output).toContain("[PHONE]");
+    expect(output).toContain("[AWS_KEY]");
+    expect(output).toContain("[CUSTOMER_ID]");
+    expect(output).toContain("[INTERNAL_HOST]");
+    expect(output).toContain("[INTERNAL_IP]");
+    expect(output).toContain("[HR_CASE]");
+  });
+
+  it("restricts to the requested categories", () => {
+    const input = "email alice@example.com token xoxb-123456789012-abcdefGHIJKL";
+
+    const secretsOnly = redact(input, { categories: ["secrets"] });
+    expect(secretsOnly).toContain("alice@example.com");
+    expect(secretsOnly).toContain("[SLACK_TOKEN]");
+
+    const contactOnly = redact(input, { categories: ["contact"] });
+    expect(contactOnly).toContain("[EMAIL]");
+    expect(contactOnly).toContain("xoxb-123456789012-abcdefGHIJKL");
+  });
+
+  it("returns clean text unchanged", () => {
+    const clean = "Deployed v1.4.2 to staging; error rate back under 0.1%.";
+    expect(redact(clean)).toBe(clean);
+  });
+});
+
+describe("scan", () => {
+  it("reports category, label, and matches without mutating text", () => {
+    const findings = scan("ssn 123-45-6789 and email a@b.co");
+
+    expect(findings).toEqual([
+      { category: "financial", label: "ssn", matches: ["123-45-6789"] },
+      { category: "contact", label: "email", matches: ["a@b.co"] },
+    ]);
+  });
+
+  it("returns an empty list for clean text", () => {
+    expect(scan("all quiet")).toEqual([]);
+  });
+
+  it("is stateless across repeated calls (no shared lastIndex)", () => {
+    const text = "a@b.co";
+    expect(scan(text)).toHaveLength(1);
+    expect(scan(text)).toHaveLength(1);
+  });
+});
+
+describe("assertNoPii", () => {
+  it("passes on clean text", () => {
+    expect(() => assertNoPii("nothing to see", "run-1")).not.toThrow();
+  });
+
+  it("throws PiiDetectedError naming the findings and context", () => {
+    expect(() => assertNoPii("ssn 123-45-6789", "run-42")).toThrowError(PiiDetectedError);
+    expect(() => assertNoPii("ssn 123-45-6789", "run-42")).toThrow(
+      "[run-42] PII detected: financial/ssn",
+    );
+    expect(() => assertNoPii("ssn 123-45-6789")).toThrow("PII detected: financial/ssn");
+  });
+
+  it("exposes structured findings on the error", () => {
+    try {
+      assertNoPii("card 4111111111111111", "run-7");
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(PiiDetectedError);
+      expect((err as PiiDetectedError).findings[0]).toMatchObject({
+        category: "financial",
+        label: "credit_card",
+      });
+    }
+  });
+});
+
+describe("pattern catalog", () => {
+  it("covers the union of the fleet's category sets", () => {
+    const categories = new Set(REDACTION_PATTERNS.map((p) => p.category));
+    expect([...categories].sort()).toEqual([
+      "aws",
+      "compensation",
+      "contact",
+      "customer",
+      "dob",
+      "financial",
+      "health",
+      "hr",
+      "secrets",
+    ]);
+  });
+
+  it("declares every pattern global so redact replaces all occurrences", () => {
+    for (const { label, pattern } of REDACTION_PATTERNS) {
+      expect(pattern.flags, `${label} must be global`).toContain("g");
+    }
+  });
+});

--- a/library/runtime/src/pii.ts
+++ b/library/runtime/src/pii.ts
@@ -1,0 +1,374 @@
+/**
+ * PII redaction — the union of the fleet's three category sets.
+ *
+ * One pattern catalog covering secrets/tokens (JWT, AWS access keys,
+ * GitHub PATs, Slack tokens, generic API keys), financial identifiers
+ * (dashed SSN, credit cards), compensation language, performance/HR-case
+ * signals, health information, dates of birth, contact info (email,
+ * phone, street address), AWS account ids, and customer/infrastructure
+ * identifiers (customer ids, account ids, RFC1918 IPs, internal
+ * hostnames).
+ *
+ * Patterns are ordered most-specific first so longer matches win over
+ * shorter ones (e.g. AKIA access keys before generic API-key prefixes,
+ * credit cards before phone numbers). Replacements are typed per label
+ * (`[JWT]`, `[SSN]`, `[COMPENSATION]`, …) so redacted text stays
+ * debuggable — you can see WHAT was removed without seeing the value.
+ *
+ * Non-dashed SSN (`\b\d{9}\b`) is intentionally NOT redacted: it collides
+ * with legitimate 9-digit account numbers and would produce unacceptable
+ * false positives in business text. If ever needed, use a context-aware
+ * detector (label + value), not a raw regex.
+ *
+ * Zero dependencies.
+ */
+
+export type PiiCategory =
+  | "secrets"
+  | "financial"
+  | "compensation"
+  | "hr"
+  | "health"
+  | "dob"
+  | "contact"
+  | "aws"
+  | "customer";
+
+export interface RedactionPattern {
+  category: PiiCategory;
+  label: string;
+  pattern: RegExp;
+  replacement: string;
+}
+
+// Compensation keywords reused across the currency-agnostic patterns below.
+const COMP_KEYWORD = "(?:salary|compensation|comp|pay|bonus|equity|RSUs?|raise|offer|base|stipend)";
+// A monetary amount: optional currency symbol, optional magnitude/cadence suffix.
+const MONEY_AMOUNT =
+  "(?:[$£€¥₹]\\s?)?[\\d,]+(?:\\.\\d{1,2})?(?:\\s*(?:k|K|thousand|million|m|/\\s*year|/\\s*yr|per\\s+annum|annually))?";
+
+export const REDACTION_PATTERNS: readonly RedactionPattern[] = [
+  // ── Secrets / tokens ─────────────────────────────────────────────
+  {
+    category: "secrets",
+    label: "jwt",
+    pattern: /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+    replacement: "[JWT]",
+  },
+  {
+    category: "secrets",
+    label: "aws_access_key",
+    pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+    replacement: "[AWS_KEY]",
+  },
+  {
+    category: "secrets",
+    label: "github_pat",
+    pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,255}\b/g,
+    replacement: "[GITHUB_PAT]",
+  },
+  {
+    category: "secrets",
+    label: "slack_token",
+    pattern: /\bxox[bpasr]-[A-Za-z0-9-]{10,}\b/g,
+    replacement: "[SLACK_TOKEN]",
+  },
+  {
+    category: "secrets",
+    label: "api_key_generic",
+    pattern: /\b(?:sk-|pk_live_|Bearer\s)[A-Za-z0-9_-]{20,}\b/g,
+    replacement: "[API_KEY]",
+  },
+
+  // ── Financial identifiers ────────────────────────────────────────
+  {
+    category: "financial",
+    label: "ssn",
+    pattern: /\b\d{3}-\d{2}-\d{4}\b/g,
+    replacement: "[SSN]",
+  },
+  {
+    category: "financial",
+    label: "credit_card",
+    pattern:
+      /\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12})\b/g,
+    replacement: "[PAYMENT]",
+  },
+  {
+    category: "financial",
+    label: "credit_card_separated",
+    pattern: /\b\d{4}[\s-]\d{4}[\s-]\d{4}[\s-]\d{4}\b/g,
+    replacement: "[PAYMENT]",
+  },
+
+  // ── Compensation ─────────────────────────────────────────────────
+  {
+    category: "compensation",
+    label: "amount_before_keyword",
+    pattern: new RegExp(
+      `[$£€¥₹]\\s?[\\d,]+(?:\\.\\d{1,2})?(?:\\s*(?:k|K|thousand|million|m))?\\s*${COMP_KEYWORD}`,
+      "gi",
+    ),
+    replacement: "[COMPENSATION]",
+  },
+  {
+    category: "compensation",
+    label: "keyword_before_currency_amount",
+    pattern: new RegExp(`${COMP_KEYWORD}\\s*(?:of|is|was|at|:)?\\s*[$£€¥₹]\\s?[\\d,]+`, "gi"),
+    replacement: "[COMPENSATION]",
+  },
+  {
+    category: "compensation",
+    label: "keyword_before_bare_amount",
+    pattern: new RegExp(`${COMP_KEYWORD}\\s*(?:of|is|was|at|:)?\\s*${MONEY_AMOUNT}`, "gi"),
+    replacement: "[COMPENSATION]",
+  },
+  {
+    category: "compensation",
+    label: "bare_amount_before_keyword",
+    pattern: new RegExp(`${MONEY_AMOUNT}\\s*${COMP_KEYWORD}`, "gi"),
+    replacement: "[COMPENSATION]",
+  },
+  {
+    category: "compensation",
+    label: "annual_cadence_amount",
+    pattern:
+      /(?:[$£€¥₹]\s?)?[\d,]+(?:\.\d{1,2})?\s*[kKmM]?\s*(?:per\s+annum|annually|\/\s*year|\/\s*yr|per\s+year|a\s+year)\b/gi,
+    replacement: "[COMPENSATION]",
+  },
+  {
+    category: "compensation",
+    label: "comp_phrase",
+    pattern: /\b(?:annual|base|total)\s+(?:comp|compensation|salary|pay)\b/gi,
+    replacement: "[COMPENSATION]",
+  },
+
+  // ── Performance / HR ─────────────────────────────────────────────
+  { category: "hr", label: "pip", pattern: /\bPIP\b/g, replacement: "[HR]" },
+  {
+    category: "hr",
+    label: "performance_process",
+    pattern: /performance\s+(?:improvement|management|plan|review|warning)/gi,
+    replacement: "[HR]",
+  },
+  {
+    category: "hr",
+    label: "disciplinary",
+    pattern: /disciplinary\s+(?:action|proceeding|process)/gi,
+    replacement: "[HR]",
+  },
+  { category: "hr", label: "written_warning", pattern: /written\s+warning/gi, replacement: "[HR]" },
+  {
+    category: "hr",
+    label: "termination_notice",
+    pattern: /termination\s+notice/gi,
+    replacement: "[HR]",
+  },
+  {
+    category: "hr",
+    label: "performance_corrective",
+    pattern: /performance\s+corrective/gi,
+    replacement: "[HR]",
+  },
+  { category: "hr", label: "hr_case_id", pattern: /HR-\d+/gi, replacement: "[HR_CASE]" },
+  { category: "hr", label: "case_number", pattern: /case\s+#?\d+/gi, replacement: "[HR_CASE]" },
+  {
+    category: "hr",
+    label: "ticket_number",
+    pattern: /ticket\s+#?[A-Z0-9]+/gi,
+    replacement: "[HR_CASE]",
+  },
+
+  // ── Health ───────────────────────────────────────────────────────
+  { category: "health", label: "fmla", pattern: /\bFMLA\b/gi, replacement: "[HEALTH]" },
+  {
+    category: "health",
+    label: "diagnosis",
+    pattern: /\bdiagnos(?:is|ed|es)\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "medical_phrase",
+    pattern: /\bmedical\s+(?:leave|condition|emergency|appointment|record|history|note)\b/gi,
+    replacement: "[HEALTH]",
+  },
+  { category: "health", label: "mental_health", pattern: /\bmental\s+health\b/gi, replacement: "[HEALTH]" },
+  {
+    category: "health",
+    label: "health_phrase",
+    pattern: /\bhealth\s+(?:condition|issue|concern|record|emergency)\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "term_disability",
+    pattern: /\b(?:short|long)[\s-]term\s+disability\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "disability_phrase",
+    pattern: /\bdisability\s+(?:accommodation|leave|claim|benefits?|status)\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "accommodation",
+    pattern: /\b(?:reasonable\s+)?accommodation\s+(?:request|for)\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "leave_type",
+    pattern: /\b(?:sick|medical|maternity|paternity|parental|bereavement)\s+leave\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "leave_of_absence",
+    pattern: /\bleave\s+of\s+absence\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "workers_comp",
+    pattern: /\bworkers?['’\s]?\s*comp(?:ensation)?\s+(?:claim|case|injury)\b/gi,
+    replacement: "[HEALTH]",
+  },
+  {
+    category: "health",
+    label: "treatment_for",
+    pattern: /\b(?:treatment|therapy|prescription|hospitaliz(?:ed|ation)|surgery)\s+for\b/gi,
+    replacement: "[HEALTH]",
+  },
+
+  // ── Date of birth ────────────────────────────────────────────────
+  {
+    category: "dob",
+    label: "dob_phrase",
+    pattern: /\b(?:date of birth|dob|born on)\s*:?\s*\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/gi,
+    replacement: "[DOB]",
+  },
+
+  // ── Contact info ─────────────────────────────────────────────────
+  {
+    category: "contact",
+    label: "email",
+    pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+    replacement: "[EMAIL]",
+  },
+  {
+    category: "contact",
+    label: "phone_us",
+    pattern: /\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s][0-9]{3}[-.\s][0-9]{4}\b/g,
+    replacement: "[PHONE]",
+  },
+  {
+    category: "contact",
+    label: "phone_intl",
+    // E.164 / international: leading "+" country code then 7-14 more digits
+    // with optional space/dash/dot grouping. The required "+" keeps it from
+    // matching bare digit runs handled by other patterns.
+    pattern: /\+\d{1,3}(?:[\s\-.]?\d){7,14}\b/g,
+    replacement: "[PHONE]",
+  },
+  {
+    category: "contact",
+    label: "street_address",
+    pattern: /\b\d{1,5}\s+[A-Z][a-z]+\s+(?:St|Ave|Blvd|Dr|Rd|Ln|Way|Court|Ct|Place|Pl)\b/gi,
+    replacement: "[ADDRESS]",
+  },
+
+  // ── AWS account ──────────────────────────────────────────────────
+  {
+    category: "aws",
+    label: "aws_account_id",
+    pattern: /\b\d{12}\b(?=\s*(?:aws|account))/gi,
+    replacement: "[AWS_ACCOUNT]",
+  },
+
+  // ── Customer / infrastructure identifiers ────────────────────────
+  {
+    category: "customer",
+    label: "customer_id",
+    pattern: /\bcust-[0-9]+\b/gi,
+    replacement: "[CUSTOMER_ID]",
+  },
+  {
+    category: "customer",
+    label: "account_id_field",
+    pattern: /\baccount[-_]?id[:=\s][^\s,]+/gi,
+    replacement: "[ACCOUNT_ID]",
+  },
+  {
+    category: "customer",
+    label: "internal_ip",
+    // RFC1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16.
+    pattern: /\b(?:10\.(?:\d{1,3}\.){2}\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3}\.)\d{1,3}|192\.168\.(?:\d{1,3}\.)\d{1,3})\b/g,
+    replacement: "[INTERNAL_IP]",
+  },
+  {
+    category: "customer",
+    label: "prod_hostname",
+    pattern: /\bprod-[a-z0-9-]+\.[a-z]+\b/gi,
+    replacement: "[INTERNAL_HOST]",
+  },
+  {
+    category: "customer",
+    label: "db_identifier",
+    pattern: /\bdb-[a-z0-9-]+\b/gi,
+    replacement: "[INTERNAL_HOST]",
+  },
+];
+
+export interface PiiFinding {
+  category: PiiCategory;
+  label: string;
+  matches: string[];
+}
+
+export class PiiDetectedError extends Error {
+  constructor(
+    public readonly findings: PiiFinding[],
+    context?: string,
+  ) {
+    const labels = findings.map((f) => `${f.category}/${f.label}`).join(", ");
+    super(`${context ? `[${context}] ` : ""}PII detected: ${labels}`);
+    this.name = "PiiDetectedError";
+  }
+}
+
+function selectPatterns(categories?: PiiCategory[]): readonly RedactionPattern[] {
+  if (!categories) return REDACTION_PATTERNS;
+  const wanted = new Set(categories);
+  return REDACTION_PATTERNS.filter((p) => wanted.has(p.category));
+}
+
+/** Replace every match of every (selected) pattern with its typed token. */
+export function redact(text: string, options?: { categories?: PiiCategory[] }): string {
+  let result = text;
+  for (const { pattern, replacement } of selectPatterns(options?.categories)) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+/** Report which patterns match, without modifying the text. */
+export function scan(text: string, options?: { categories?: PiiCategory[] }): PiiFinding[] {
+  const findings: PiiFinding[] = [];
+  for (const { category, label, pattern } of selectPatterns(options?.categories)) {
+    // Fresh RegExp per scan — never share lastIndex state with redact().
+    const matches = text.match(new RegExp(pattern.source, pattern.flags)) ?? [];
+    if (matches.length > 0) findings.push({ category, label, matches });
+  }
+  return findings;
+}
+
+/** Guard for LLM prompt/output checkpoints — throws `PiiDetectedError` on any finding. */
+export function assertNoPii(text: string, context?: string): void {
+  const findings = scan(text);
+  if (findings.length > 0) {
+    throw new PiiDetectedError(findings, context);
+  }
+}

--- a/library/runtime/src/registry.test.ts
+++ b/library/runtime/src/registry.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { createRegistry } from "./registry.js";
+
+interface FakeProvider {
+  kind: string;
+}
+
+describe("createRegistry", () => {
+  it("registers and resolves providers by name", () => {
+    const registry = createRegistry<FakeProvider>("llm");
+    registry.register("bedrock", () => ({ kind: "bedrock" }));
+
+    expect(registry.get("bedrock")).toEqual({ kind: "bedrock" });
+  });
+
+  it("invokes the factory on every get (fresh instance per lookup)", () => {
+    const registry = createRegistry<FakeProvider>("llm");
+    registry.register("bedrock", () => ({ kind: "bedrock" }));
+
+    const a = registry.get("bedrock");
+    const b = registry.get("bedrock");
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+
+  it("throws an actionable error naming the kind and available providers", () => {
+    const registry = createRegistry<FakeProvider>("embedding");
+    registry.register("bedrock", () => ({ kind: "bedrock" }));
+    registry.register("openai", () => ({ kind: "openai" }));
+
+    expect(() => registry.get("cohere")).toThrow(
+      'Unknown embedding provider "cohere". Available: bedrock, openai',
+    );
+  });
+
+  it("reports <none> when the registry is empty", () => {
+    const registry = createRegistry<FakeProvider>("vector-store");
+
+    expect(() => registry.get("pgvector")).toThrow(
+      'Unknown vector-store provider "pgvector". Available: <none>',
+    );
+  });
+
+  it("answers has() without invoking factories", () => {
+    const registry = createRegistry<FakeProvider>("llm");
+    let invoked = 0;
+    registry.register("bedrock", () => {
+      invoked++;
+      return { kind: "bedrock" };
+    });
+
+    expect(registry.has("bedrock")).toBe(true);
+    expect(registry.has("openai")).toBe(false);
+    expect(invoked).toBe(0);
+  });
+
+  it("lists registered names in registration order", () => {
+    const registry = createRegistry<FakeProvider>("llm");
+    registry.register("bedrock", () => ({ kind: "bedrock" }));
+    registry.register("anthropic", () => ({ kind: "anthropic" }));
+
+    expect(registry.names()).toEqual(["bedrock", "anthropic"]);
+  });
+
+  it("lets a later registration override an earlier one", () => {
+    const registry = createRegistry<FakeProvider>("llm");
+    registry.register("bedrock", () => ({ kind: "v1" }));
+    registry.register("bedrock", () => ({ kind: "v2" }));
+
+    expect(registry.get("bedrock")).toEqual({ kind: "v2" });
+    expect(registry.names()).toEqual(["bedrock"]);
+  });
+});

--- a/library/runtime/src/registry.ts
+++ b/library/runtime/src/registry.ts
@@ -1,0 +1,43 @@
+/**
+ * Provider registry — the nanohype convention for pluggable seams.
+ *
+ * Kept small: register + get + has + names. `get` invokes the factory on
+ * every call (a fresh instance per lookup — consumers that want a
+ * singleton memoize inside their factory). Errors on get-by-unknown-name
+ * include the available names so call sites fail loudly with an
+ * actionable message rather than returning undefined.
+ *
+ * Zero dependencies.
+ */
+
+export type ProviderFactory<T> = () => T;
+
+export interface ProviderRegistry<T> {
+  register(name: string, factory: ProviderFactory<T>): void;
+  get(name: string): T;
+  has(name: string): boolean;
+  names(): string[];
+}
+
+export function createRegistry<T>(kind: string): ProviderRegistry<T> {
+  const factories = new Map<string, ProviderFactory<T>>();
+  return {
+    register(name, factory) {
+      factories.set(name, factory);
+    },
+    get(name) {
+      const factory = factories.get(name);
+      if (!factory) {
+        const available = [...factories.keys()].join(", ") || "<none>";
+        throw new Error(`Unknown ${kind} provider "${name}". Available: ${available}`);
+      }
+      return factory();
+    },
+    has(name) {
+      return factories.has(name);
+    },
+    names() {
+      return [...factories.keys()];
+    },
+  };
+}

--- a/library/runtime/src/resilience.test.ts
+++ b/library/runtime/src/resilience.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { withTimeout, withRetry, TimeoutError } from "./resilience.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withTimeout", () => {
+  it("resolves when the promise settles before the deadline", async () => {
+    await expect(withTimeout(Promise.resolve(42), 1_000)).resolves.toBe(42);
+  });
+
+  it("propagates the underlying rejection", async () => {
+    await expect(withTimeout(Promise.reject(new Error("boom")), 1_000)).rejects.toThrow("boom");
+  });
+
+  it("rejects with TimeoutError when the deadline wins", async () => {
+    vi.useFakeTimers();
+    const never = new Promise<never>(() => {});
+
+    const result = withTimeout(never, 50, "slack.pin");
+    const assertion = expect(result).rejects.toMatchObject({
+      name: "TimeoutError",
+      message: "slack.pin timed out after 50ms",
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+  });
+
+  it("labels the error with a default when no label is given", async () => {
+    vi.useFakeTimers();
+    const never = new Promise<never>(() => {});
+
+    const result = withTimeout(never, 10);
+    const assertion = expect(result).rejects.toThrow("operation timed out after 10ms");
+    await vi.advanceTimersByTimeAsync(10);
+    await assertion;
+    await expect(result).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it("clears the timer when the promise settles first", async () => {
+    vi.useFakeTimers();
+    await withTimeout(Promise.resolve("ok"), 5_000);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("withRetry", () => {
+  /** Records requested delays instead of sleeping. */
+  function makeSleepRecorder() {
+    const delays: number[] = [];
+    return { delays, sleep: (ms: number) => (delays.push(ms), Promise.resolve()) };
+  }
+
+  it("returns the first successful result without sleeping", async () => {
+    const { delays, sleep } = makeSleepRecorder();
+    const factory = vi.fn(async () => "ok");
+
+    await expect(withRetry(factory, { attempts: 3, initialDelayMs: 100, jitter: false, sleep })).resolves.toBe("ok");
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  it("retries with exponential backoff until success", async () => {
+    const { delays, sleep } = makeSleepRecorder();
+    const factory = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(new Error("second"))
+      .mockResolvedValueOnce("third time lucky");
+
+    await expect(withRetry(factory, { attempts: 3, initialDelayMs: 100, jitter: false, sleep })).resolves.toBe(
+      "third time lucky",
+    );
+    expect(factory).toHaveBeenCalledTimes(3);
+    expect(delays).toEqual([100, 200]);
+  });
+
+  it("caps the backoff at maxDelayMs", async () => {
+    const { delays, sleep } = makeSleepRecorder();
+    const factory = vi.fn(async () => {
+      throw new Error("always");
+    });
+
+    await expect(
+      withRetry(factory, { attempts: 5, initialDelayMs: 100, maxDelayMs: 250, jitter: false, sleep }),
+    ).rejects.toThrow("always");
+    expect(delays).toEqual([100, 200, 250, 250]);
+  });
+
+  it("throws the last error on exhaustion", async () => {
+    const { sleep } = makeSleepRecorder();
+    const factory = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(new Error("last"));
+
+    await expect(withRetry(factory, { attempts: 2, initialDelayMs: 10, jitter: false, sleep })).rejects.toThrow(
+      "last",
+    );
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("jitters each delay to 50-100% of the computed backoff", async () => {
+    const { delays, sleep } = makeSleepRecorder();
+    const factory = vi.fn(async () => {
+      throw new Error("always");
+    });
+
+    await expect(
+      withRetry(factory, { attempts: 4, initialDelayMs: 100, maxDelayMs: 5_000, jitter: true, sleep }),
+    ).rejects.toThrow("always");
+
+    expect(delays).toHaveLength(3);
+    const bases = [100, 200, 400];
+    delays.forEach((delay, i) => {
+      expect(delay).toBeGreaterThanOrEqual(bases[i] * 0.5);
+      expect(delay).toBeLessThanOrEqual(bases[i]);
+    });
+  });
+});

--- a/library/runtime/src/resilience.ts
+++ b/library/runtime/src/resilience.ts
@@ -1,0 +1,79 @@
+/**
+ * Resilience primitives: deadline-bound awaits and jittered retries.
+ *
+ * `withTimeout` races a promise against a deadline and rejects with
+ * `TimeoutError` when the deadline wins. The underlying promise is NOT
+ * cancelled (a JS limitation) — the caller just stops waiting, so pair
+ * it with a transport-level abort (AbortSignal, SDK requestHandler
+ * timeout) when the downstream supports one.
+ *
+ * `withRetry` re-invokes a factory up to `attempts` times with jittered
+ * exponential backoff. Only use it around idempotent calls. The sleep is
+ * injectable so tests capture the delay schedule synchronously instead
+ * of faking timers.
+ *
+ * Zero dependencies.
+ */
+
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * Rejects with `TimeoutError` if `promise` does not settle within `ms`.
+ * `label` names the operation in the error message for actionable logs.
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, label = "operation"): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new TimeoutError(`${label} timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface RetryOptions {
+  /** Total invocation attempts (first call included). */
+  attempts: number;
+  /** Backoff before the second attempt, in ms. Doubles each retry. */
+  initialDelayMs: number;
+  /** Backoff ceiling, in ms. Default: 5000. */
+  maxDelayMs?: number;
+  /** Randomize each delay to 50–100% of the computed backoff. */
+  jitter: boolean;
+  /** Sleep override. Defaults to a real setTimeout sleep. Tests inject a recorder. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Invokes `factory` until it resolves or `attempts` is exhausted, sleeping
+ * `initialDelayMs * 2^(attempt-1)` (capped at `maxDelayMs`, jittered when
+ * `jitter` is set) between attempts. Throws the last error on exhaustion.
+ */
+export async function withRetry<T>(factory: () => Promise<T>, options: RetryOptions): Promise<T> {
+  const { attempts, initialDelayMs, maxDelayMs = 5_000, jitter } = options;
+  const sleep = options.sleep ?? defaultSleep;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await factory();
+    } catch (err) {
+      lastError = err;
+      if (attempt === attempts) break;
+      const base = Math.min(initialDelayMs * Math.pow(2, attempt - 1), maxDelayMs);
+      const delay = jitter ? base * (0.5 + Math.random() * 0.5) : base;
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/library/runtime/src/workos-directory.test.ts
+++ b/library/runtime/src/workos-directory.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from "vitest";
+import { createWorkOsDirectoryClient } from "./workos-directory.js";
+
+interface RawUser {
+  id: string;
+  email?: string | null;
+  emails?: Array<{ primary?: boolean; type?: string; value: string }>;
+  first_name?: string | null;
+  last_name?: string | null;
+  job_title?: string | null;
+  state?: "active" | "suspended" | "inactive";
+  custom_attributes?: Record<string, unknown>;
+  created_at?: string;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function page(data: RawUser[], after?: string) {
+  return { data, list_metadata: { after: after ?? null } };
+}
+
+const alice: RawUser = {
+  id: "directory_user_alice",
+  email: "alice@example.com",
+  first_name: "Alice",
+  last_name: "Anders",
+  job_title: "Staff Engineer",
+  state: "active",
+  custom_attributes: { githubLogin: "alicehub", department: "Platform" },
+  created_at: "2026-06-01T00:00:00.000Z",
+};
+
+const bob: RawUser = {
+  id: "directory_user_bob",
+  emails: [
+    { primary: false, value: "bob-alias@example.com" },
+    { primary: true, value: "bob@example.com" },
+  ],
+  first_name: "Bob",
+  last_name: "Bristow",
+  state: "suspended",
+  custom_attributes: { slackUserId: "U0BOB" },
+  created_at: "2026-01-15T00:00:00.000Z",
+};
+
+function makeClient(pages: Array<{ data: RawUser[]; list_metadata: { after: string | null } }>) {
+  let call = 0;
+  const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+    jsonResponse(pages[Math.min(call++, pages.length - 1)]),
+  );
+  const client = createWorkOsDirectoryClient({
+    apiKey: "sk_test_123",
+    directoryId: "directory_01",
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, fetchImpl };
+}
+
+describe("createWorkOsDirectoryClient", () => {
+  it("sends the bearer key, directory id, and page size on every request", async () => {
+    const { client, fetchImpl } = makeClient([page([alice])]);
+
+    await client.findByEmail("alice@example.com");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe("https://api.workos.com/directory_users");
+    expect(parsed.searchParams.get("directory")).toBe("directory_01");
+    expect(parsed.searchParams.get("limit")).toBe("100");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer sk_test_123");
+  });
+
+  it("follows the after cursor across pages", async () => {
+    const { client, fetchImpl } = makeClient([page([bob], "cursor-2"), page([alice])]);
+
+    const found = await client.findByEmail("alice@example.com");
+
+    expect(found?.id).toBe("directory_user_alice");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const secondUrl = new URL(fetchImpl.mock.calls[1][0] as unknown as string);
+    expect(secondUrl.searchParams.get("after")).toBe("cursor-2");
+  });
+
+  it("matches email case-insensitively and falls back to the primary emails[] entry", async () => {
+    const { client } = makeClient([page([bob])]);
+
+    const found = await client.findByEmail("BOB@example.com");
+
+    expect(found).toMatchObject({
+      id: "directory_user_bob",
+      email: "bob@example.com",
+      displayName: "Bob Bristow",
+      state: "suspended",
+    });
+  });
+
+  it("returns null when no user matches", async () => {
+    const { client } = makeClient([page([alice, bob])]);
+
+    await expect(client.findByEmail("nobody@example.com")).resolves.toBeNull();
+  });
+
+  it("finds users by custom attribute", async () => {
+    const { client } = makeClient([page([alice, bob])]);
+
+    const byGithub = await client.findByCustomAttribute("githubLogin", "alicehub");
+    expect(byGithub?.id).toBe("directory_user_alice");
+    expect(byGithub?.department).toBe("Platform");
+    expect(byGithub?.title).toBe("Staff Engineer");
+
+    await expect(client.findByCustomAttribute("githubLogin", "nobody")).resolves.toBeNull();
+  });
+
+  it("lists users created at or after the cutoff", async () => {
+    const { client } = makeClient([page([alice, bob])]);
+
+    const joiners = await client.listUsersSince(new Date("2026-05-01T00:00:00.000Z"));
+
+    expect(joiners.map((u) => u.id)).toEqual(["directory_user_alice"]);
+  });
+
+  it("scopes group listings with the group param and maps every member", async () => {
+    const { client, fetchImpl } = makeClient([page([alice, bob])]);
+
+    const members = await client.listUsersInGroup("group_oncall");
+
+    expect(members).toHaveLength(2);
+    const url = new URL(fetchImpl.mock.calls[0][0] as unknown as string);
+    expect(url.searchParams.get("group")).toBe("group_oncall");
+  });
+
+  it("throws on a non-ok response with the status in the message", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ message: "nope" }, 401));
+    const client = createWorkOsDirectoryClient({
+      apiKey: "bad",
+      directoryId: "directory_01",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.findByEmail("alice@example.com")).rejects.toThrow(
+      "WorkOS directory list failed (401 Error)",
+    );
+  });
+
+  it("bounds pagination at maxPages so a misbehaving API cannot loop forever", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(page([bob], "always-more")));
+    const client = createWorkOsDirectoryClient({
+      apiKey: "sk_test_123",
+      directoryId: "directory_01",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxPages: 3,
+    });
+
+    await expect(client.findByEmail("alice@example.com")).resolves.toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to custom displayName, then id, when names are absent", async () => {
+    const anon: RawUser = { id: "directory_user_anon", custom_attributes: {} };
+    const branded: RawUser = {
+      id: "directory_user_branded",
+      custom_attributes: { displayName: "The Brand" },
+    };
+    const { client } = makeClient([page([anon, branded])]);
+
+    const members = await client.listUsersInGroup("group_x");
+
+    expect(members.map((u) => u.displayName)).toEqual(["directory_user_anon", "The Brand"]);
+  });
+
+  it("excludes users without a parseable created_at from since-listings", async () => {
+    const anon: RawUser = { id: "directory_user_anon" };
+    const { client } = makeClient([page([anon, alice])]);
+
+    const users = await client.listUsersSince(new Date(0));
+
+    expect(users.map((u) => u.id)).toEqual(["directory_user_alice"]);
+  });
+});

--- a/library/runtime/src/workos-directory.ts
+++ b/library/runtime/src/workos-directory.ts
@@ -1,0 +1,178 @@
+/**
+ * WorkOS Directory Sync client — typed, port-injected, cursor-paginated.
+ *
+ * Uses an injected `fetchImpl: typeof fetch` against the WorkOS REST API
+ * instead of `@workos-inc/node`: the SDK's transitive footprint is far
+ * larger than the handful of calls consumers actually make, and the
+ * injectable fetch gives a clean seam for tests (`vi.fn<typeof fetch>()`).
+ *
+ * WorkOS auth is a single Bearer API key — no client-credentials token
+ * exchange, so there is no token refresh and no `/token` roundtrip.
+ *
+ * The `/directory_users` endpoint does NOT support server-side filtering
+ * by email or custom attribute (documented params: `directory`, `group`,
+ * `limit`, `before`, `after`, `order`), so the finders paginate with
+ * `limit=100` via the `after` cursor and scan client-side. Pagination is
+ * bounded at `maxPages` (default 50 → 5000 users) so a misbehaving API
+ * can never produce a runaway loop. Callers own caching — every fleet
+ * consumer fronts this client with its own cache (DDB, in-memory TTL),
+ * so the client stays stateless.
+ *
+ * Zero dependencies (native fetch types only).
+ */
+
+export interface DirectoryUser {
+  /** WorkOS directory user id (`directory_user_…`). */
+  id: string;
+  /** Primary email — top-level `email`, else the primary/first entry of `emails[]`. */
+  email?: string;
+  firstName: string;
+  lastName: string;
+  /** `first_name last_name`, falling back to custom `displayName`, then id. */
+  displayName: string;
+  title?: string;
+  department?: string;
+  state?: "active" | "suspended" | "inactive";
+  customAttributes: Record<string, unknown>;
+  /** ISO 8601 from WorkOS. */
+  createdAt?: string;
+}
+
+export interface WorkOsDirectoryClient {
+  /** First user whose primary email matches (case-insensitive), or null. */
+  findByEmail(email: string): Promise<DirectoryUser | null>;
+  /** First user whose custom attribute equals `value` (e.g. `githubLogin`, `slackUserId`), or null. */
+  findByCustomAttribute(attribute: string, value: string): Promise<DirectoryUser | null>;
+  /** Users created at or after `since` (new-joiner detection). */
+  listUsersSince(since: Date): Promise<DirectoryUser[]>;
+  /** All members of a directory group. Filter on `state` at the call site if needed. */
+  listUsersInGroup(groupId: string): Promise<DirectoryUser[]>;
+}
+
+export interface WorkOsDirectoryConfig {
+  apiKey: string;
+  directoryId: string;
+  /** Default: https://api.workos.com */
+  baseUrl?: string;
+  /** Injected fetch port. Default: globalThis.fetch. */
+  fetchImpl?: typeof fetch;
+  /** Page size for cursor pagination. Default: 100 (WorkOS max). */
+  pageSize?: number;
+  /** Upper bound on pages walked per call. Default: 50. */
+  maxPages?: number;
+}
+
+interface RawDirectoryUser {
+  id: string;
+  email?: string | null;
+  emails?: Array<{ primary?: boolean; type?: string; value: string }>;
+  first_name?: string | null;
+  last_name?: string | null;
+  job_title?: string | null;
+  state?: "active" | "suspended" | "inactive";
+  custom_attributes?: Record<string, unknown>;
+  created_at?: string;
+}
+
+interface RawDirectoryUserList {
+  data: RawDirectoryUser[];
+  list_metadata?: { after?: string | null };
+}
+
+function primaryEmailOf(raw: RawDirectoryUser): string | undefined {
+  if (raw.email) return raw.email;
+  const emails = raw.emails ?? [];
+  return emails.find((e) => e.primary)?.value ?? emails[0]?.value;
+}
+
+function toDirectoryUser(raw: RawDirectoryUser): DirectoryUser {
+  const attrs = raw.custom_attributes ?? {};
+  const displayName =
+    [raw.first_name, raw.last_name].filter(Boolean).join(" ").trim() ||
+    String(attrs.displayName ?? raw.id);
+  const email = primaryEmailOf(raw);
+  return {
+    id: raw.id,
+    ...(email !== undefined ? { email } : {}),
+    firstName: raw.first_name ?? "",
+    lastName: raw.last_name ?? "",
+    displayName,
+    ...(raw.job_title != null
+      ? { title: raw.job_title }
+      : typeof attrs.title === "string"
+        ? { title: attrs.title }
+        : {}),
+    ...(typeof attrs.department === "string" ? { department: attrs.department } : {}),
+    ...(raw.state !== undefined ? { state: raw.state } : {}),
+    customAttributes: attrs,
+    ...(raw.created_at !== undefined ? { createdAt: raw.created_at } : {}),
+  };
+}
+
+export function createWorkOsDirectoryClient(config: WorkOsDirectoryConfig): WorkOsDirectoryClient {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const baseUrl = (config.baseUrl ?? "https://api.workos.com").replace(/\/$/, "");
+  const pageSize = config.pageSize ?? 100;
+  const maxPages = config.maxPages ?? 50;
+  const headers = {
+    Authorization: `Bearer ${config.apiKey}`,
+    Accept: "application/json",
+  };
+
+  async function* walk(params: { group?: string } = {}): AsyncGenerator<RawDirectoryUser> {
+    let after: string | null | undefined;
+    for (let page = 0; page < maxPages; page++) {
+      const url = new URL(`${baseUrl}/directory_users`);
+      url.searchParams.set("directory", config.directoryId);
+      url.searchParams.set("limit", String(pageSize));
+      if (params.group) url.searchParams.set("group", params.group);
+      if (after) url.searchParams.set("after", after);
+
+      const response = await fetchImpl(url.toString(), { headers });
+      if (!response.ok) {
+        throw new Error(`WorkOS directory list failed (${response.status} ${response.statusText})`);
+      }
+      const body = (await response.json()) as RawDirectoryUserList;
+      for (const user of body.data) yield user;
+
+      after = body.list_metadata?.after;
+      if (!after) return;
+    }
+  }
+
+  return {
+    async findByEmail(email) {
+      const needle = email.toLowerCase();
+      for await (const raw of walk()) {
+        if (primaryEmailOf(raw)?.toLowerCase() === needle) return toDirectoryUser(raw);
+      }
+      return null;
+    },
+
+    async findByCustomAttribute(attribute, value) {
+      for await (const raw of walk()) {
+        const attr = raw.custom_attributes?.[attribute];
+        if (typeof attr === "string" && attr === value) return toDirectoryUser(raw);
+      }
+      return null;
+    },
+
+    async listUsersSince(since) {
+      const cutoff = since.getTime();
+      const matches: DirectoryUser[] = [];
+      for await (const raw of walk()) {
+        const created = raw.created_at ? Date.parse(raw.created_at) : NaN;
+        if (!Number.isNaN(created) && created >= cutoff) matches.push(toDirectoryUser(raw));
+      }
+      return matches;
+    },
+
+    async listUsersInGroup(groupId) {
+      const members: DirectoryUser[] = [];
+      for await (const raw of walk({ group: groupId })) {
+        members.push(toDirectoryUser(raw));
+      }
+      return members;
+    },
+  };
+}

--- a/library/runtime/tsconfig.json
+++ b/library/runtime/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/templates/a2a-agent/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/a2a-agent/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/agent-orchestrator/skeleton/src/orchestrator/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/agent-orchestrator/skeleton/src/orchestrator/resilience/__tests__/circuit-breaker.test.ts
@@ -51,16 +51,19 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {

--- a/templates/agentic-loop/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/agentic-loop/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open — should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/data-pipeline/skeleton/src/pipeline/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open — should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/discord-bot/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/discord-bot/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/eval-harness/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/eval-harness/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/fine-tune-pipeline/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/fine-tune-pipeline/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/go-cli/skeleton/cmd/root_test.go
+++ b/templates/go-cli/skeleton/cmd/root_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestExecute(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+		wantOut string // substring expected in combined output; "" skips the check
+		check   func(t *testing.T)
+	}{
+		{
+			name:    "no args prints help",
+			args:    []string{},
+			wantErr: false,
+			wantOut: "Usage:",
+		},
+		{
+			name:    "help flag prints usage",
+			args:    []string{"--help"},
+			wantErr: false,
+			wantOut: "__PROJECT_NAME__",
+		},
+		{
+			name:    "version subcommand runs",
+			args:    []string{"version"},
+			wantErr: false,
+		},
+		{
+			name:    "unknown command errors",
+			args:    []string{"definitely-not-a-command"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown flag errors",
+			args:    []string{"--no-such-flag"},
+			wantErr: true,
+		},
+		{
+			name:    "log-format flag parses",
+			args:    []string{"version", "--log-format", "text"},
+			wantErr: false,
+			check: func(t *testing.T) {
+				if logFormat != "text" {
+					t.Errorf("logFormat = %q, want %q", logFormat, "text")
+				}
+			},
+		},
+		{
+			name:    "verbose flag parses",
+			args:    []string{"version", "--verbose"},
+			wantErr: false,
+			check: func(t *testing.T) {
+				if !verbose {
+					t.Error("verbose = false, want true")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				logFormat = "__LOG_FORMAT__"
+				verbose = false
+				cfgFile = ""
+			}()
+
+			out := &bytes.Buffer{}
+			rootCmd.SetOut(out)
+			rootCmd.SetErr(out)
+			rootCmd.SetArgs(tt.args)
+
+			err := rootCmd.Execute()
+
+			if tt.wantErr && err == nil {
+				t.Fatalf("Execute(%v) = nil error, want error", tt.args)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("Execute(%v) = %v, want nil", tt.args, err)
+			}
+			if tt.wantOut != "" && !strings.Contains(out.String(), tt.wantOut) {
+				t.Errorf("output %q does not contain %q", out.String(), tt.wantOut)
+			}
+			if tt.check != nil {
+				tt.check(t)
+			}
+		})
+	}
+}
+
+func TestFindResolvesCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantName string
+	}{
+		{"empty args resolve to root", []string{}, rootCmd.Name()},
+		{"version resolves to version subcommand", []string{"version"}, "version"},
+		{"flags alone resolve to root", []string{"--verbose"}, rootCmd.Name()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, _, err := rootCmd.Find(tt.args)
+			if err != nil {
+				t.Fatalf("Find(%v) error: %v", tt.args, err)
+			}
+			if cmd.Name() != tt.wantName {
+				t.Errorf("Find(%v) = %q, want %q", tt.args, cmd.Name(), tt.wantName)
+			}
+		})
+	}
+}

--- a/templates/go-cli/skeleton/go.mod
+++ b/templates/go-cli/skeleton/go.mod
@@ -1,6 +1,6 @@
 module __GO_MODULE__
 
-go 1.24
+go 1.26
 
 require (
 	github.com/spf13/cobra v1.9.1

--- a/templates/go-service/skeleton/.github/workflows/ci.yml
+++ b/templates/go-service/skeleton/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       - name: Run go vet
         run: go vet ./...
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/templates/go-service/skeleton/Dockerfile
+++ b/templates/go-service/skeleton/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ──
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
@@ -12,7 +12,7 @@ COPY . .
 RUN CGO_ENABLED=1 go build -o /bin/server ./cmd/server
 
 # ── Runtime stage ──
-FROM alpine:3.21
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates
 

--- a/templates/go-service/skeleton/go.mod
+++ b/templates/go-service/skeleton/go.mod
@@ -1,6 +1,6 @@
 module __GO_MODULE__
 
-go 1.24
+go 1.26
 
 require (
 	github.com/go-chi/chi/v5 v5.3.0

--- a/templates/go-service/skeleton/internal/handler/handler_test.go
+++ b/templates/go-service/skeleton/internal/handler/handler_test.go
@@ -1,0 +1,249 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"__GO_MODULE__/internal/handler"
+	"__GO_MODULE__/internal/middleware"
+	"__GO_MODULE__/internal/repository"
+	"__GO_MODULE__/internal/service"
+)
+
+// newTestServer wires the router exactly as cmd/server/main.go does, so the
+// tests exercise the real HTTP surface: middleware chain, routes, handlers,
+// and the service layer behind them.
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	svc := service.NewExampleService()
+	exampleHandler := handler.NewExampleHandler(svc)
+
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recovery)
+	r.Use(middleware.MaxBody(1 << 20))
+
+	r.Get("/health", handler.Health)
+	r.Get("/readyz", handler.Readyz(nil))
+
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Get("/examples", exampleHandler.List)
+		r.Post("/examples", exampleHandler.Create)
+		r.Get("/examples/{id}", exampleHandler.Get)
+		r.Put("/examples/{id}", exampleHandler.Update)
+		r.Delete("/examples/{id}", exampleHandler.Delete)
+	})
+
+	ts := httptest.NewServer(r)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func decodeJSON[T any](t *testing.T, body io.Reader) T {
+	t.Helper()
+	var v T
+	if err := json.NewDecoder(body).Decode(&v); err != nil {
+		t.Fatalf("decoding response body: %v", err)
+	}
+	return v
+}
+
+func TestHealth(t *testing.T) {
+	ts := newTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+
+	body := decodeJSON[map[string]string](t, resp.Body)
+	if body["status"] != "ok" {
+		t.Errorf(`status field = %q, want "ok"`, body["status"])
+	}
+}
+
+func TestReadyz(t *testing.T) {
+	t.Run("nil checker reports ready", func(t *testing.T) {
+		ts := newTestServer(t)
+
+		resp, err := http.Get(ts.URL + "/readyz")
+		if err != nil {
+			t.Fatalf("GET /readyz: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		body := decodeJSON[map[string]string](t, resp.Body)
+		if body["status"] != "ready" {
+			t.Errorf(`status field = %q, want "ready"`, body["status"])
+		}
+	})
+
+	t.Run("failing checker reports not ready", func(t *testing.T) {
+		h := handler.Readyz(func(ctx context.Context) error {
+			return fmt.Errorf("db unreachable")
+		})
+
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+		}
+		body := decodeJSON[map[string]string](t, rec.Body)
+		if body["status"] != "not_ready" {
+			t.Errorf(`status field = %q, want "not_ready"`, body["status"])
+		}
+		if body["error"] != "db unreachable" {
+			t.Errorf(`error field = %q, want "db unreachable"`, body["error"])
+		}
+	})
+}
+
+func TestExampleLifecycle(t *testing.T) {
+	ts := newTestServer(t)
+	base := ts.URL + "/api/v1/examples"
+
+	// ── Create ──
+	payload := []byte(`{"name":"first","value":"v1"}`)
+	resp, err := http.Post(base, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST /examples: %v", err)
+	}
+	created := decodeJSON[repository.Example](t, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	if created.ID == "" {
+		t.Fatal("created example has empty id")
+	}
+	if created.Name != "first" || created.Value != "v1" {
+		t.Errorf("created = %+v, want name=first value=v1", created)
+	}
+
+	// ── Get ──
+	resp, err = http.Get(base + "/" + created.ID)
+	if err != nil {
+		t.Fatalf("GET /examples/%s: %v", created.ID, err)
+	}
+	got := decodeJSON[repository.Example](t, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got.ID != created.ID || got.Name != "first" {
+		t.Errorf("got = %+v, want id=%s name=first", got, created.ID)
+	}
+
+	// ── Update ──
+	req, err := http.NewRequest(http.MethodPut, base+"/"+created.ID, bytes.NewReader([]byte(`{"name":"renamed","value":"v2"}`)))
+	if err != nil {
+		t.Fatalf("building PUT request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /examples/%s: %v", created.ID, err)
+	}
+	updated := decodeJSON[repository.Example](t, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if updated.Name != "renamed" || updated.Value != "v2" {
+		t.Errorf("updated = %+v, want name=renamed value=v2", updated)
+	}
+
+	// ── List ──
+	resp, err = http.Get(base)
+	if err != nil {
+		t.Fatalf("GET /examples: %v", err)
+	}
+	list := decodeJSON[[]repository.Example](t, resp.Body)
+	resp.Body.Close()
+
+	if len(list) != 1 {
+		t.Fatalf("list length = %d, want 1", len(list))
+	}
+	if list[0].Name != "renamed" {
+		t.Errorf("listed name = %q, want %q", list[0].Name, "renamed")
+	}
+
+	// ── Delete ──
+	req, err = http.NewRequest(http.MethodDelete, base+"/"+created.ID, nil)
+	if err != nil {
+		t.Fatalf("building DELETE request: %v", err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /examples/%s: %v", created.ID, err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	// ── Get after delete ──
+	resp, err = http.Get(base + "/" + created.ID)
+	if err != nil {
+		t.Fatalf("GET after delete: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("get-after-delete status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestCreateRejectsInvalidJSON(t *testing.T) {
+	ts := newTestServer(t)
+
+	resp, err := http.Post(ts.URL+"/api/v1/examples", "application/json", bytes.NewReader([]byte(`{not json`)))
+	if err != nil {
+		t.Fatalf("POST /examples: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestGetUnknownIDReturns404(t *testing.T) {
+	ts := newTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/api/v1/examples/does-not-exist")
+	if err != nil {
+		t.Fatalf("GET /examples/does-not-exist: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}

--- a/templates/go-service/template.yaml
+++ b/templates/go-service/template.yaml
@@ -87,6 +87,6 @@ composition:
 
 prerequisites:
   - name: go
-    version: ">=1.24"
+    version: ">=1.26"
     purpose: "Go compilation and module management"
     optional: false

--- a/templates/infra-fly/skeleton/Dockerfile
+++ b/templates/infra-fly/skeleton/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ───────────────────────────────────────────────────────
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /src
 
@@ -10,7 +10,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app ./cmd/server
 
 # ── Runtime stage ─────────────────────────────────────────────────────
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates tzdata \
     && addgroup -S app && adduser -S app -G app

--- a/templates/infra-gcp/skeleton/Dockerfile
+++ b/templates/infra-gcp/skeleton/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ───────────────────────────────────────────────────────
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /src
 
@@ -10,7 +10,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app ./cmd/server
 
 # ── Runtime stage ─────────────────────────────────────────────────────
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates tzdata \
     && addgroup -S app && adduser -S app -G app

--- a/templates/llm-wiki/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/llm-wiki/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/module-analytics-ts/skeleton/src/analytics/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-analytics-ts/skeleton/src/analytics/resilience/__tests__/circuit-breaker.test.ts
@@ -47,6 +47,7 @@ describe("createCircuitBreaker", () => {
   });
 
   it("transitions to half-open after reset timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -58,16 +59,19 @@ describe("createCircuitBreaker", () => {
 
     expect(cb.getState()).toBe("open");
 
-    // Wait for reset timeout
-    await new Promise((r) => setTimeout(r, 150));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(150);
 
     // Next call should attempt (half-open)
     const result = await cb.execute(async () => "recovered");
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure during half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -77,13 +81,15 @@ describe("createCircuitBreaker", () => {
       throw new Error("fail");
     })).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 150));
+    vi.advanceTimersByTime(150);
 
     await expect(cb.execute(async () => {
       throw new Error("still failing");
     })).rejects.toThrow("still failing");
 
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("resets to closed state", async () => {

--- a/templates/module-auth-go/skeleton/go.mod
+++ b/templates/module-auth-go/skeleton/go.mod
@@ -1,6 +1,6 @@
 module __GO_MODULE__
 
-go 1.24
+go 1.26
 
 require (
 	github.com/MicahParks/keyfunc/v3 v3.3.11

--- a/templates/module-auth-ts/skeleton/src/auth/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-auth-ts/skeleton/src/auth/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open — should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/module-feature-flags-ts/skeleton/src/feature-flags/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-feature-flags-ts/skeleton/src/feature-flags/resilience/__tests__/circuit-breaker.test.ts
@@ -51,16 +51,19 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {

--- a/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/module-llm-providers/skeleton/src/llm-providers/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/resilience/__tests__/circuit-breaker.test.ts
@@ -47,6 +47,7 @@ describe("createCircuitBreaker", () => {
   });
 
   it("transitions to half-open after reset timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -58,16 +59,19 @@ describe("createCircuitBreaker", () => {
 
     expect(cb.getState()).toBe("open");
 
-    // Wait for reset timeout
-    await new Promise((r) => setTimeout(r, 150));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(150);
 
     // Next call should attempt (half-open)
     const result = await cb.execute(async () => "recovered");
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure during half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -77,13 +81,15 @@ describe("createCircuitBreaker", () => {
       throw new Error("fail");
     })).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 150));
+    vi.advanceTimersByTime(150);
 
     await expect(cb.execute(async () => {
       throw new Error("still failing");
     })).rejects.toThrow("still failing");
 
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("resets to closed state", async () => {

--- a/templates/module-media-ts/skeleton/src/media/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-media-ts/skeleton/src/media/resilience/__tests__/circuit-breaker.test.ts
@@ -47,6 +47,7 @@ describe("createCircuitBreaker", () => {
   });
 
   it("transitions to half-open after reset timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -58,16 +59,19 @@ describe("createCircuitBreaker", () => {
 
     expect(cb.getState()).toBe("open");
 
-    // Wait for reset timeout
-    await new Promise((r) => setTimeout(r, 150));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(150);
 
     // Next call should attempt (half-open)
     const result = await cb.execute(async () => "recovered");
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure during half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -77,13 +81,15 @@ describe("createCircuitBreaker", () => {
       throw new Error("fail");
     })).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 150));
+    vi.advanceTimersByTime(150);
 
     await expect(cb.execute(async () => {
       throw new Error("still failing");
     })).rejects.toThrow("still failing");
 
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("resets to closed state", async () => {

--- a/templates/module-notifications-ts/skeleton/src/notifications/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-notifications-ts/skeleton/src/notifications/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open — should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/module-project-mgmt-ts/skeleton/src/project-mgmt/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-project-mgmt-ts/skeleton/src/project-mgmt/resilience/__tests__/circuit-breaker.test.ts
@@ -47,6 +47,7 @@ describe("createCircuitBreaker", () => {
   });
 
   it("transitions to half-open after reset timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -58,16 +59,19 @@ describe("createCircuitBreaker", () => {
 
     expect(cb.getState()).toBe("open");
 
-    // Wait for reset timeout
-    await new Promise((r) => setTimeout(r, 150));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(150);
 
     // Next call should attempt (half-open)
     const result = await cb.execute(async () => "recovered");
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure during half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -77,13 +81,15 @@ describe("createCircuitBreaker", () => {
       throw new Error("fail");
     })).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 150));
+    vi.advanceTimersByTime(150);
 
     await expect(cb.execute(async () => {
       throw new Error("still failing");
     })).rejects.toThrow("still failing");
 
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("resets to closed state", async () => {

--- a/templates/module-search-ts/skeleton/src/search/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-search-ts/skeleton/src/search/resilience/__tests__/circuit-breaker.test.ts
@@ -47,6 +47,7 @@ describe("createCircuitBreaker", () => {
   });
 
   it("transitions to half-open after reset timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -58,16 +59,19 @@ describe("createCircuitBreaker", () => {
 
     expect(cb.getState()).toBe("open");
 
-    // Wait for reset timeout
-    await new Promise((r) => setTimeout(r, 150));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(150);
 
     // Next call should attempt (half-open)
     const result = await cb.execute(async () => "recovered");
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure during half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 100,
@@ -77,13 +81,15 @@ describe("createCircuitBreaker", () => {
       throw new Error("fail");
     })).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 150));
+    vi.advanceTimersByTime(150);
 
     await expect(cb.execute(async () => {
       throw new Error("still failing");
     })).rejects.toThrow("still failing");
 
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("resets to closed state", async () => {

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/__tests__/circuit-breaker.test.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/__tests__/circuit-breaker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   createCircuitBreaker,
   CircuitBreakerOpenError,
@@ -38,6 +38,7 @@ describe("circuit breaker", () => {
   });
 
   it("probes half-open after the reset timeout and closes on success", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 5,
@@ -46,25 +47,30 @@ describe("circuit breaker", () => {
     await expect(cb.execute(fail)).rejects.toThrow("boom");
     expect(cb.getState()).toBe("open");
 
-    // Wait past the reset window so the next call probes.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Advance past the reset window so the next call probes.
+    vi.advanceTimersByTime(10);
 
     await expect(cb.execute(ok)).resolves.toBe("ok");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens when the half-open probe fails", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({
       failureThreshold: 1,
       resetTimeoutMs: 5,
     });
 
     await expect(cb.execute(fail)).rejects.toThrow("boom");
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    vi.advanceTimersByTime(10);
 
     // The probe fails — breaker goes straight back to open.
     await expect(cb.execute(fail)).rejects.toThrow("boom");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset() returns the breaker to closed", async () => {
@@ -79,14 +85,17 @@ describe("circuit breaker", () => {
   });
 
   it("decays old failures outside the sliding window", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 2, windowMs: 5 });
 
     await expect(cb.execute(fail)).rejects.toThrow("boom");
-    // Let the first failure age out of the window.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Advance so the first failure ages out of the window.
+    vi.advanceTimersByTime(10);
 
     // A second failure alone shouldn't trip the breaker — the first decayed.
     await expect(cb.execute(fail)).rejects.toThrow("boom");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 });

--- a/templates/module-storage-ts/skeleton/src/storage/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-storage-ts/skeleton/src/storage/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open — should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/module-vector-store/skeleton/src/vector-store/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/module-vector-store/skeleton/src/vector-store/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open — should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/multimodal-pipeline/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/multimodal-pipeline/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/next-app/skeleton/Dockerfile
+++ b/templates/next-app/skeleton/Dockerfile
@@ -1,6 +1,6 @@
 # ── Build Stage ───────────────────────────────────────────────────────
 
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ RUN npm run build
 
 # ── Production Stage ──────────────────────────────────────────────────
 
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 
 WORKDIR /app
 

--- a/templates/next-app/skeleton/package.json
+++ b/templates/next-app/skeleton/package.json
@@ -32,7 +32,7 @@
     "@eslint/js": "^9.20.0",
     "@tailwindcss/postcss": "^4.1.0",
     "@testing-library/react": "^16.3.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^24.13.2",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "drizzle-kit": "^0.30.0",
@@ -45,6 +45,6 @@
     "vitest": "^3.1.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/templates/next-app/template.yaml
+++ b/templates/next-app/template.yaml
@@ -94,6 +94,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
+    version: ">=24"
     purpose: "Node.js runtime for the Next.js application"
     optional: false

--- a/templates/rag-pipeline/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/rag-pipeline/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open — should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });

--- a/templates/slack-bot/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
+++ b/templates/slack-bot/skeleton/src/resilience/__tests__/circuit-breaker.test.ts
@@ -54,42 +54,51 @@ describe("circuit breaker", () => {
   });
 
   it("transitions to half-open after timeout", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    // Wait for the reset timeout
-    await new Promise((r) => setTimeout(r, 60));
+    // Advance past the reset timeout
+    vi.advanceTimersByTime(60);
 
     // Next call should transition to half-open and execute
     const result = await cb.execute(() => Promise.resolve("recovered"));
     expect(result).toBe("recovered");
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("closes on success in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     await cb.execute(() => Promise.resolve("ok"));
     expect(cb.getState()).toBe("closed");
+
+    vi.useRealTimers();
   });
 
   it("re-opens on failure in half-open", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50 });
 
     await expect(cb.execute(() => Promise.reject(new Error("fail")))).rejects.toThrow("fail");
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Fail again during half-open -- should re-open
     await expect(cb.execute(() => Promise.reject(new Error("fail again")))).rejects.toThrow("fail again");
     expect(cb.getState()).toBe("open");
+
+    vi.useRealTimers();
   });
 
   it("reset returns to closed", async () => {
@@ -130,6 +139,7 @@ describe("circuit breaker", () => {
   });
 
   it("successful half-open probe clears failure timestamps", async () => {
+    vi.useFakeTimers();
     const cb = createCircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 50, windowMs: 60_000 });
 
     // Trip the breaker
@@ -138,7 +148,7 @@ describe("circuit breaker", () => {
     }
     expect(cb.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 60));
+    vi.advanceTimersByTime(60);
 
     // Successful probe resets to closed with clean slate
     await cb.execute(() => Promise.resolve("ok"));
@@ -148,5 +158,7 @@ describe("circuit breaker", () => {
     await expect(cb.execute(() => Promise.reject(new Error("f1")))).rejects.toThrow("f1");
     await expect(cb.execute(() => Promise.reject(new Error("f2")))).rejects.toThrow("f2");
     expect(cb.getState()).toBe("closed"); // only 2 of 3
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
See the six commit messages for full details.

## Summary
- Base images registry-resolved to current stable across all skeleton Dockerfiles (golang 1.26, alpine 3.24, node 24) with adjacent go.mod/engines/CI/prerequisite pins aligned
- Circuit-breaker tests drive fake timers instead of real sleeps — the actual blast radius was 23 templates, all fixed and green
- go-service + go-cli skeletons reach test parity (httptest integration + table-driven CLI tests, render-then-build verified)
- New library/runtime: vendorable zero-dep source of truth for the fleet-duplicated primitives — sliding-window injectable-clock circuit breaker, withTimeout/withRetry, createRegistry, WorkOS Directory client, and one unified PII policy (union of all three apps' category sets), 80 tests, own CI workflow. Tenant adoption is the follow-up.