### PR TITLE
Adopt the org prettier identity at the repo root

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-template.md
+++ b/.github/ISSUE_TEMPLATE/new-template.md
@@ -1,9 +1,9 @@
 ---
 name: New Template Request
 about: Propose a new template for the nanohype catalog
-title: "[Template] "
+title: '[Template] '
 labels: new-template
-assignees: ""
+assignees: ''
 ---
 
 ## Template Name

--- a/.github/actions/render-assert/README.md
+++ b/.github/actions/render-assert/README.md
@@ -3,7 +3,7 @@
 A composite GitHub Action that asserts **rendered** Kubernetes manifests carry no
 unfilled sentinels. It's the render-time complement to a source-file
 no-placeholders gate: a source scan catches sentinels you can see in the repo,
-this catches the ones that only appear *after* templating — chart defaults,
+this catches the ones that only appear _after_ templating — chart defaults,
 vendored charts, or an ARN a template builds from a value it never received.
 
 ## What it flags
@@ -44,10 +44,10 @@ action against the output:
 
 ## Inputs
 
-| input | default | description |
-|-------|---------|-------------|
-| `manifests` | `rendered` | Directory of rendered manifests to scan. |
-| `exclude` | `''` | Extended-regex matched against `file:line:match` result lines, to drop known-legitimate hits. |
+| input       | default    | description                                                                                   |
+| ----------- | ---------- | --------------------------------------------------------------------------------------------- |
+| `manifests` | `rendered` | Directory of rendered manifests to scan.                                                      |
+| `exclude`   | `''`       | Extended-regex matched against `file:line:match` result lines, to drop known-legitimate hits. |
 
 An empty manifests directory fails the action (a render step that produced nothing
 is a misconfiguration, not a pass).

--- a/.github/actions/render-assert/testdata/clean/serviceaccount.yaml
+++ b/.github/actions/render-assert/testdata/clean/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: tenants-demo
   annotations:
     # Empty at render time — injected at sync time. Not flagged.
-    eks.amazonaws.com/role-arn: ""
+    eks.amazonaws.com/role-arn: ''
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - "docs/**"
-      - "*.md"
+      - 'docs/**'
+      - '*.md'
   pull_request:
     paths:
-      - "docs/**"
-      - "*.md"
+      - 'docs/**'
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/template-doctor.yml
+++ b/.github/workflows/template-doctor.yml
@@ -4,23 +4,23 @@ on:
   # Weekly cron — Sunday 06:00 UTC. Full catalog runs take a while; the
   # weekly cadence matches how fast the ecosystem drifts in practice.
   schedule:
-    - cron: "0 6 * * 0"
+    - cron: '0 6 * * 0'
   # Gate PRs that touch templates, composites, or the doctor itself: fail on
   # hard errors so typecheck/build/lint/ref debt can't land silently. Advisory
   # findings (outdated deps, dead deps) are reported but don't block.
   pull_request:
     paths:
-      - "templates/**"
-      - "composites/**"
-      - "scripts/template-doctor/**"
-      - ".github/workflows/template-doctor.yml"
+      - 'templates/**'
+      - 'composites/**'
+      - 'scripts/template-doctor/**'
+      - '.github/workflows/template-doctor.yml'
   # Manual trigger for on-demand runs (e.g., before cutting a release).
   workflow_dispatch:
     inputs:
       only:
-        description: "Limit to specific check groups (comma-separated: ts,go,java,python,cross)"
+        description: 'Limit to specific check groups (comma-separated: ts,go,java,python,cross)'
         required: false
-        default: "ts,go,java,python,cross"
+        default: 'ts,go,java,python,cross'
 
 jobs:
   doctor:
@@ -37,25 +37,25 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: '22'
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           # go-service's pgx/otel deps require go 1.25; keep the doctor on a
           # current toolchain so it validates skeletons against what they build on.
-          go-version: "1.26"
+          go-version: '1.26'
 
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
-          java-version: "25"
+          distribution: 'temurin'
+          java-version: '25'
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: '3.12'
 
       - name: Run doctor
         id: doctor

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: '20'
           cache: npm
 
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: '20'
           cache: npm
 
       - name: Install dependencies
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: '22'
 
       - name: Run template tests
         run: |

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -12,12 +12,7 @@
     // Allow bare URLs
     "MD034": false,
     // Don't enforce table column padding style (compact vs aligned)
-    "MD060": false
+    "MD060": false,
   },
-  "globs": [
-    "**/*.md",
-    "!node_modules/**",
-    "!templates/*/skeleton/**",
-    "!.plans/**"
-  ]
+  "globs": ["**/*.md", "!node_modules/**", "!templates/*/skeleton/**", "!.plans/**"],
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+# Dependencies and build output
+node_modules/
+dist/
+package-lock.json
+
+# Generated — catalog.json is emitted by scripts/generate-catalog.mjs via
+# JSON.stringify(..., null, 2); prettier would collapse short arrays and
+# break verify:catalog's byte-diff. Regenerate, never reformat.
+catalog.json
+
+# Template skeletons are product — they ship to consumers with their own
+# per-template formatting. Deliberately excluded from the org identity pass.
+templates/*/skeleton/
+
+# Internal planning docs and issue drafts (mirrors lint:docs excludes)
+.plans/
+.github/ISSUE_DRAFTS/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,14 +23,14 @@ curl https://raw.githubusercontent.com/nanohype/nanohype/main/catalog.json \
 Render programmatically (TypeScript):
 
 ```ts
-import { GitHubSource, renderTemplate } from "@nanohype/sdk";
+import { GitHubSource, renderTemplate } from '@nanohype/sdk';
 
-const source = new GitHubSource("nanohype/nanohype");
+const source = new GitHubSource('nanohype/nanohype');
 await renderTemplate({
   source,
-  templateName: "rag-pipeline",
-  outputDir: "./my-rag-bot",
-  variables: { ProjectName: "my-rag-bot", LlmProvider: "anthropic" },
+  templateName: 'rag-pipeline',
+  outputDir: './my-rag-bot',
+  variables: { ProjectName: 'my-rag-bot', LlmProvider: 'anthropic' },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,82 +13,82 @@ Templates span four engineering categories plus composable modules. Beyond engin
 
 ### AI Systems
 
-| Template | Description | Tags |
-|---|---|---|
-| [agentic-loop](templates/agentic-loop/) | Autonomous agent with tool registry, memory, provider abstraction, eval harness | `typescript` `agent` `llm` |
-| [rag-pipeline](templates/rag-pipeline/) | TypeScript RAG pipeline with chunking, embedding, vector store, retrieval, generation | `typescript` `rag` `embeddings` |
-| [mcp-server-ts](templates/mcp-server-ts/) | TypeScript MCP server with tool/resource registration and Zod validation | `mcp` `typescript` `tools` |
-| [mcp-server-python](templates/mcp-server-python/) | Python MCP server with tool/resource registration | `mcp` `python` `tools` |
-| [eval-harness](templates/eval-harness/) | Standalone LLM evaluation framework with YAML suites, assertions, and reporters | `typescript` `eval` `testing` |
-| [prompt-library](templates/prompt-library/) | Versioned prompt management with YAML frontmatter and optional TypeScript SDK | `prompts` `yaml` `versioning` |
-| [a2a-agent](templates/a2a-agent/) | Agent-to-Agent protocol peer with skill registry, transport abstraction, and discovery | `typescript` `a2a` `agents` |
-| [guardrails](templates/guardrails/) | Input/output safety filters — prompt injection, PII, content policy, token limits | `typescript` `safety` `filters` |
-| [multimodal-pipeline](templates/multimodal-pipeline/) | Process images, audio, and video with AI models | `typescript` `multimodal` `ai` |
-| [fine-tune-pipeline](templates/fine-tune-pipeline/) | LLM fine-tuning pipeline with dataset preparation and training | `typescript` `fine-tuning` `llm` |
-| [data-pipeline](templates/data-pipeline/) | Data ingestion and transformation pipeline | `typescript` `data` `pipeline` |
-| [agent-orchestrator](templates/agent-orchestrator/) | Multi-agent orchestration with delegation and coordination | `typescript` `agents` `orchestrator` |
-| [ci-eval](templates/ci-eval/) | CI-integrated LLM evaluation with GitHub Actions | `typescript` `eval` `ci` |
+| Template                                              | Description                                                                            | Tags                                 |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------ |
+| [agentic-loop](templates/agentic-loop/)               | Autonomous agent with tool registry, memory, provider abstraction, eval harness        | `typescript` `agent` `llm`           |
+| [rag-pipeline](templates/rag-pipeline/)               | TypeScript RAG pipeline with chunking, embedding, vector store, retrieval, generation  | `typescript` `rag` `embeddings`      |
+| [mcp-server-ts](templates/mcp-server-ts/)             | TypeScript MCP server with tool/resource registration and Zod validation               | `mcp` `typescript` `tools`           |
+| [mcp-server-python](templates/mcp-server-python/)     | Python MCP server with tool/resource registration                                      | `mcp` `python` `tools`               |
+| [eval-harness](templates/eval-harness/)               | Standalone LLM evaluation framework with YAML suites, assertions, and reporters        | `typescript` `eval` `testing`        |
+| [prompt-library](templates/prompt-library/)           | Versioned prompt management with YAML frontmatter and optional TypeScript SDK          | `prompts` `yaml` `versioning`        |
+| [a2a-agent](templates/a2a-agent/)                     | Agent-to-Agent protocol peer with skill registry, transport abstraction, and discovery | `typescript` `a2a` `agents`          |
+| [guardrails](templates/guardrails/)                   | Input/output safety filters — prompt injection, PII, content policy, token limits      | `typescript` `safety` `filters`      |
+| [multimodal-pipeline](templates/multimodal-pipeline/) | Process images, audio, and video with AI models                                        | `typescript` `multimodal` `ai`       |
+| [fine-tune-pipeline](templates/fine-tune-pipeline/)   | LLM fine-tuning pipeline with dataset preparation and training                         | `typescript` `fine-tuning` `llm`     |
+| [data-pipeline](templates/data-pipeline/)             | Data ingestion and transformation pipeline                                             | `typescript` `data` `pipeline`       |
+| [agent-orchestrator](templates/agent-orchestrator/)   | Multi-agent orchestration with delegation and coordination                             | `typescript` `agents` `orchestrator` |
+| [ci-eval](templates/ci-eval/)                         | CI-integrated LLM evaluation with GitHub Actions                                       | `typescript` `eval` `ci`             |
 
 ### Applications
 
-| Template | Description | Tags |
-|---|---|---|
-| [go-cli](templates/go-cli/) | Cobra CLI with Viper config, slog logging, GoReleaser release workflow | `go` `cli` `cobra` |
-| [ts-service](templates/ts-service/) | Hono HTTP service with database drivers, JWT auth, and OpenTelemetry | `typescript` `hono` `api` |
-| [go-service](templates/go-service/) | Go HTTP service with chi router, repository pattern, and OpenTelemetry | `go` `chi` `api` |
-| [chrome-ext](templates/chrome-ext/) | Chrome extension (Manifest V3) with React sidepanel for AI interactions | `chrome-extension` `react` `vite` |
-| [vscode-ext](templates/vscode-ext/) | VS Code extension with optional React webview and AI provider integration | `vscode` `extension` `typescript` |
-| [next-app](templates/next-app/) | Next.js 15 App Router with streaming AI chat, Tailwind, auth, and database | `typescript` `nextjs` `react` |
-| [slack-bot](templates/slack-bot/) | Slack bot with event handling and slash commands | `typescript` `slack` `bot` |
-| [discord-bot](templates/discord-bot/) | Discord bot with command registration and event handling | `typescript` `discord` `bot` |
-| [electron-app](templates/electron-app/) | Electron desktop application with IPC and auto-updates | `typescript` `electron` `desktop` |
-| [api-gateway](templates/api-gateway/) | API gateway with routing, rate limiting, and upstream management | `typescript` `gateway` `api` |
-| [worker-service](templates/worker-service/) | Background worker service with job processing | `typescript` `worker` `jobs` |
-| [spring-boot-service](templates/spring-boot-service/) | Spring Boot 4 HTTP service on JDK 25 with Spring Data JPA, Flyway, Micrometer + OTel, structured logging | `java` `spring-boot` `api` |
+| Template                                              | Description                                                                                              | Tags                              |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| [go-cli](templates/go-cli/)                           | Cobra CLI with Viper config, slog logging, GoReleaser release workflow                                   | `go` `cli` `cobra`                |
+| [ts-service](templates/ts-service/)                   | Hono HTTP service with database drivers, JWT auth, and OpenTelemetry                                     | `typescript` `hono` `api`         |
+| [go-service](templates/go-service/)                   | Go HTTP service with chi router, repository pattern, and OpenTelemetry                                   | `go` `chi` `api`                  |
+| [chrome-ext](templates/chrome-ext/)                   | Chrome extension (Manifest V3) with React sidepanel for AI interactions                                  | `chrome-extension` `react` `vite` |
+| [vscode-ext](templates/vscode-ext/)                   | VS Code extension with optional React webview and AI provider integration                                | `vscode` `extension` `typescript` |
+| [next-app](templates/next-app/)                       | Next.js 15 App Router with streaming AI chat, Tailwind, auth, and database                               | `typescript` `nextjs` `react`     |
+| [slack-bot](templates/slack-bot/)                     | Slack bot with event handling and slash commands                                                         | `typescript` `slack` `bot`        |
+| [discord-bot](templates/discord-bot/)                 | Discord bot with command registration and event handling                                                 | `typescript` `discord` `bot`      |
+| [electron-app](templates/electron-app/)               | Electron desktop application with IPC and auto-updates                                                   | `typescript` `electron` `desktop` |
+| [api-gateway](templates/api-gateway/)                 | API gateway with routing, rate limiting, and upstream management                                         | `typescript` `gateway` `api`      |
+| [worker-service](templates/worker-service/)           | Background worker service with job processing                                                            | `typescript` `worker` `jobs`      |
+| [spring-boot-service](templates/spring-boot-service/) | Spring Boot 4 HTTP service on JDK 25 with Spring Data JPA, Flyway, Micrometer + OTel, structured logging | `java` `spring-boot` `api`        |
 
 ### Infrastructure
 
-| Template | Description | Tags |
-|---|---|---|
-| [infra-aws](templates/infra-aws/) | AWS CDK with Lambda/ECS, VPC, RDS, and CloudWatch monitoring | `aws` `cdk` `infrastructure` |
-| [infra-fly](templates/infra-fly/) | Fly.io deployment with Dockerfile, fly.toml, and CI/CD | `fly` `deployment` `docker` |
-| [infra-gcp](templates/infra-gcp/) | GCP Cloud Run with Cloud SQL, monitoring, and GitHub Actions | `gcp` `cloud-run` `infrastructure` |
-| [infra-vercel](templates/infra-vercel/) | Vercel deployment with edge functions and CI/CD | `vercel` `deployment` `edge` |
-| [infra-druid](templates/infra-druid/) | Apache Druid cluster with ingestion and query configuration | `druid` `analytics` `infrastructure` |
-| [infra-cloudflare](templates/infra-cloudflare/) | Cloudflare Workers with KV, D1, and R2 | `cloudflare` `workers` `infrastructure` |
-| [k8s-deploy](templates/k8s-deploy/) | Kubernetes manifests and Helm chart with Ingress, HPA, and CI/CD | `kubernetes` `helm` `deployment` |
-| [istio-policy](templates/istio-policy/) | Istio policy bundle — AuthorizationPolicy, RequestAuthentication, JWT issuer + JWKs wiring | `istio` `service-mesh` `auth` |
-| [monorepo](templates/monorepo/) | Turborepo/pnpm workspace with shared packages and CI | `monorepo` `turborepo` `pnpm` |
-| [monitoring-stack](templates/monitoring-stack/) | Observability infrastructure with metrics, logs, and traces | `monitoring` `observability` `infrastructure` |
+| Template                                        | Description                                                                                | Tags                                          |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| [infra-aws](templates/infra-aws/)               | AWS CDK with Lambda/ECS, VPC, RDS, and CloudWatch monitoring                               | `aws` `cdk` `infrastructure`                  |
+| [infra-fly](templates/infra-fly/)               | Fly.io deployment with Dockerfile, fly.toml, and CI/CD                                     | `fly` `deployment` `docker`                   |
+| [infra-gcp](templates/infra-gcp/)               | GCP Cloud Run with Cloud SQL, monitoring, and GitHub Actions                               | `gcp` `cloud-run` `infrastructure`            |
+| [infra-vercel](templates/infra-vercel/)         | Vercel deployment with edge functions and CI/CD                                            | `vercel` `deployment` `edge`                  |
+| [infra-druid](templates/infra-druid/)           | Apache Druid cluster with ingestion and query configuration                                | `druid` `analytics` `infrastructure`          |
+| [infra-cloudflare](templates/infra-cloudflare/) | Cloudflare Workers with KV, D1, and R2                                                     | `cloudflare` `workers` `infrastructure`       |
+| [k8s-deploy](templates/k8s-deploy/)             | Kubernetes manifests and Helm chart with Ingress, HPA, and CI/CD                           | `kubernetes` `helm` `deployment`              |
+| [istio-policy](templates/istio-policy/)         | Istio policy bundle — AuthorizationPolicy, RequestAuthentication, JWT issuer + JWKs wiring | `istio` `service-mesh` `auth`                 |
+| [monorepo](templates/monorepo/)                 | Turborepo/pnpm workspace with shared packages and CI                                       | `monorepo` `turborepo` `pnpm`                 |
+| [monitoring-stack](templates/monitoring-stack/) | Observability infrastructure with metrics, logs, and traces                                | `monitoring` `observability` `infrastructure` |
 
 ### Composable Modules
 
-| Template | Description | Tags |
-|---|---|---|
-| [module-auth-ts](templates/module-auth-ts/) | Authentication middleware with pluggable providers (JWT, Clerk, Auth0, Supabase, API key) | `auth` `middleware` `jwt` |
-| [module-auth-go](templates/module-auth-go/) | Go HTTP auth middleware with pluggable providers (JWT/JWKS, Auth0, Clerk, Supabase, API key) | `auth` `go` `middleware` |
-| [module-database-ts](templates/module-database-ts/) | Drizzle ORM with pluggable drivers (PostgreSQL, SQLite, Turso) | `database` `drizzle` `orm` |
-| [module-observability-ts](templates/module-observability-ts/) | OpenTelemetry instrumentation with pluggable exporters (console, OTLP, Datadog) | `observability` `opentelemetry` `tracing` |
-| [module-storage-ts](templates/module-storage-ts/) | Blob storage abstraction with pluggable backends (local, S3, R2, GCS) | `storage` `s3` `blob` |
-| [module-queue-ts](templates/module-queue-ts/) | Background job processing with pluggable brokers (in-memory, BullMQ, SQS) | `queue` `jobs` `workers` |
-| [module-cache-ts](templates/module-cache-ts/) | Caching layer with pluggable backends (memory, Redis) | `cache` `redis` `performance` |
-| [module-rate-limit-ts](templates/module-rate-limit-ts/) | Rate limiting with pluggable algorithms (token bucket, sliding window) | `rate-limit` `throttle` `middleware` |
-| [module-webhook-ts](templates/module-webhook-ts/) | Webhook ingestion and delivery with signature verification | `webhook` `events` `middleware` |
-| [module-notifications-ts](templates/module-notifications-ts/) | Multi-channel notifications (email, SMS, push) | `notifications` `email` `messaging` |
-| [module-oauth-delegation-ts](templates/module-oauth-delegation-ts/) | Outbound OAuth 2.0 with PKCE, HMAC-signed state cookies, per-user token storage, refresh-before-expiry | `oauth` `delegation` `pkce` |
-| [module-search-ts](templates/module-search-ts/) | Full-text search with pluggable backends (Algolia, Typesense, Meilisearch) | `search` `full-text` `algolia` |
-| [module-knowledge-base-ts](templates/module-knowledge-base-ts/) | Knowledge base providers (Notion, Confluence, Google Docs, Coda) normalized to markdown | `knowledge-base` `notion` `confluence` |
-| [module-project-mgmt-ts](templates/module-project-mgmt-ts/) | Project management providers (Linear, Jira, Asana, Shortcut) | `linear` `jira` `pm` |
-| [module-analytics-ts](templates/module-analytics-ts/) | Product analytics with pluggable backends (Segment, PostHog, Mixpanel, Amplitude) | `analytics` `events` `posthog` |
-| [module-media-ts](templates/module-media-ts/) | Media processing and delivery (Cloudinary, Uploadcare, imgix) | `media` `images` `cdn` |
-| [module-llm-gateway](templates/module-llm-gateway/) | LLM provider gateway with routing and fallback | `llm` `gateway` `ai` |
-| [module-llm-providers](templates/module-llm-providers/) | Shared LLM provider pack (Anthropic, OpenAI, Groq core; Bedrock/Azure/Vertex/HF/Ollama optional) | `llm` `providers` `ai` |
-| [module-vector-store](templates/module-vector-store/) | Vector store abstraction with pluggable backends | `vectors` `embeddings` `ai` |
-| [module-semantic-cache](templates/module-semantic-cache/) | Semantic caching for LLM responses using embeddings | `cache` `semantic` `ai` |
-| [module-llm-observability](templates/module-llm-observability/) | LLM-specific observability with cost and latency tracking | `observability` `llm` `cost` |
-| [module-billing-ts](templates/module-billing-ts/) | Usage-based billing and subscription management | `billing` `payments` `saas` |
-| [module-feature-flags-ts](templates/module-feature-flags-ts/) | Feature flag management with evaluation rules | `feature-flags` `toggles` `configuration` |
-| [module-spring-security](templates/module-spring-security/) | Drop-in Spring Security module — OIDC JWT resource server, header API keys, multi-provider filter chain | `java` `spring-security` `oidc` |
+| Template                                                            | Description                                                                                             | Tags                                      |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| [module-auth-ts](templates/module-auth-ts/)                         | Authentication middleware with pluggable providers (JWT, Clerk, Auth0, Supabase, API key)               | `auth` `middleware` `jwt`                 |
+| [module-auth-go](templates/module-auth-go/)                         | Go HTTP auth middleware with pluggable providers (JWT/JWKS, Auth0, Clerk, Supabase, API key)            | `auth` `go` `middleware`                  |
+| [module-database-ts](templates/module-database-ts/)                 | Drizzle ORM with pluggable drivers (PostgreSQL, SQLite, Turso)                                          | `database` `drizzle` `orm`                |
+| [module-observability-ts](templates/module-observability-ts/)       | OpenTelemetry instrumentation with pluggable exporters (console, OTLP, Datadog)                         | `observability` `opentelemetry` `tracing` |
+| [module-storage-ts](templates/module-storage-ts/)                   | Blob storage abstraction with pluggable backends (local, S3, R2, GCS)                                   | `storage` `s3` `blob`                     |
+| [module-queue-ts](templates/module-queue-ts/)                       | Background job processing with pluggable brokers (in-memory, BullMQ, SQS)                               | `queue` `jobs` `workers`                  |
+| [module-cache-ts](templates/module-cache-ts/)                       | Caching layer with pluggable backends (memory, Redis)                                                   | `cache` `redis` `performance`             |
+| [module-rate-limit-ts](templates/module-rate-limit-ts/)             | Rate limiting with pluggable algorithms (token bucket, sliding window)                                  | `rate-limit` `throttle` `middleware`      |
+| [module-webhook-ts](templates/module-webhook-ts/)                   | Webhook ingestion and delivery with signature verification                                              | `webhook` `events` `middleware`           |
+| [module-notifications-ts](templates/module-notifications-ts/)       | Multi-channel notifications (email, SMS, push)                                                          | `notifications` `email` `messaging`       |
+| [module-oauth-delegation-ts](templates/module-oauth-delegation-ts/) | Outbound OAuth 2.0 with PKCE, HMAC-signed state cookies, per-user token storage, refresh-before-expiry  | `oauth` `delegation` `pkce`               |
+| [module-search-ts](templates/module-search-ts/)                     | Full-text search with pluggable backends (Algolia, Typesense, Meilisearch)                              | `search` `full-text` `algolia`            |
+| [module-knowledge-base-ts](templates/module-knowledge-base-ts/)     | Knowledge base providers (Notion, Confluence, Google Docs, Coda) normalized to markdown                 | `knowledge-base` `notion` `confluence`    |
+| [module-project-mgmt-ts](templates/module-project-mgmt-ts/)         | Project management providers (Linear, Jira, Asana, Shortcut)                                            | `linear` `jira` `pm`                      |
+| [module-analytics-ts](templates/module-analytics-ts/)               | Product analytics with pluggable backends (Segment, PostHog, Mixpanel, Amplitude)                       | `analytics` `events` `posthog`            |
+| [module-media-ts](templates/module-media-ts/)                       | Media processing and delivery (Cloudinary, Uploadcare, imgix)                                           | `media` `images` `cdn`                    |
+| [module-llm-gateway](templates/module-llm-gateway/)                 | LLM provider gateway with routing and fallback                                                          | `llm` `gateway` `ai`                      |
+| [module-llm-providers](templates/module-llm-providers/)             | Shared LLM provider pack (Anthropic, OpenAI, Groq core; Bedrock/Azure/Vertex/HF/Ollama optional)        | `llm` `providers` `ai`                    |
+| [module-vector-store](templates/module-vector-store/)               | Vector store abstraction with pluggable backends                                                        | `vectors` `embeddings` `ai`               |
+| [module-semantic-cache](templates/module-semantic-cache/)           | Semantic caching for LLM responses using embeddings                                                     | `cache` `semantic` `ai`                   |
+| [module-llm-observability](templates/module-llm-observability/)     | LLM-specific observability with cost and latency tracking                                               | `observability` `llm` `cost`              |
+| [module-billing-ts](templates/module-billing-ts/)                   | Usage-based billing and subscription management                                                         | `billing` `payments` `saas`               |
+| [module-feature-flags-ts](templates/module-feature-flags-ts/)       | Feature flag management with evaluation rules                                                           | `feature-flags` `toggles` `configuration` |
+| [module-spring-security](templates/module-spring-security/)         | Drop-in Spring Security module — OIDC JWT resource server, header API keys, multi-provider filter chain | `java` `spring-security` `oidc`           |
 
 ### Cross-Functional Templates
 
@@ -110,32 +110,32 @@ Scaffolding tools read `template.yaml`, collect variable values from the user, a
 
 Pre-configured multi-template stacks in `composites/`:
 
-| Composite | Use case |
-|---|---|
-| [proof-of-concept](composites/proof-of-concept.yaml) | Minimal AI agent + evals — fastest path to a working prototype |
-| [ai-chatbot](composites/ai-chatbot.yaml) | Customer-facing chatbot with agent, service, auth, and deployment |
-| [document-intelligence](composites/document-intelligence.yaml) | Document search and Q&A with RAG, storage, and database |
-| [rag-agent](composites/rag-agent.yaml) | AI agent using RAG as a knowledge tool |
-| [safe-ai-agent](composites/safe-ai-agent.yaml) | Agent with guardrails, evals, and prompt management |
-| [multi-agent](composites/multi-agent.yaml) | A2A protocol peers with MCP tools, guardrails, and orchestration |
-| [ai-web-app](composites/ai-web-app.yaml) | Full-stack Next.js app with RAG, auth, database, and observability |
-| [mcp-toolkit](composites/mcp-toolkit.yaml) | MCP server with prompts and evals |
-| [chrome-ai-extension](composites/chrome-ai-extension.yaml) | Chrome extension backed by MCP tools |
-| [vscode-ai-extension](composites/vscode-ai-extension.yaml) | VS Code extension with AI, MCP, and prompts |
-| [production-api](composites/production-api.yaml) | Full-stack API with auth, database, cache, rate limiting, queue, observability |
-| [go-microservice](composites/go-microservice.yaml) | Go service with evals and Fly.io deployment |
-| [background-processor](composites/background-processor.yaml) | Async job processing with queue, storage, and database |
-| [internal-tool](composites/internal-tool.yaml) | CLI or browser extension with MCP tools |
-| [enterprise-ai](composites/enterprise-ai.yaml) | Full enterprise stack — agents, RAG, guardrails, evals, K8s |
-| [eval-suite](composites/eval-suite.yaml) | Standalone eval infrastructure with prompts and safety testing |
-| [cost-optimized-ai](composites/cost-optimized-ai.yaml) | LLM gateway with cost-aware routing, semantic caching, and cost tracking |
-| [ai-platform](composites/ai-platform.yaml) | Full AI platform with service, gateway, vectors, pipeline, auth, billing, monitoring |
-| [agent-team](composites/agent-team.yaml) | Multi-agent system with orchestrator, specialized agents, evals, and MCP tools |
-| [spring-boot-microservice](composites/spring-boot-microservice.yaml) | Spring Boot 4 service on JDK 25 with K8s deploy and optional Grafana + Prometheus + Loki |
-| [identity-aware-service](composites/identity-aware-service.yaml) | Spring Boot 4 service with Istio mesh-edge auth plus Spring Security resource server (defense in depth) |
-| [client-engagement](composites/client-engagement.yaml) | Proposal, battle cards, brand guidelines, campaign brief, onboarding playbook (non-engineering) |
-| [product-launch](composites/product-launch.yaml) | Cross-functional launch spanning eng through marketing — Next.js app, design system, PRD, campaign, runbook |
-| [research-to-prototype](composites/research-to-prototype.yaml) | PRD + agentic-loop prototype + optional test plan — idea to validated POC |
+| Composite                                                            | Use case                                                                                                    |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [proof-of-concept](composites/proof-of-concept.yaml)                 | Minimal AI agent + evals — fastest path to a working prototype                                              |
+| [ai-chatbot](composites/ai-chatbot.yaml)                             | Customer-facing chatbot with agent, service, auth, and deployment                                           |
+| [document-intelligence](composites/document-intelligence.yaml)       | Document search and Q&A with RAG, storage, and database                                                     |
+| [rag-agent](composites/rag-agent.yaml)                               | AI agent using RAG as a knowledge tool                                                                      |
+| [safe-ai-agent](composites/safe-ai-agent.yaml)                       | Agent with guardrails, evals, and prompt management                                                         |
+| [multi-agent](composites/multi-agent.yaml)                           | A2A protocol peers with MCP tools, guardrails, and orchestration                                            |
+| [ai-web-app](composites/ai-web-app.yaml)                             | Full-stack Next.js app with RAG, auth, database, and observability                                          |
+| [mcp-toolkit](composites/mcp-toolkit.yaml)                           | MCP server with prompts and evals                                                                           |
+| [chrome-ai-extension](composites/chrome-ai-extension.yaml)           | Chrome extension backed by MCP tools                                                                        |
+| [vscode-ai-extension](composites/vscode-ai-extension.yaml)           | VS Code extension with AI, MCP, and prompts                                                                 |
+| [production-api](composites/production-api.yaml)                     | Full-stack API with auth, database, cache, rate limiting, queue, observability                              |
+| [go-microservice](composites/go-microservice.yaml)                   | Go service with evals and Fly.io deployment                                                                 |
+| [background-processor](composites/background-processor.yaml)         | Async job processing with queue, storage, and database                                                      |
+| [internal-tool](composites/internal-tool.yaml)                       | CLI or browser extension with MCP tools                                                                     |
+| [enterprise-ai](composites/enterprise-ai.yaml)                       | Full enterprise stack — agents, RAG, guardrails, evals, K8s                                                 |
+| [eval-suite](composites/eval-suite.yaml)                             | Standalone eval infrastructure with prompts and safety testing                                              |
+| [cost-optimized-ai](composites/cost-optimized-ai.yaml)               | LLM gateway with cost-aware routing, semantic caching, and cost tracking                                    |
+| [ai-platform](composites/ai-platform.yaml)                           | Full AI platform with service, gateway, vectors, pipeline, auth, billing, monitoring                        |
+| [agent-team](composites/agent-team.yaml)                             | Multi-agent system with orchestrator, specialized agents, evals, and MCP tools                              |
+| [spring-boot-microservice](composites/spring-boot-microservice.yaml) | Spring Boot 4 service on JDK 25 with K8s deploy and optional Grafana + Prometheus + Loki                    |
+| [identity-aware-service](composites/identity-aware-service.yaml)     | Spring Boot 4 service with Istio mesh-edge auth plus Spring Security resource server (defense in depth)     |
+| [client-engagement](composites/client-engagement.yaml)               | Proposal, battle cards, brand guidelines, campaign brief, onboarding playbook (non-engineering)             |
+| [product-launch](composites/product-launch.yaml)                     | Cross-functional launch spanning eng through marketing — Next.js app, design system, PRD, campaign, runbook |
+| [research-to-prototype](composites/research-to-prototype.yaml)       | PRD + agentic-loop prototype + optional test plan — idea to validated POC                                   |
 
 Composites define which templates to scaffold, where to nest them, and how variables flow across templates. See the [composite contract](docs/spec/composite-contract.md) for the specification.
 

--- a/composites/agent-team.yaml
+++ b/composites/agent-team.yaml
@@ -1,67 +1,67 @@
 apiVersion: nanohype/v1
 kind: composite
 name: agent-team
-displayName: "Agent Team"
+displayName: 'Agent Team'
 description: >
   Multi-agent system with a central orchestrator, specialized agents
   for research and writing, an evaluation harness, and MCP tool
   server. Agents coordinate through the orchestrator, each with
   distinct roles and capabilities.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, agents, orchestrator, multi-agent, mcp]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for agent reasoning"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for agent reasoning'
+    default: 'anthropic'
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: agent-orchestrator
     path: packages/orchestrator
     variables:
-      ProjectName: "${ProjectName}-orchestrator"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-orchestrator'
+      LlmProvider: '${LlmProvider}'
 
   - template: agentic-loop
     path: packages/agents/researcher
     variables:
-      ProjectName: "${ProjectName}-researcher"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-researcher'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
 
   - template: agentic-loop
     path: packages/agents/writer
     variables:
-      ProjectName: "${ProjectName}-writer"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-writer'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
 
   - template: eval-harness
     path: packages/evals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: mcp-server-ts
     path: packages/tools
     variables:
-      ProjectName: "${ProjectName}-tools"
-      ServerName: "${ProjectName} Tools"
-      Transport: "stdio"
+      ProjectName: '${ProjectName}-tools'
+      ServerName: '${ProjectName} Tools'
+      Transport: 'stdio'

--- a/composites/ai-chatbot.yaml
+++ b/composites/ai-chatbot.yaml
@@ -1,73 +1,73 @@
 apiVersion: nanohype/v1
 kind: composite
 name: ai-chatbot
-displayName: "AI Chatbot"
+displayName: 'AI Chatbot'
 description: >
   Full-stack AI chatbot with agentic loop, HTTP service,
   authentication, evaluation harness, and deployment.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, chatbot, fullstack, typescript]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for AI features"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for AI features'
+    default: 'anthropic'
 
   - name: IncludeEvals
     type: bool
-    placeholder: "__INCLUDE_EVALS__"
-    description: "Include evaluation harness"
+    placeholder: '__INCLUDE_EVALS__'
+    description: 'Include evaluation harness'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
       IncludeSharedUi: false
 
   - template: agentic-loop
     path: packages/ai
     variables:
-      ProjectName: "${ProjectName}-ai"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-ai'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
       IncludeEval: false
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
       IncludeDocker: true
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
-      AuthProvider: "jwt"
+      ProjectName: '${ProjectName}-auth'
+      AuthProvider: 'jwt'
 
   - template: eval-harness
     path: packages/evals
     condition: IncludeEvals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: infra-fly
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      AppName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
+      AppName: '${ProjectName}'
       IncludeCi: true

--- a/composites/ai-platform.yaml
+++ b/composites/ai-platform.yaml
@@ -1,91 +1,91 @@
 apiVersion: nanohype/v1
 kind: composite
 name: ai-platform
-displayName: "AI Platform"
+displayName: 'AI Platform'
 description: >
   Full AI platform with HTTP service, LLM gateway, vector store,
   data pipeline, auth, billing, and monitoring. Everything needed
   to ship a production AI product with usage-based billing and
   operational visibility.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, platform, fullstack, billing, typescript]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for AI features"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for AI features'
+    default: 'anthropic'
 
   - name: DatabaseDriver
     type: string
-    placeholder: "__DATABASE_DRIVER__"
-    description: "Database driver"
-    default: "postgres"
+    placeholder: '__DATABASE_DRIVER__'
+    description: 'Database driver'
+    default: 'postgres'
 
   - name: IncludeBilling
     type: bool
-    placeholder: "__INCLUDE_BILLING__"
-    description: "Include billing and usage tracking"
+    placeholder: '__INCLUDE_BILLING__'
+    description: 'Include billing and usage tracking'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
       IncludeDocker: true
 
   - template: module-llm-gateway
     path: packages/gateway
     variables:
-      ProjectName: "${ProjectName}-gateway"
-      DefaultProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-gateway'
+      DefaultProvider: '${LlmProvider}'
 
   - template: module-vector-store
     path: packages/vectors
     variables:
-      ProjectName: "${ProjectName}-vectors"
+      ProjectName: '${ProjectName}-vectors'
 
   - template: data-pipeline
     path: packages/pipeline
     variables:
-      ProjectName: "${ProjectName}-pipeline"
+      ProjectName: '${ProjectName}-pipeline'
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
-      AuthProvider: "jwt"
+      ProjectName: '${ProjectName}-auth'
+      AuthProvider: 'jwt'
 
   - template: module-billing-ts
     path: packages/billing
     condition: IncludeBilling
     variables:
-      ProjectName: "${ProjectName}-billing"
+      ProjectName: '${ProjectName}-billing'
 
   - template: module-database-ts
     path: packages/db
     variables:
-      ProjectName: "${ProjectName}-db"
-      DatabaseDriver: "${DatabaseDriver}"
+      ProjectName: '${ProjectName}-db'
+      DatabaseDriver: '${DatabaseDriver}'
 
   - template: monitoring-stack
     path: infra/monitoring
     variables:
-      ProjectName: "${ProjectName}-monitoring"
+      ProjectName: '${ProjectName}-monitoring'

--- a/composites/ai-web-app.yaml
+++ b/composites/ai-web-app.yaml
@@ -1,54 +1,54 @@
 apiVersion: nanohype/v1
 kind: composite
 name: ai-web-app
-displayName: "AI Web Application"
+displayName: 'AI Web Application'
 description: >
   Full-stack web application with Next.js frontend, RAG pipeline,
   authentication, database, and deployment.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, nextjs, fullstack, rag, typescript]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for AI features"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for AI features'
+    default: 'anthropic'
 
   - name: IncludeRag
     type: bool
-    placeholder: "__INCLUDE_RAG__"
-    description: "Include RAG pipeline for document search"
+    placeholder: '__INCLUDE_RAG__'
+    description: 'Include RAG pipeline for document search'
     default: true
 
   - name: IncludeEvals
     type: bool
-    placeholder: "__INCLUDE_EVALS__"
-    description: "Include evaluation harness"
+    placeholder: '__INCLUDE_EVALS__'
+    description: 'Include evaluation harness'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
       IncludeSharedUi: true
 
   - template: next-app
     path: apps/web
     variables:
-      ProjectName: "${ProjectName}-web"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-web'
+      LlmProvider: '${LlmProvider}'
       IncludeAuth: true
       IncludeDatabase: true
       IncludeDocker: false
@@ -57,40 +57,40 @@ templates:
     path: packages/rag
     condition: IncludeRag
     variables:
-      ProjectName: "${ProjectName}-rag"
-      LlmProvider: "${LlmProvider}"
-      VectorStore: "pgvector"
+      ProjectName: '${ProjectName}-rag'
+      LlmProvider: '${LlmProvider}'
+      VectorStore: 'pgvector'
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
-      AuthProvider: "clerk"
+      ProjectName: '${ProjectName}-auth'
+      AuthProvider: 'clerk'
 
   - template: module-database-ts
     path: packages/db
     variables:
-      ProjectName: "${ProjectName}-db"
-      DatabaseDriver: "postgres"
+      ProjectName: '${ProjectName}-db'
+      DatabaseDriver: 'postgres'
 
   - template: module-observability-ts
     path: packages/observability
     variables:
-      ProjectName: "${ProjectName}-otel"
-      Exporter: "otlp"
+      ProjectName: '${ProjectName}-otel'
+      Exporter: 'otlp'
 
   - template: eval-harness
     path: packages/evals
     condition: IncludeEvals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: infra-aws
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      ComputeTarget: "ecs"
+      ProjectName: '${ProjectName}'
+      ComputeTarget: 'ecs'
       IncludeVpc: true
       IncludeRds: true
       IncludeMonitoring: true

--- a/composites/background-processor.yaml
+++ b/composites/background-processor.yaml
@@ -1,71 +1,71 @@
 apiVersion: nanohype/v1
 kind: composite
 name: background-processor
-displayName: "Background Processor"
+displayName: 'Background Processor'
 description: >
   Async job processing service with queue, database,
   storage, observability, and deployment. For workloads
   that don't need synchronous responses.
-version: "0.1.0"
+version: '0.1.0'
 tags: [queue, worker, async, service]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: QueueProvider
     type: string
-    placeholder: "__QUEUE_PROVIDER__"
-    description: "Queue backend"
-    default: "bullmq"
+    placeholder: '__QUEUE_PROVIDER__'
+    description: 'Queue backend'
+    default: 'bullmq'
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: ts-service
     path: apps/worker
     variables:
-      ProjectName: "${ProjectName}-worker"
+      ProjectName: '${ProjectName}-worker'
       IncludeDocker: true
 
   - template: module-queue-ts
     path: packages/queue
     variables:
-      ProjectName: "${ProjectName}-queue"
-      QueueProvider: "${QueueProvider}"
+      ProjectName: '${ProjectName}-queue'
+      QueueProvider: '${QueueProvider}'
 
   - template: module-database-ts
     path: packages/db
     variables:
-      ProjectName: "${ProjectName}-db"
-      DatabaseDriver: "postgres"
+      ProjectName: '${ProjectName}-db'
+      DatabaseDriver: 'postgres'
 
   - template: module-storage-ts
     path: packages/storage
     variables:
-      ProjectName: "${ProjectName}-storage"
-      StorageProvider: "s3"
+      ProjectName: '${ProjectName}-storage'
+      StorageProvider: 's3'
 
   - template: module-observability-ts
     path: packages/observability
     variables:
-      ProjectName: "${ProjectName}-otel"
-      Exporter: "otlp"
+      ProjectName: '${ProjectName}-otel'
+      Exporter: 'otlp'
 
   - template: infra-fly
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      AppName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
+      AppName: '${ProjectName}'
       IncludeRedis: true
       IncludeCi: true

--- a/composites/chrome-ai-extension.yaml
+++ b/composites/chrome-ai-extension.yaml
@@ -1,60 +1,60 @@
 apiVersion: nanohype/v1
 kind: composite
 name: chrome-ai-extension
-displayName: "Chrome AI Extension"
+displayName: 'Chrome AI Extension'
 description: >
   Chrome extension with AI sidepanel backed by MCP tool
   servers and optional prompt library.
-version: "0.1.0"
+version: '0.1.0'
 tags: [chrome, extension, ai, mcp]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: ExtensionName
     type: string
-    placeholder: "__EXTENSION_NAME__"
-    description: "Display name in Chrome"
+    placeholder: '__EXTENSION_NAME__'
+    description: 'Display name in Chrome'
     required: true
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludePrompts
     type: bool
-    placeholder: "__INCLUDE_PROMPTS__"
-    description: "Include versioned prompt library"
+    placeholder: '__INCLUDE_PROMPTS__'
+    description: 'Include versioned prompt library'
     default: true
 
 templates:
   - template: chrome-ext
     root: true
     variables:
-      ProjectName: "${ProjectName}"
-      ExtensionName: "${ExtensionName}"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}'
+      ExtensionName: '${ExtensionName}'
+      LlmProvider: '${LlmProvider}'
       IncludeContentScript: true
       IncludeOptions: true
 
   - template: mcp-server-ts
     path: mcp-server
     variables:
-      ProjectName: "${ProjectName}-mcp"
-      ServerName: "${ExtensionName} Tools"
-      Transport: "stdio"
+      ProjectName: '${ProjectName}-mcp'
+      ServerName: '${ExtensionName} Tools'
+      Transport: 'stdio'
 
   - template: prompt-library
     path: prompts
     condition: IncludePrompts
     variables:
-      ProjectName: "${ProjectName}-prompts"
+      ProjectName: '${ProjectName}-prompts'

--- a/composites/client-engagement.yaml
+++ b/composites/client-engagement.yaml
@@ -1,85 +1,85 @@
 apiVersion: nanohype/v1
 kind: composite
 name: client-engagement
-displayName: "Client Engagement"
+displayName: 'Client Engagement'
 description: >
   Non-engineering client engagement package. Sales proposal with
   competitive battle cards, brand guidelines, marketing campaign
   brief, and optional customer onboarding playbook. Zero engineering
   templates — proves the catalog works for non-code workflows.
-version: "0.1.0"
+version: '0.1.0'
 tags: [sales, marketing, design, customer-success, engagement]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name for the engagement"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name for the engagement'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: CompanyName
     type: string
-    placeholder: "__COMPANY_NAME__"
-    description: "Your company name"
+    placeholder: '__COMPANY_NAME__'
+    description: 'Your company name'
     required: true
 
   - name: CompetitorCount
     type: int
-    placeholder: "__COMPETITOR_COUNT__"
-    description: "Number of competitors to track"
+    placeholder: '__COMPETITOR_COUNT__'
+    description: 'Number of competitors to track'
     default: 3
 
   - name: IncludeOnboarding
     type: bool
-    placeholder: "__INCLUDE_ONBOARDING__"
-    description: "Include customer onboarding playbook"
+    placeholder: '__INCLUDE_ONBOARDING__'
+    description: 'Include customer onboarding playbook'
     default: true
 
   - name: IncludeProposalDraft
     type: bool
-    placeholder: "__INCLUDE_PROPOSAL_DRAFT__"
-    description: "Include agent brief for proposal drafting"
+    placeholder: '__INCLUDE_PROPOSAL_DRAFT__'
+    description: 'Include agent brief for proposal drafting'
     default: false
 
 templates:
   - template: proposal-template
     path: sales/proposal
     variables:
-      ProjectName: "${ProjectName}-proposal"
-      CompanyName: "${CompanyName}"
+      ProjectName: '${ProjectName}-proposal'
+      CompanyName: '${CompanyName}'
 
   - template: battle-cards
     path: sales/competitive
     variables:
-      ProjectName: "${ProjectName}-competitive"
-      CompetitorCount: "${CompetitorCount}"
+      ProjectName: '${ProjectName}-competitive'
+      CompetitorCount: '${CompetitorCount}'
 
   - template: brand-guidelines
     path: brand
     variables:
-      ProjectName: "${ProjectName}-brand"
-      BrandName: "${CompanyName}"
+      ProjectName: '${ProjectName}-brand'
+      BrandName: '${CompanyName}'
 
   - template: campaign-brief
     path: marketing
     variables:
-      ProjectName: "${ProjectName}-campaign"
-      CampaignName: "${ProjectName} Launch"
+      ProjectName: '${ProjectName}-campaign'
+      CampaignName: '${ProjectName} Launch'
 
   - template: onboarding-playbook
     path: customer-success
     condition: IncludeOnboarding
     variables:
-      ProjectName: "${ProjectName}-onboarding"
-      ProductName: "${ProjectName}"
+      ProjectName: '${ProjectName}-onboarding'
+      ProductName: '${ProjectName}'
 
   - template: brief-proposal
     path: drafts
     condition: IncludeProposalDraft
     variables:
-      ProjectName: "${ProjectName}"
-      CompanyName: "${CompanyName}"
-      ClientName: "Client"
+      ProjectName: '${ProjectName}'
+      CompanyName: '${CompanyName}'
+      ClientName: 'Client'

--- a/composites/cost-optimized-ai.yaml
+++ b/composites/cost-optimized-ai.yaml
@@ -1,53 +1,53 @@
 apiVersion: nanohype/v1
 kind: composite
 name: cost-optimized-ai
-displayName: "Cost-Optimized AI Stack"
+displayName: 'Cost-Optimized AI Stack'
 description: >
   Minimize LLM costs with intelligent routing, response caching,
   and cost monitoring. Routes to the cheapest provider that meets
   quality thresholds, caches similar prompts to avoid redundant calls,
   and tracks spend with anomaly detection.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, cost, optimization, caching]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider for the gateway"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider for the gateway'
+    default: 'anthropic'
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: module-llm-gateway
     path: packages/gateway
     variables:
-      ProjectName: "${ProjectName}-gateway"
-      DefaultProvider: "${LlmProvider}"
-      RoutingStrategy: "cost"
+      ProjectName: '${ProjectName}-gateway'
+      DefaultProvider: '${LlmProvider}'
+      RoutingStrategy: 'cost'
 
   - template: module-semantic-cache
     path: packages/cache
     variables:
-      ProjectName: "${ProjectName}-cache"
-      EmbeddingProvider: "openai"
+      ProjectName: '${ProjectName}-cache'
+      EmbeddingProvider: 'openai'
 
   - template: module-llm-observability
     path: packages/observability
     variables:
-      ProjectName: "${ProjectName}-observability"
-      Exporter: "console"
+      ProjectName: '${ProjectName}-observability'
+      Exporter: 'console'

--- a/composites/document-intelligence.yaml
+++ b/composites/document-intelligence.yaml
@@ -1,91 +1,91 @@
 apiVersion: nanohype/v1
 kind: composite
 name: document-intelligence
-displayName: "Document Intelligence"
+displayName: 'Document Intelligence'
 description: >
   Document search and question-answering system with RAG pipeline,
   HTTP service, file storage, database, and deployment.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, rag, documents, search, typescript]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for generation"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for generation'
+    default: 'anthropic'
 
   - name: VectorStore
     type: string
-    placeholder: "__VECTOR_STORE__"
-    description: "Vector database backend"
-    default: "pgvector"
+    placeholder: '__VECTOR_STORE__'
+    description: 'Vector database backend'
+    default: 'pgvector'
 
   - name: IncludeEvals
     type: bool
-    placeholder: "__INCLUDE_EVALS__"
-    description: "Include evaluation harness"
+    placeholder: '__INCLUDE_EVALS__'
+    description: 'Include evaluation harness'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: rag-pipeline
     path: packages/rag
     variables:
-      ProjectName: "${ProjectName}-rag"
-      LlmProvider: "${LlmProvider}"
-      VectorStore: "${VectorStore}"
-      EmbeddingProvider: "openai"
+      ProjectName: '${ProjectName}-rag'
+      LlmProvider: '${LlmProvider}'
+      VectorStore: '${VectorStore}'
+      EmbeddingProvider: 'openai'
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
       IncludeDocker: true
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
+      ProjectName: '${ProjectName}-auth'
 
   - template: module-database-ts
     path: packages/db
     variables:
-      ProjectName: "${ProjectName}-db"
-      DatabaseDriver: "postgres"
+      ProjectName: '${ProjectName}-db'
+      DatabaseDriver: 'postgres'
 
   - template: module-storage-ts
     path: packages/storage
     variables:
-      ProjectName: "${ProjectName}-storage"
-      StorageProvider: "s3"
+      ProjectName: '${ProjectName}-storage'
+      StorageProvider: 's3'
 
   - template: eval-harness
     path: packages/evals
     condition: IncludeEvals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: infra-aws
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      ComputeTarget: "ecs"
+      ProjectName: '${ProjectName}'
+      ComputeTarget: 'ecs'
       IncludeVpc: true
       IncludeRds: true
       IncludeMonitoring: true

--- a/composites/enterprise-ai.yaml
+++ b/composites/enterprise-ai.yaml
@@ -1,66 +1,66 @@
 apiVersion: nanohype/v1
 kind: composite
 name: enterprise-ai
-displayName: "Enterprise AI Infrastructure"
+displayName: 'Enterprise AI Infrastructure'
 description: >
   Full enterprise AI stack with agents, tool servers, safety
   guardrails, evaluation, prompt management, observability,
   and Kubernetes deployment.
-version: "0.1.0"
+version: '0.1.0'
 tags: [enterprise, ai, kubernetes, agents, guardrails]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeRag
     type: bool
-    placeholder: "__INCLUDE_RAG__"
-    description: "Include RAG pipeline"
+    placeholder: '__INCLUDE_RAG__'
+    description: 'Include RAG pipeline'
     default: true
 
   - name: IncludeA2a
     type: bool
-    placeholder: "__INCLUDE_A2A__"
-    description: "Include multi-agent coordination"
+    placeholder: '__INCLUDE_A2A__'
+    description: 'Include multi-agent coordination'
     default: false
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: agentic-loop
     path: packages/agent
     variables:
-      ProjectName: "${ProjectName}-agent"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-agent'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
 
   - template: mcp-server-ts
     path: packages/tools
     variables:
-      ProjectName: "${ProjectName}-tools"
-      ServerName: "${ProjectName} Tools"
+      ProjectName: '${ProjectName}-tools'
+      ServerName: '${ProjectName} Tools'
 
   - template: guardrails
     path: packages/guardrails
     variables:
-      ProjectName: "${ProjectName}-guardrails"
+      ProjectName: '${ProjectName}-guardrails'
       IncludePii: true
       IncludeContentPolicy: true
 
@@ -68,67 +68,67 @@ templates:
     path: packages/rag
     condition: IncludeRag
     variables:
-      ProjectName: "${ProjectName}-rag"
-      LlmProvider: "${LlmProvider}"
-      VectorStore: "pgvector"
+      ProjectName: '${ProjectName}-rag'
+      LlmProvider: '${LlmProvider}'
+      VectorStore: 'pgvector'
 
   - template: a2a-agent
     path: packages/orchestrator
     condition: IncludeA2a
     variables:
-      ProjectName: "${ProjectName}-orchestrator"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-orchestrator'
+      LlmProvider: '${LlmProvider}'
 
   - template: eval-harness
     path: packages/evals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: prompt-library
     path: packages/prompts
     variables:
-      ProjectName: "${ProjectName}-prompts"
+      ProjectName: '${ProjectName}-prompts'
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
       IncludeDocker: true
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
+      ProjectName: '${ProjectName}-auth'
 
   - template: module-database-ts
     path: packages/db
     variables:
-      ProjectName: "${ProjectName}-db"
-      DatabaseDriver: "postgres"
+      ProjectName: '${ProjectName}-db'
+      DatabaseDriver: 'postgres'
 
   - template: module-observability-ts
     path: packages/observability
     variables:
-      ProjectName: "${ProjectName}-otel"
-      Exporter: "otlp"
+      ProjectName: '${ProjectName}-otel'
+      Exporter: 'otlp'
 
   - template: module-queue-ts
     path: packages/queue
     variables:
-      ProjectName: "${ProjectName}-queue"
-      QueueProvider: "bullmq"
+      ProjectName: '${ProjectName}-queue'
+      QueueProvider: 'bullmq'
 
   - template: module-storage-ts
     path: packages/storage
     variables:
-      ProjectName: "${ProjectName}-storage"
-      StorageProvider: "s3"
+      ProjectName: '${ProjectName}-storage'
+      StorageProvider: 's3'
 
   - template: k8s-deploy
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeHelm: true
       IncludeHpa: true
       IncludeIngress: true

--- a/composites/eval-suite.yaml
+++ b/composites/eval-suite.yaml
@@ -1,58 +1,58 @@
 apiVersion: nanohype/v1
 kind: composite
 name: eval-suite
-displayName: "AI Evaluation Suite"
+displayName: 'AI Evaluation Suite'
 description: >
   Standalone evaluation infrastructure with test harness,
   versioned prompts, and guardrails validation. For teams
   that need to test AI systems without building them.
-version: "0.1.0"
+version: '0.1.0'
 tags: [eval, testing, prompts, ai, quality]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for eval targets"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for eval targets'
+    default: 'anthropic'
 
   - name: IncludeGuardrails
     type: bool
-    placeholder: "__INCLUDE_GUARDRAILS__"
-    description: "Include safety filter testing"
+    placeholder: '__INCLUDE_GUARDRAILS__'
+    description: 'Include safety filter testing'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: eval-harness
     path: packages/evals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
       IncludeCi: true
 
   - template: prompt-library
     path: packages/prompts
     variables:
-      ProjectName: "${ProjectName}-prompts"
+      ProjectName: '${ProjectName}-prompts'
       IncludeSdk: true
 
   - template: guardrails
     path: packages/guardrails
     condition: IncludeGuardrails
     variables:
-      ProjectName: "${ProjectName}-guardrails"
+      ProjectName: '${ProjectName}-guardrails'

--- a/composites/go-microservice.yaml
+++ b/composites/go-microservice.yaml
@@ -1,66 +1,66 @@
 apiVersion: nanohype/v1
 kind: composite
 name: go-microservice
-displayName: "Go Microservice"
+displayName: 'Go Microservice'
 description: >
   Go HTTP service with observability and deployment.
   Lightweight, single-binary, production-ready.
-version: "0.1.0"
+version: '0.1.0'
 tags: [go, microservice, api, deployment]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: GoModule
     type: string
-    placeholder: "__GO_MODULE__"
-    description: "Go module path"
+    placeholder: '__GO_MODULE__'
+    description: 'Go module path'
     required: true
 
   - name: Org
     type: string
-    placeholder: "__ORG__"
-    description: "GitHub org or username"
+    placeholder: '__ORG__'
+    description: 'GitHub org or username'
     required: true
 
   - name: DeployTarget
     type: string
-    placeholder: "__DEPLOY_TARGET__"
-    description: "Deployment target"
-    default: "fly"
+    placeholder: '__DEPLOY_TARGET__'
+    description: 'Deployment target'
+    default: 'fly'
 
 templates:
   - template: go-service
     root: true
     variables:
-      ProjectName: "${ProjectName}"
-      GoModule: "${GoModule}"
-      Org: "${Org}"
+      ProjectName: '${ProjectName}'
+      GoModule: '${GoModule}'
+      Org: '${Org}'
       IncludeDocker: true
 
   - template: module-auth-go
     path: auth
     variables:
-      ProjectName: "${ProjectName}-auth"
-      GoModule: "${GoModule}/auth"
-      Org: "${Org}"
-      AuthProvider: "jwt"
+      ProjectName: '${ProjectName}-auth'
+      GoModule: '${GoModule}/auth'
+      Org: '${Org}'
+      AuthProvider: 'jwt'
 
   - template: eval-harness
     path: evals
     variables:
-      ProjectName: "${ProjectName}-evals"
+      ProjectName: '${ProjectName}-evals'
 
   - template: infra-fly
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      AppName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
+      AppName: '${ProjectName}'
       IncludeCi: true

--- a/composites/identity-aware-service.yaml
+++ b/composites/identity-aware-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 kind: composite
 name: identity-aware-service
-displayName: "Identity-Aware Spring Boot Microservice"
+displayName: 'Identity-Aware Spring Boot Microservice'
 description: >
   Spring Boot 4 microservice on JDK 25 with identity enforced at both the
   service-mesh edge (Istio RequestAuthentication + AuthorizationPolicy) and
@@ -9,126 +9,126 @@ description: >
   defense in depth against the same OIDC issuer. Deployed via Kubernetes
   with optional STRICT mTLS, VirtualService routing, and a Grafana +
   Prometheus + Loki observability bundle.
-version: "0.1.0"
+version: '0.1.0'
 tags: [java, spring-boot, jvm, microservice, istio, oauth2, identity, kubernetes]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used across service, k8s resources, istio selectors, and repo"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used across service, k8s resources, istio selectors, and repo'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: GroupId
     type: string
-    placeholder: "__GROUP_ID__"
-    description: "Maven groupId (reverse-DNS, dot-separated, lowercase)"
-    prompt: "Maven groupId"
-    default: "com.example"
+    placeholder: '__GROUP_ID__'
+    description: 'Maven groupId (reverse-DNS, dot-separated, lowercase)'
+    prompt: 'Maven groupId'
+    default: 'com.example'
     required: true
 
   - name: JavaPackage
     type: string
-    placeholder: "__JAVA_PKG__"
-    description: "Root Java package (dot form)"
-    prompt: "Root Java package (dot form)"
-    default: "${GroupId}.app"
+    placeholder: '__JAVA_PKG__'
+    description: 'Root Java package (dot form)'
+    prompt: 'Root Java package (dot form)'
+    default: '${GroupId}.app'
     required: true
 
   - name: PackageDir
     type: string
-    placeholder: "__PKG_DIR__"
-    description: "Root Java package (slash form) — must match JavaPackage"
-    prompt: "Root Java package (slash form)"
-    default: "com/example/app"
+    placeholder: '__PKG_DIR__'
+    description: 'Root Java package (slash form) — must match JavaPackage'
+    prompt: 'Root Java package (slash form)'
+    default: 'com/example/app'
     required: true
 
   - name: Database
     type: string
-    placeholder: "__DATABASE__"
-    description: "Database driver (postgres, mysql, h2)"
-    prompt: "Database driver"
-    default: "postgres"
+    placeholder: '__DATABASE__'
+    description: 'Database driver (postgres, mysql, h2)'
+    prompt: 'Database driver'
+    default: 'postgres'
 
   - name: Namespace
     type: string
-    placeholder: "__NAMESPACE__"
-    description: "Kubernetes namespace for deployed resources"
-    prompt: "Kubernetes namespace"
-    default: "default"
+    placeholder: '__NAMESPACE__'
+    description: 'Kubernetes namespace for deployed resources'
+    prompt: 'Kubernetes namespace'
+    default: 'default'
 
   - name: Replicas
     type: string
-    placeholder: "__REPLICAS__"
-    description: "Kubernetes pod replica count"
-    prompt: "Replicas"
-    default: "2"
+    placeholder: '__REPLICAS__'
+    description: 'Kubernetes pod replica count'
+    prompt: 'Replicas'
+    default: '2'
 
   - name: OidcIssuer
     type: string
-    placeholder: "__OIDC_ISSUER__"
+    placeholder: '__OIDC_ISSUER__'
     description: >
       OIDC issuer URL. Used by both Spring Security (for JWT validation in
       the app) and Istio RequestAuthentication (for JWT validation at the
       mesh edge). Same value flows to both — defense in depth.
-    prompt: "OIDC issuer URL"
+    prompt: 'OIDC issuer URL'
     required: true
 
   - name: AllowedAudience
     type: string
-    placeholder: "__ALLOWED_AUD__"
-    description: "Expected JWT `aud` claim value"
-    prompt: "Expected JWT audience"
-    default: "${ProjectName}"
+    placeholder: '__ALLOWED_AUD__'
+    description: 'Expected JWT `aud` claim value'
+    prompt: 'Expected JWT audience'
+    default: '${ProjectName}'
 
   - name: IncludeMTls
     type: bool
-    placeholder: "__INCLUDE_MTLS__"
+    placeholder: '__INCLUDE_MTLS__'
     description: >
       Include an Istio PeerAuthentication enforcing STRICT mTLS. Only enable
       when every workload in the namespace is sidecar-injected — STRICT mode
       rejects non-mesh traffic.
-    prompt: "Enforce STRICT mTLS across the namespace?"
+    prompt: 'Enforce STRICT mTLS across the namespace?'
     default: false
 
   - name: IncludeMonitoring
     type: bool
-    placeholder: "__INCLUDE_MONITORING__"
-    description: "Include the Grafana + Prometheus + Loki observability stack"
-    prompt: "Include observability stack?"
+    placeholder: '__INCLUDE_MONITORING__'
+    description: 'Include the Grafana + Prometheus + Loki observability stack'
+    prompt: 'Include observability stack?'
     default: false
 
 templates:
   - template: spring-boot-service
     root: true
     variables:
-      ProjectName: "${ProjectName}"
-      GroupId: "${GroupId}"
-      ArtifactId: "${ProjectName}"
-      JavaPackage: "${JavaPackage}"
-      PackageDir: "${PackageDir}"
-      Database: "${Database}"
+      ProjectName: '${ProjectName}'
+      GroupId: '${GroupId}'
+      ArtifactId: '${ProjectName}'
+      JavaPackage: '${JavaPackage}'
+      PackageDir: '${PackageDir}'
+      Database: '${Database}'
       IncludeDocker: true
 
   - template: module-spring-security
-    path: "."
+    path: '.'
     variables:
-      ProjectName: "${ProjectName}"
-      JavaPackage: "${JavaPackage}"
-      PackageDir: "${PackageDir}"
-      OidcIssuer: "${OidcIssuer}"
-      AllowedAudience: "${AllowedAudience}"
+      ProjectName: '${ProjectName}'
+      JavaPackage: '${JavaPackage}'
+      PackageDir: '${PackageDir}'
+      OidcIssuer: '${OidcIssuer}'
+      AllowedAudience: '${AllowedAudience}'
 
   - template: k8s-deploy
     path: k8s
     variables:
-      ProjectName: "${ProjectName}"
-      Namespace: "${Namespace}"
-      Replicas: "${Replicas}"
+      ProjectName: '${ProjectName}'
+      Namespace: '${Namespace}'
+      Replicas: '${Replicas}'
       IncludeIngress: true
       IncludeHpa: true
       IncludeHelm: true
@@ -137,18 +137,18 @@ templates:
   - template: istio-policy
     path: istio
     variables:
-      ProjectName: "${ProjectName}"
-      Namespace: "${Namespace}"
-      OidcIssuer: "${OidcIssuer}"
-      AllowedAudience: "${AllowedAudience}"
-      IncludeMTls: "${IncludeMTls}"
+      ProjectName: '${ProjectName}'
+      Namespace: '${Namespace}'
+      OidcIssuer: '${OidcIssuer}'
+      AllowedAudience: '${AllowedAudience}'
+      IncludeMTls: '${IncludeMTls}'
       IncludeVirtualService: true
-      GatewayName: "mesh"
+      GatewayName: 'mesh'
 
   - template: monitoring-stack
     path: observability
     condition: IncludeMonitoring
     variables:
-      ProjectName: "${ProjectName}"
-      DeployTarget: "docker-compose"
+      ProjectName: '${ProjectName}'
+      DeployTarget: 'docker-compose'
       IncludeAlerts: true

--- a/composites/internal-tool.yaml
+++ b/composites/internal-tool.yaml
@@ -1,59 +1,59 @@
 apiVersion: nanohype/v1
 kind: composite
 name: internal-tool
-displayName: "Internal Tool"
+displayName: 'Internal Tool'
 description: >
   CLI tool or browser extension backed by MCP servers
   for internal team use.
-version: "0.1.0"
+version: '0.1.0'
 tags: [cli, mcp, tools, internal]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: IncludeCli
     type: bool
-    placeholder: "__INCLUDE_CLI__"
-    description: "Include CLI interface (go-cli template)"
+    placeholder: '__INCLUDE_CLI__'
+    description: 'Include CLI interface (go-cli template)'
     default: true
 
   - name: IncludeEvals
     type: bool
-    placeholder: "__INCLUDE_EVALS__"
-    description: "Include evaluation harness"
+    placeholder: '__INCLUDE_EVALS__'
+    description: 'Include evaluation harness'
     default: true
 
 templates:
   - template: go-cli
-    path: "."
+    path: '.'
     condition: IncludeCli
     variables:
-      ProjectName: "${ProjectName}"
-      Org: "${ProjectName}"
-      GoModule: "github.com/${ProjectName}/${ProjectName}"
+      ProjectName: '${ProjectName}'
+      Org: '${ProjectName}'
+      GoModule: 'github.com/${ProjectName}/${ProjectName}'
 
   - template: mcp-server-ts
     path: mcp-server
     variables:
-      ProjectName: "${ProjectName}-mcp"
-      ServerName: "${ProjectName} Tools"
-      Transport: "stdio"
+      ProjectName: '${ProjectName}-mcp'
+      ServerName: '${ProjectName} Tools'
+      Transport: 'stdio'
 
   - template: eval-harness
     path: evals
     condition: IncludeEvals
     variables:
-      ProjectName: "${ProjectName}-evals"
+      ProjectName: '${ProjectName}-evals'
 
   - template: infra-fly
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      AppName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
+      AppName: '${ProjectName}'

--- a/composites/mcp-toolkit.yaml
+++ b/composites/mcp-toolkit.yaml
@@ -1,56 +1,56 @@
 apiVersion: nanohype/v1
 kind: composite
 name: mcp-toolkit
-displayName: "MCP Toolkit"
+displayName: 'MCP Toolkit'
 description: >
   MCP server with evaluation harness, prompt library,
   and deployment. The standard stack for building
   tool servers for AI systems.
-version: "0.1.0"
+version: '0.1.0'
 tags: [mcp, tools, ai, typescript]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: ServerName
     type: string
-    placeholder: "__SERVER_NAME__"
-    description: "Human-readable MCP server name"
+    placeholder: '__SERVER_NAME__'
+    description: 'Human-readable MCP server name'
     required: true
 
   - name: IncludePrompts
     type: bool
-    placeholder: "__INCLUDE_PROMPTS__"
-    description: "Include versioned prompt library"
+    placeholder: '__INCLUDE_PROMPTS__'
+    description: 'Include versioned prompt library'
     default: true
 
   - name: IncludeEvals
     type: bool
-    placeholder: "__INCLUDE_EVALS__"
-    description: "Include evaluation harness"
+    placeholder: '__INCLUDE_EVALS__'
+    description: 'Include evaluation harness'
     default: true
 
 templates:
   - template: mcp-server-ts
     root: true
     variables:
-      ProjectName: "${ProjectName}"
-      ServerName: "${ServerName}"
-      Transport: "stdio"
+      ProjectName: '${ProjectName}'
+      ServerName: '${ServerName}'
+      Transport: 'stdio'
       IncludeResources: true
 
   - template: prompt-library
     path: prompts
     condition: IncludePrompts
     variables:
-      ProjectName: "${ProjectName}-prompts"
+      ProjectName: '${ProjectName}-prompts'
       IncludeSdk: true
       IncludeTests: true
 
@@ -58,4 +58,4 @@ templates:
     path: evals
     condition: IncludeEvals
     variables:
-      ProjectName: "${ProjectName}-evals"
+      ProjectName: '${ProjectName}-evals'

--- a/composites/multi-agent.yaml
+++ b/composites/multi-agent.yaml
@@ -1,89 +1,89 @@
 apiVersion: nanohype/v1
 kind: composite
 name: multi-agent
-displayName: "Multi-Agent System"
+displayName: 'Multi-Agent System'
 description: >
   Multi-agent architecture with A2A protocol peers, MCP tool
   servers, and an orchestrating agent. Agents discover each
   other, delegate tasks, and share tools.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, agents, a2a, mcp, multi-agent]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for agent reasoning"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for agent reasoning'
+    default: 'anthropic'
 
   - name: IncludeGuardrails
     type: bool
-    placeholder: "__INCLUDE_GUARDRAILS__"
-    description: "Include safety guardrails"
+    placeholder: '__INCLUDE_GUARDRAILS__'
+    description: 'Include safety guardrails'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: a2a-agent
     path: packages/orchestrator
     variables:
-      ProjectName: "${ProjectName}-orchestrator"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-orchestrator'
+      LlmProvider: '${LlmProvider}'
       IncludeDiscovery: true
 
   - template: agentic-loop
     path: packages/agent
     variables:
-      ProjectName: "${ProjectName}-agent"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-agent'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
 
   - template: mcp-server-ts
     path: packages/tools
     variables:
-      ProjectName: "${ProjectName}-tools"
-      ServerName: "${ProjectName} Tools"
-      Transport: "stdio"
+      ProjectName: '${ProjectName}-tools'
+      ServerName: '${ProjectName} Tools'
+      Transport: 'stdio'
 
   - template: guardrails
     path: packages/guardrails
     condition: IncludeGuardrails
     variables:
-      ProjectName: "${ProjectName}-guardrails"
+      ProjectName: '${ProjectName}-guardrails'
 
   - template: eval-harness
     path: packages/evals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
+      ProjectName: '${ProjectName}-auth'
 
   - template: infra-aws
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      ComputeTarget: "ecs"
+      ProjectName: '${ProjectName}'
+      ComputeTarget: 'ecs'
       IncludeVpc: true

--- a/composites/platform-tenant.yaml
+++ b/composites/platform-tenant.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 kind: composite
 name: platform-tenant
-displayName: "Platform Tenant"
+displayName: 'Platform Tenant'
 description: >
   One-shot scaffolder for a k8s-native nanohype Platform tenant: the
   k8s-app-tenant chart (which vendors tenant-chart-base and ships per-env values,
@@ -11,109 +11,109 @@ description: >
   required templates, the gitops entry, and the Platform CR, with the OTel
   agents.tenant / agents.platform attributes set and no inline IAM. Pair the
   packages with a ts-service or agentic-loop for the app's own logic.
-version: "0.1.0"
+version: '0.1.0'
 tags: [kubernetes, platform, tenant, ai, nanohype]
 
 variables:
   - name: AppName
     type: string
-    placeholder: "__APP_NAME__"
-    description: "Kebab-case app name — chart name, namespace, Platform CR name, and the package prefix."
+    placeholder: '__APP_NAME__'
+    description: 'Kebab-case app name — chart name, namespace, Platform CR name, and the package prefix.'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Tenant
     type: string
-    placeholder: "__TENANT__"
-    description: "Owning team — drives the namespace prefix, ArgoCD AppProject, and quotas."
+    placeholder: '__TENANT__'
+    description: 'Owning team — drives the namespace prefix, ArgoCD AppProject, and quotas.'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: Image
     type: string
-    placeholder: "__IMAGE__"
-    description: "Container image base (no tag — pinned per-env in values-{env}.yaml)."
+    placeholder: '__IMAGE__'
+    description: 'Container image base (no tag — pinned per-env in values-{env}.yaml).'
     required: true
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short app description for Chart.yaml and README."
-    default: "k8s-native Platform tenant"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short app description for Chart.yaml and README.'
+    default: 'k8s-native Platform tenant'
 
   - name: Port
     type: string
-    placeholder: "__PORT__"
-    description: "Container port the app listens on."
-    default: "8080"
+    placeholder: '__PORT__'
+    description: 'Container port the app listens on.'
+    default: '8080'
 
   - name: IncludeLlmGateway
     type: bool
-    placeholder: "__INCLUDE_LLM_GATEWAY__"
-    description: "Include the LLM gateway package (Bedrock-first, routing + caching + cost tracking)."
+    placeholder: '__INCLUDE_LLM_GATEWAY__'
+    description: 'Include the LLM gateway package (Bedrock-first, routing + caching + cost tracking).'
     default: true
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider for the gateway."
-    default: "bedrock"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider for the gateway.'
+    default: 'bedrock'
 
   - name: IncludeVectorStore
     type: bool
-    placeholder: "__INCLUDE_VECTOR_STORE__"
-    description: "Include the vector store package (embedding storage + similarity search)."
+    placeholder: '__INCLUDE_VECTOR_STORE__'
+    description: 'Include the vector store package (embedding storage + similarity search).'
     default: false
 
   - name: VectorProvider
     type: string
-    placeholder: "__VECTOR_PROVIDER__"
-    description: "Default vector store backend."
-    default: "memory"
+    placeholder: '__VECTOR_PROVIDER__'
+    description: 'Default vector store backend.'
+    default: 'memory'
 
   - name: IncludeAuditLedger
     type: bool
-    placeholder: "__INCLUDE_AUDIT_LEDGER__"
-    description: "Include the audit ledger package (append-only event log over pluggable storage)."
+    placeholder: '__INCLUDE_AUDIT_LEDGER__'
+    description: 'Include the audit ledger package (append-only event log over pluggable storage).'
     default: false
 
   - name: AuditProvider
     type: string
-    placeholder: "__AUDIT_PROVIDER__"
-    description: "Default audit ledger backend."
-    default: "memory"
+    placeholder: '__AUDIT_PROVIDER__'
+    description: 'Default audit ledger backend.'
+    default: 'memory'
 
 templates:
   - template: k8s-app-tenant
     root: true
     variables:
-      AppName: "${AppName}"
-      Tenant: "${Tenant}"
-      Image: "${Image}"
-      Description: "${Description}"
-      Port: "${Port}"
+      AppName: '${AppName}'
+      Tenant: '${Tenant}'
+      Image: '${Image}'
+      Description: '${Description}'
+      Port: '${Port}'
 
   - template: module-llm-gateway
     path: packages/gateway
     condition: IncludeLlmGateway
     variables:
-      ProjectName: "${AppName}-gateway"
-      DefaultProvider: "${LlmProvider}"
+      ProjectName: '${AppName}-gateway'
+      DefaultProvider: '${LlmProvider}'
 
   - template: module-vector-store
     path: packages/vectors
     condition: IncludeVectorStore
     variables:
-      ProjectName: "${AppName}-vectors"
-      VectorProvider: "${VectorProvider}"
+      ProjectName: '${AppName}-vectors'
+      VectorProvider: '${VectorProvider}'
 
   - template: module-audit-ledger-ts
     path: packages/audit
     condition: IncludeAuditLedger
     variables:
-      ProjectName: "${AppName}-audit"
-      AuditProvider: "${AuditProvider}"
+      ProjectName: '${AppName}-audit'
+      AuditProvider: '${AuditProvider}'

--- a/composites/product-launch.yaml
+++ b/composites/product-launch.yaml
@@ -1,104 +1,104 @@
 apiVersion: nanohype/v1
 kind: composite
 name: product-launch
-displayName: "Product Launch"
+displayName: 'Product Launch'
 description: >
   Full product launch kit spanning engineering, design, QA, product,
   marketing, and operations. Scaffolds a Next.js app with auth and
   analytics alongside a design system, design tokens, test plan,
   acceptance criteria, PRD, campaign brief, and operational runbook.
-version: "0.1.0"
+version: '0.1.0'
 tags: [launch, cross-functional, product, design, qa, marketing, operations]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: ProductName
     type: string
-    placeholder: "__PRODUCT_NAME__"
-    description: "Human-readable product name"
+    placeholder: '__PRODUCT_NAME__'
+    description: 'Human-readable product name'
     required: true
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for AI features"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for AI features'
+    default: 'anthropic'
 
   - name: IncludeMarketing
     type: bool
-    placeholder: "__INCLUDE_MARKETING__"
-    description: "Include marketing campaign brief"
+    placeholder: '__INCLUDE_MARKETING__'
+    description: 'Include marketing campaign brief'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: prd-template
     path: docs/product
     variables:
-      ProjectName: "${ProjectName}-prd"
-      ProductName: "${ProductName}"
+      ProjectName: '${ProjectName}-prd'
+      ProductName: '${ProductName}'
       IncludeUserStories: true
       IncludeMetrics: true
 
   - template: design-system
     path: docs/design
     variables:
-      ProjectName: "${ProjectName}-design"
+      ProjectName: '${ProjectName}-design'
 
   - template: design-tokens
     path: packages/tokens
     variables:
-      ProjectName: "${ProjectName}-tokens"
+      ProjectName: '${ProjectName}-tokens'
 
   - template: next-app
     path: apps/web
     variables:
-      ProjectName: "${ProjectName}-web"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-web'
+      LlmProvider: '${LlmProvider}'
       IncludeAuth: true
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
+      ProjectName: '${ProjectName}-auth'
 
   - template: module-analytics-ts
     path: packages/analytics
     variables:
-      ProjectName: "${ProjectName}-analytics"
+      ProjectName: '${ProjectName}-analytics'
 
   - template: test-plan
     path: docs/qa
     variables:
-      ProjectName: "${ProjectName}-qa"
+      ProjectName: '${ProjectName}-qa'
 
   - template: acceptance-criteria
     path: docs/qa/criteria
     variables:
-      ProjectName: "${ProjectName}-criteria"
+      ProjectName: '${ProjectName}-criteria'
 
   - template: runbook
     path: docs/ops
     variables:
-      ProjectName: "${ProjectName}-ops"
-      ServiceName: "${ProjectName}-web"
+      ProjectName: '${ProjectName}-ops'
+      ServiceName: '${ProjectName}-web'
 
   - template: campaign-brief
     path: docs/marketing
     condition: IncludeMarketing
     variables:
-      ProjectName: "${ProjectName}-campaign"
-      CampaignName: "${ProductName} Launch"
+      ProjectName: '${ProjectName}-campaign'
+      CampaignName: '${ProductName} Launch'

--- a/composites/production-api.yaml
+++ b/composites/production-api.yaml
@@ -1,102 +1,102 @@
 apiVersion: nanohype/v1
 kind: composite
 name: production-api
-displayName: "Production API Service"
+displayName: 'Production API Service'
 description: >
   Production-grade TypeScript API service with auth, database,
   caching, rate limiting, background jobs, observability,
   and deployment.
-version: "0.1.0"
+version: '0.1.0'
 tags: [api, service, production, typescript]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: DatabaseDriver
     type: string
-    placeholder: "__DATABASE_DRIVER__"
-    description: "Database driver"
-    default: "postgres"
+    placeholder: '__DATABASE_DRIVER__'
+    description: 'Database driver'
+    default: 'postgres'
 
   - name: DeployTarget
     type: string
-    placeholder: "__DEPLOY_TARGET__"
-    description: "Deployment target (infra-fly, infra-aws, infra-gcp, k8s-deploy)"
-    default: "infra-fly"
+    placeholder: '__DEPLOY_TARGET__'
+    description: 'Deployment target (infra-fly, infra-aws, infra-gcp, k8s-deploy)'
+    default: 'infra-fly'
 
   - name: IncludeQueue
     type: bool
-    placeholder: "__INCLUDE_QUEUE__"
-    description: "Include background job processing"
+    placeholder: '__INCLUDE_QUEUE__'
+    description: 'Include background job processing'
     default: true
 
   - name: IncludeCache
     type: bool
-    placeholder: "__INCLUDE_CACHE__"
-    description: "Include caching layer"
+    placeholder: '__INCLUDE_CACHE__'
+    description: 'Include caching layer'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
       IncludeDocker: true
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
-      AuthProvider: "jwt"
+      ProjectName: '${ProjectName}-auth'
+      AuthProvider: 'jwt'
 
   - template: module-database-ts
     path: packages/db
     variables:
-      ProjectName: "${ProjectName}-db"
-      DatabaseDriver: "${DatabaseDriver}"
+      ProjectName: '${ProjectName}-db'
+      DatabaseDriver: '${DatabaseDriver}'
 
   - template: module-observability-ts
     path: packages/observability
     variables:
-      ProjectName: "${ProjectName}-otel"
-      Exporter: "otlp"
+      ProjectName: '${ProjectName}-otel'
+      Exporter: 'otlp'
 
   - template: module-queue-ts
     path: packages/queue
     condition: IncludeQueue
     variables:
-      ProjectName: "${ProjectName}-queue"
-      QueueProvider: "bullmq"
+      ProjectName: '${ProjectName}-queue'
+      QueueProvider: 'bullmq'
 
   - template: module-cache-ts
     path: packages/cache
     condition: IncludeCache
     variables:
-      ProjectName: "${ProjectName}-cache"
-      CacheProvider: "memory"
+      ProjectName: '${ProjectName}-cache'
+      CacheProvider: 'memory'
 
   - template: module-rate-limit-ts
     path: packages/rate-limit
     variables:
-      ProjectName: "${ProjectName}-rate-limit"
-      Algorithm: "token-bucket"
+      ProjectName: '${ProjectName}-rate-limit'
+      Algorithm: 'token-bucket'
 
   - template: infra-fly
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      AppName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
+      AppName: '${ProjectName}'
       IncludeCi: true

--- a/composites/proof-of-concept.yaml
+++ b/composites/proof-of-concept.yaml
@@ -1,40 +1,40 @@
 apiVersion: nanohype/v1
 kind: composite
 name: proof-of-concept
-displayName: "AI Proof of Concept"
+displayName: 'AI Proof of Concept'
 description: >
   Minimal AI agent with evaluation harness. The fastest
   path to a working prototype with quality gates.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, poc, agent, eval]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider'
+    default: 'anthropic'
 
 templates:
   - template: agentic-loop
     root: true
     variables:
-      ProjectName: "${ProjectName}"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
       IncludeEval: false
 
   - template: eval-harness
     path: evals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'

--- a/composites/rag-agent.yaml
+++ b/composites/rag-agent.yaml
@@ -1,90 +1,90 @@
 apiVersion: nanohype/v1
 kind: composite
 name: rag-agent
-displayName: "RAG-Powered Agent"
+displayName: 'RAG-Powered Agent'
 description: >
   AI agent that uses retrieval-augmented generation as a
   tool. The agent reasons and acts, the RAG pipeline provides
   grounded knowledge from a document corpus.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, rag, agent, retrieval]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider'
+    default: 'anthropic'
 
   - name: VectorStore
     type: string
-    placeholder: "__VECTOR_STORE__"
-    description: "Vector database backend"
-    default: "pgvector"
+    placeholder: '__VECTOR_STORE__'
+    description: 'Vector database backend'
+    default: 'pgvector'
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: agentic-loop
     path: packages/agent
     variables:
-      ProjectName: "${ProjectName}-agent"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-agent'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
 
   - template: rag-pipeline
     path: packages/rag
     variables:
-      ProjectName: "${ProjectName}-rag"
-      LlmProvider: "${LlmProvider}"
-      VectorStore: "${VectorStore}"
+      ProjectName: '${ProjectName}-rag'
+      LlmProvider: '${LlmProvider}'
+      VectorStore: '${VectorStore}'
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
       IncludeDocker: true
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
+      ProjectName: '${ProjectName}-auth'
 
   - template: module-database-ts
     path: packages/db
     variables:
-      ProjectName: "${ProjectName}-db"
-      DatabaseDriver: "postgres"
+      ProjectName: '${ProjectName}-db'
+      DatabaseDriver: 'postgres'
 
   - template: module-storage-ts
     path: packages/storage
     variables:
-      ProjectName: "${ProjectName}-storage"
-      StorageProvider: "s3"
+      ProjectName: '${ProjectName}-storage'
+      StorageProvider: 's3'
 
   - template: eval-harness
     path: packages/evals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: infra-aws
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      ComputeTarget: "ecs"
+      ProjectName: '${ProjectName}'
+      ComputeTarget: 'ecs'
       IncludeVpc: true
       IncludeRds: true

--- a/composites/research-to-prototype.yaml
+++ b/composites/research-to-prototype.yaml
@@ -1,68 +1,68 @@
 apiVersion: nanohype/v1
 kind: composite
 name: research-to-prototype
-displayName: "Research to Prototype"
+displayName: 'Research to Prototype'
 description: >
   Research-driven prototype pipeline. Starts with product research
   and a PRD, scaffolds an agentic loop prototype, and optionally
   adds a test plan for validation.
-version: "0.1.0"
+version: '0.1.0'
 tags: [research, prototype, product, ai, qa]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: ResearchType
     type: string
-    placeholder: "__RESEARCH_TYPE__"
-    description: "Type of research (generative, evaluative)"
-    default: "generative"
+    placeholder: '__RESEARCH_TYPE__'
+    description: 'Type of research (generative, evaluative)'
+    default: 'generative'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for the prototype"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for the prototype'
+    default: 'anthropic'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test plan for prototype validation"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test plan for prototype validation'
     default: true
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: false
 
   - template: research-framework
     path: docs/research
     variables:
-      ProjectName: "${ProjectName}-research"
-      ResearchType: "${ResearchType}"
+      ProjectName: '${ProjectName}-research'
+      ResearchType: '${ResearchType}'
 
   - template: prd-template
     path: docs/product
     variables:
-      ProjectName: "${ProjectName}-prd"
-      ProductName: "${ProjectName}"
+      ProjectName: '${ProjectName}-prd'
+      ProductName: '${ProjectName}'
       IncludeUserStories: true
       IncludeMetrics: false
 
   - template: agentic-loop
     path: apps/agent
     variables:
-      ProjectName: "${ProjectName}-agent"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-agent'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
       IncludeEval: false
 
@@ -70,4 +70,4 @@ templates:
     path: docs/qa
     condition: IncludeTests
     variables:
-      ProjectName: "${ProjectName}-qa"
+      ProjectName: '${ProjectName}-qa'

--- a/composites/safe-ai-agent.yaml
+++ b/composites/safe-ai-agent.yaml
@@ -1,58 +1,58 @@
 apiVersion: nanohype/v1
 kind: composite
 name: safe-ai-agent
-displayName: "Safe AI Agent"
+displayName: 'Safe AI Agent'
 description: >
   AI agent with safety guardrails, evaluation harness,
   and prompt management. The responsible AI stack —
   filter inputs, validate outputs, test everything.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, safety, guardrails, agent, eval]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider'
+    default: 'anthropic'
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
 
   - template: agentic-loop
     path: packages/agent
     variables:
-      ProjectName: "${ProjectName}-agent"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-agent'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
 
   - template: guardrails
     path: packages/guardrails
     variables:
-      ProjectName: "${ProjectName}-guardrails"
+      ProjectName: '${ProjectName}-guardrails'
       IncludePii: true
       IncludeContentPolicy: true
 
   - template: eval-harness
     path: packages/evals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: prompt-library
     path: packages/prompts
     variables:
-      ProjectName: "${ProjectName}-prompts"
+      ProjectName: '${ProjectName}-prompts'

--- a/composites/spring-boot-microservice.yaml
+++ b/composites/spring-boot-microservice.yaml
@@ -1,106 +1,106 @@
 apiVersion: nanohype/v1
 kind: composite
 name: spring-boot-microservice
-displayName: "Spring Boot Microservice"
+displayName: 'Spring Boot Microservice'
 description: >
   Java Spring Boot 4 HTTP service on JDK 25 with a Kubernetes deployment
   and an optional Grafana + Prometheus + Loki observability stack.
   Production-shaped: Spring Security via module-spring-security (JWT /
   API-key / opaque-token), Spring Data JPA with Flyway, Micrometer +
   OpenTelemetry, Helm chart, HPA, and ingress.
-version: "0.1.0"
+version: '0.1.0'
 tags: [java, spring-boot, jvm, microservice, api, kubernetes]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used across service, k8s resources, and repo"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used across service, k8s resources, and repo'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: GroupId
     type: string
-    placeholder: "__GROUP_ID__"
-    description: "Maven groupId (reverse-DNS, dot-separated, lowercase)"
-    prompt: "Maven groupId"
-    default: "com.example"
+    placeholder: '__GROUP_ID__'
+    description: 'Maven groupId (reverse-DNS, dot-separated, lowercase)'
+    prompt: 'Maven groupId'
+    default: 'com.example'
     required: true
 
   - name: JavaPackage
     type: string
-    placeholder: "__JAVA_PKG__"
-    description: "Root Java package (dot form)"
-    prompt: "Root Java package (dot form)"
-    default: "${GroupId}.app"
+    placeholder: '__JAVA_PKG__'
+    description: 'Root Java package (dot form)'
+    prompt: 'Root Java package (dot form)'
+    default: '${GroupId}.app'
     required: true
 
   - name: PackageDir
     type: string
-    placeholder: "__PKG_DIR__"
+    placeholder: '__PKG_DIR__'
     description: >
       Root Java package as a directory path (slash form). Must be the
       slash-form of JavaPackage.
-    prompt: "Root Java package (slash form)"
-    default: "com/example/app"
+    prompt: 'Root Java package (slash form)'
+    default: 'com/example/app'
     required: true
 
   - name: Database
     type: string
-    placeholder: "__DATABASE__"
-    description: "Database driver (postgres, mysql, h2)"
-    prompt: "Database driver"
-    default: "postgres"
+    placeholder: '__DATABASE__'
+    description: 'Database driver (postgres, mysql, h2)'
+    prompt: 'Database driver'
+    default: 'postgres'
 
   - name: Namespace
     type: string
-    placeholder: "__NAMESPACE__"
-    description: "Kubernetes namespace for deployed resources"
-    prompt: "Kubernetes namespace"
-    default: "default"
+    placeholder: '__NAMESPACE__'
+    description: 'Kubernetes namespace for deployed resources'
+    prompt: 'Kubernetes namespace'
+    default: 'default'
 
   - name: Replicas
     type: string
-    placeholder: "__REPLICAS__"
-    description: "Kubernetes pod replica count"
-    prompt: "Replicas"
-    default: "2"
+    placeholder: '__REPLICAS__'
+    description: 'Kubernetes pod replica count'
+    prompt: 'Replicas'
+    default: '2'
 
   - name: IncludeMonitoring
     type: bool
-    placeholder: "__INCLUDE_MONITORING__"
-    description: "Include Grafana + Prometheus + Loki observability stack under observability/"
-    prompt: "Include observability stack?"
+    placeholder: '__INCLUDE_MONITORING__'
+    description: 'Include Grafana + Prometheus + Loki observability stack under observability/'
+    prompt: 'Include observability stack?'
     default: false
 
 templates:
   - template: spring-boot-service
     root: true
     variables:
-      ProjectName: "${ProjectName}"
-      GroupId: "${GroupId}"
-      ArtifactId: "${ProjectName}"
-      JavaPackage: "${JavaPackage}"
-      PackageDir: "${PackageDir}"
-      Database: "${Database}"
+      ProjectName: '${ProjectName}'
+      GroupId: '${GroupId}'
+      ArtifactId: '${ProjectName}'
+      JavaPackage: '${JavaPackage}'
+      PackageDir: '${PackageDir}'
+      Database: '${Database}'
       IncludeDocker: true
 
   - template: module-spring-security
-    path: "."
+    path: '.'
     variables:
-      ProjectName: "${ProjectName}"
-      JavaPackage: "${JavaPackage}"
-      PackageDir: "${PackageDir}"
+      ProjectName: '${ProjectName}'
+      JavaPackage: '${JavaPackage}'
+      PackageDir: '${PackageDir}'
 
   - template: k8s-deploy
     path: k8s
     variables:
-      ProjectName: "${ProjectName}"
-      Namespace: "${Namespace}"
-      Replicas: "${Replicas}"
+      ProjectName: '${ProjectName}'
+      Namespace: '${Namespace}'
+      Replicas: '${Replicas}'
       IncludeIngress: true
       IncludeHpa: true
       IncludeHelm: true
@@ -110,6 +110,6 @@ templates:
     path: observability
     condition: IncludeMonitoring
     variables:
-      ProjectName: "${ProjectName}"
-      DeployTarget: "docker-compose"
+      ProjectName: '${ProjectName}'
+      DeployTarget: 'docker-compose'
       IncludeAlerts: true

--- a/composites/vscode-ai-extension.yaml
+++ b/composites/vscode-ai-extension.yaml
@@ -1,66 +1,66 @@
 apiVersion: nanohype/v1
 kind: composite
 name: vscode-ai-extension
-displayName: "VS Code AI Extension"
+displayName: 'VS Code AI Extension'
 description: >
   VS Code extension with AI provider integration, MCP tool
   servers, and versioned prompt management.
-version: "0.1.0"
+version: '0.1.0'
 tags: [vscode, extension, ai, mcp]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: ExtensionName
     type: string
-    placeholder: "__EXTENSION_NAME__"
-    description: "Display name in VS Code"
+    placeholder: '__EXTENSION_NAME__'
+    description: 'Display name in VS Code'
     required: true
 
   - name: Publisher
     type: string
-    placeholder: "__PUBLISHER__"
-    description: "VS Code marketplace publisher ID"
+    placeholder: '__PUBLISHER__'
+    description: 'VS Code marketplace publisher ID'
     required: true
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludePrompts
     type: bool
-    placeholder: "__INCLUDE_PROMPTS__"
-    description: "Include versioned prompt library"
+    placeholder: '__INCLUDE_PROMPTS__'
+    description: 'Include versioned prompt library'
     default: true
 
 templates:
   - template: vscode-ext
     root: true
     variables:
-      ProjectName: "${ProjectName}"
-      ExtensionName: "${ExtensionName}"
-      Publisher: "${Publisher}"
+      ProjectName: '${ProjectName}'
+      ExtensionName: '${ExtensionName}'
+      Publisher: '${Publisher}'
       IncludeWebview: true
       IncludeAi: true
 
   - template: mcp-server-ts
     path: mcp-server
     variables:
-      ProjectName: "${ProjectName}-mcp"
-      ServerName: "${ExtensionName} Tools"
-      Transport: "stdio"
+      ProjectName: '${ProjectName}-mcp'
+      ServerName: '${ExtensionName} Tools'
+      Transport: 'stdio'
 
   - template: prompt-library
     path: prompts
     condition: IncludePrompts
     variables:
-      ProjectName: "${ProjectName}-prompts"
+      ProjectName: '${ProjectName}-prompts'

--- a/docs/authoring-guide.md
+++ b/docs/authoring-guide.md
@@ -64,11 +64,11 @@ This is always `nanohype/v1`. Consumers reject manifests with any other value.
 
 ```yaml
 name: my-template
-displayName: "My Template"
+displayName: 'My Template'
 description: >
   A one-to-three sentence description of what this template scaffolds
   and why someone would reach for it.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 tags: [python, cli, async]
 ```
@@ -90,14 +90,14 @@ Variables are the inputs users provide when scaffolding. Declare them as an orde
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Name of the project"
-    prompt: "Project name"
-    default: "myapp"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Name of the project'
+    prompt: 'Project name'
+    default: 'myapp'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 ```
 
 Every variable needs four fields: `name`, `type`, `placeholder`, and `description`. Everything else is optional (but `prompt`, `default`, and `validation` are strongly recommended).
@@ -113,13 +113,13 @@ There are four types. Here is a complete example of each.
 ```yaml
 - name: GoModule
   type: string
-  placeholder: "__GO_MODULE__"
-  description: "Full Go module path"
-  default: "github.com/example/${ProjectName}"
+  placeholder: '__GO_MODULE__'
+  description: 'Full Go module path'
+  default: 'github.com/example/${ProjectName}'
   required: true
   validation:
-    pattern: "^[a-z][a-z0-9./-]*$"
-    message: "Must be a valid Go module path"
+    pattern: '^[a-z][a-z0-9./-]*$'
+    message: 'Must be a valid Go module path'
 ```
 
 **bool** -- True or false. Primarily used with conditionals to include or exclude files:
@@ -127,8 +127,8 @@ There are four types. Here is a complete example of each.
 ```yaml
 - name: IncludeDocker
   type: bool
-  placeholder: "__INCLUDE_DOCKER__"
-  description: "Include Dockerfile and docker-compose.yaml"
+  placeholder: '__INCLUDE_DOCKER__'
+  description: 'Include Dockerfile and docker-compose.yaml'
   default: false
 ```
 
@@ -137,10 +137,10 @@ There are four types. Here is a complete example of each.
 ```yaml
 - name: LogLevel
   type: enum
-  placeholder: "__LOG_LEVEL__"
-  description: "Default log level"
-  default: "info"
-  options: ["debug", "info", "warn", "error"]
+  placeholder: '__LOG_LEVEL__'
+  description: 'Default log level'
+  default: 'info'
+  options: ['debug', 'info', 'warn', 'error']
 ```
 
 **int** -- An integer value:
@@ -148,8 +148,8 @@ There are four types. Here is a complete example of each.
 ```yaml
 - name: HttpPort
   type: int
-  placeholder: "__HTTP_PORT__"
-  description: "Default HTTP port"
+  placeholder: '__HTTP_PORT__'
+  description: 'Default HTTP port'
   default: 8080
 ```
 
@@ -162,15 +162,15 @@ Defaults can reference other variables using `${VariableName}` syntax:
 ```yaml
 - name: ProjectName
   type: string
-  placeholder: "__PROJECT_NAME__"
-  description: "Project name"
-  default: "myapp"
+  placeholder: '__PROJECT_NAME__'
+  description: 'Project name'
+  default: 'myapp'
 
 - name: BinaryName
   type: string
-  placeholder: "__BINARY_NAME__"
-  description: "Output binary name"
-  default: "${ProjectName}"
+  placeholder: '__BINARY_NAME__'
+  description: 'Output binary name'
+  default: '${ProjectName}'
 ```
 
 Cross-references are resolved after the user provides all explicit values. Circular references are invalid -- consumers will reject them.
@@ -183,8 +183,8 @@ The `validation.pattern` field takes an ECMAScript regex. Consumers treat it as 
 
 ```yaml
 validation:
-  pattern: "^[a-z][a-z0-9-]*$"
-  message: "Must be lowercase kebab-case starting with a letter"
+  pattern: '^[a-z][a-z0-9-]*$'
+  message: 'Must be lowercase kebab-case starting with a letter'
 ```
 
 Validation runs after defaults are resolved, before placeholder substitution. It applies to `string` and `int` types. There is no validation for `bool` (it is inherently constrained) and `enum` values are validated against `options` automatically.
@@ -246,16 +246,16 @@ Conditionals let you include or exclude files based on a `bool` variable.
 variables:
   - name: IncludeDocker
     type: bool
-    placeholder: "__INCLUDE_DOCKER__"
-    description: "Include Docker configuration"
+    placeholder: '__INCLUDE_DOCKER__'
+    description: 'Include Docker configuration'
     default: false
 
 conditionals:
-  - path: "Dockerfile"
+  - path: 'Dockerfile'
     when: IncludeDocker
-  - path: "docker-compose.yaml"
+  - path: 'docker-compose.yaml'
     when: IncludeDocker
-  - path: ".dockerignore"
+  - path: '.dockerignore'
     when: IncludeDocker
 ```
 
@@ -278,13 +278,13 @@ hooks:
   pre: []
   post:
     - name: install-dependencies
-      description: "Install Python dependencies"
-      run: "pip install -r requirements.txt"
-      workdir: "."
+      description: 'Install Python dependencies'
+      run: 'pip install -r requirements.txt'
+      workdir: '.'
     - name: init-git
-      description: "Initialize git repository"
-      run: "git init && git add -A"
-      workdir: "."
+      description: 'Initialize git repository'
+      run: 'git init && git add -A'
+      workdir: '.'
 ```
 
 ### 6.1 Lifecycle
@@ -339,11 +339,11 @@ Prerequisites declare external tools the scaffolded output or hooks depend on.
 ```yaml
 prerequisites:
   - name: go
-    version: ">=1.22"
-    purpose: "Go compilation and module management"
+    version: '>=1.22'
+    purpose: 'Go compilation and module management'
     optional: false
   - name: goreleaser
-    purpose: "Automated release builds (only if release config is included)"
+    purpose: 'Automated release builds (only if release config is included)'
     optional: true
 ```
 
@@ -463,9 +463,9 @@ Use `type: string` (not `enum`) for the variable so users can add custom provide
 variables:
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider (built-in: anthropic, openai — or any registered custom provider)"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider (built-in: anthropic, openai — or any registered custom provider)'
+    default: 'anthropic'
 ```
 
 Adding a new provider to a scaffolded project is then: create a file, implement the interface, self-register, add one import line.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -8,62 +8,62 @@ A decision guide for selecting and composing templates. Read this to understand 
 
 ### By client problem
 
-| Client says... | Start with | Layer in | Deploy with |
-|---|---|---|---|
-| "We need an AI chatbot" | agentic-loop | module-auth-ts, module-database-ts | ts-service + infra-fly |
-| "Search our internal docs" | rag-pipeline | module-storage-ts, module-database-ts | ts-service + infra-aws |
-| "Build us an MCP server" | mcp-server-ts | eval-harness | infra-fly |
-| "CLI tool for our platform" | go-cli | eval-harness | infra-fly |
-| "Chrome extension with AI" | chrome-ext | mcp-server-ts | — |
-| "VS Code extension" | vscode-ext | mcp-server-ts, prompt-library | — |
-| "Full-stack AI web app" | next-app | module-auth-ts, module-database-ts, rag-pipeline | infra-vercel |
-| "API service (TypeScript)" | ts-service | module-auth-ts, module-database-ts, module-observability-ts | infra-aws or infra-fly |
-| "API service (Go)" | go-service | — (auth + db built in) | infra-aws or infra-fly |
-| "We need background processing" | ts-service | module-queue-ts, module-database-ts | infra-aws |
-| "Evaluate our LLM outputs" | eval-harness | prompt-library | — |
-| "Manage our prompts" | prompt-library | eval-harness | — |
-| "Multi-agent system" | a2a-agent | agentic-loop, mcp-server-ts | ts-service + infra-aws |
-| "AI safety / content filtering" | guardrails | agentic-loop or ts-service | — |
-| "Process images/audio/video" | multimodal-pipeline | module-storage-ts, rag-pipeline | ts-service + infra-aws |
-| "Deploy to AWS" | infra-aws | — | — |
-| "Deploy to Fly.io" | infra-fly | — | — |
-| "Deploy to GCP" | infra-gcp | — | — |
-| "Deploy to Vercel" | infra-vercel | — | — |
-| "Kubernetes deployment" | k8s-deploy | — | — |
-| "Monorepo for everything" | monorepo | (all others nest inside) | — |
+| Client says...                  | Start with          | Layer in                                                    | Deploy with            |
+| ------------------------------- | ------------------- | ----------------------------------------------------------- | ---------------------- |
+| "We need an AI chatbot"         | agentic-loop        | module-auth-ts, module-database-ts                          | ts-service + infra-fly |
+| "Search our internal docs"      | rag-pipeline        | module-storage-ts, module-database-ts                       | ts-service + infra-aws |
+| "Build us an MCP server"        | mcp-server-ts       | eval-harness                                                | infra-fly              |
+| "CLI tool for our platform"     | go-cli              | eval-harness                                                | infra-fly              |
+| "Chrome extension with AI"      | chrome-ext          | mcp-server-ts                                               | —                      |
+| "VS Code extension"             | vscode-ext          | mcp-server-ts, prompt-library                               | —                      |
+| "Full-stack AI web app"         | next-app            | module-auth-ts, module-database-ts, rag-pipeline            | infra-vercel           |
+| "API service (TypeScript)"      | ts-service          | module-auth-ts, module-database-ts, module-observability-ts | infra-aws or infra-fly |
+| "API service (Go)"              | go-service          | — (auth + db built in)                                      | infra-aws or infra-fly |
+| "We need background processing" | ts-service          | module-queue-ts, module-database-ts                         | infra-aws              |
+| "Evaluate our LLM outputs"      | eval-harness        | prompt-library                                              | —                      |
+| "Manage our prompts"            | prompt-library      | eval-harness                                                | —                      |
+| "Multi-agent system"            | a2a-agent           | agentic-loop, mcp-server-ts                                 | ts-service + infra-aws |
+| "AI safety / content filtering" | guardrails          | agentic-loop or ts-service                                  | —                      |
+| "Process images/audio/video"    | multimodal-pipeline | module-storage-ts, rag-pipeline                             | ts-service + infra-aws |
+| "Deploy to AWS"                 | infra-aws           | —                                                           | —                      |
+| "Deploy to Fly.io"              | infra-fly           | —                                                           | —                      |
+| "Deploy to GCP"                 | infra-gcp           | —                                                           | —                      |
+| "Deploy to Vercel"              | infra-vercel        | —                                                           | —                      |
+| "Kubernetes deployment"         | k8s-deploy          | —                                                           | —                      |
+| "Monorepo for everything"       | monorepo            | (all others nest inside)                                    | —                      |
 
 ### By engagement type
 
-| Engagement | Typical stack | Timeline signal |
-|---|---|---|
-| **Proof of concept** | agentic-loop + eval-harness | Days |
-| **Internal tool** | go-cli or chrome-ext + mcp-server-ts | 1-2 weeks |
-| **Customer-facing chatbot** | agentic-loop + ts-service + module-auth-ts + module-database-ts + infra-fly | 2-4 weeks |
-| **Document intelligence** | rag-pipeline + ts-service + module-storage-ts + infra-aws | 2-4 weeks |
-| **Platform with AI features** | next-app + rag-pipeline + module-auth-ts + module-database-ts + module-queue-ts + infra-aws | 4-8 weeks |
-| **Enterprise AI infrastructure** | monorepo + agentic-loop + mcp-server-ts + guardrails + eval-harness + k8s-deploy | 8+ weeks |
-| **Developer tooling** | vscode-ext or chrome-ext + mcp-server-ts + prompt-library | 2-4 weeks |
+| Engagement                       | Typical stack                                                                               | Timeline signal |
+| -------------------------------- | ------------------------------------------------------------------------------------------- | --------------- |
+| **Proof of concept**             | agentic-loop + eval-harness                                                                 | Days            |
+| **Internal tool**                | go-cli or chrome-ext + mcp-server-ts                                                        | 1-2 weeks       |
+| **Customer-facing chatbot**      | agentic-loop + ts-service + module-auth-ts + module-database-ts + infra-fly                 | 2-4 weeks       |
+| **Document intelligence**        | rag-pipeline + ts-service + module-storage-ts + infra-aws                                   | 2-4 weeks       |
+| **Platform with AI features**    | next-app + rag-pipeline + module-auth-ts + module-database-ts + module-queue-ts + infra-aws | 4-8 weeks       |
+| **Enterprise AI infrastructure** | monorepo + agentic-loop + mcp-server-ts + guardrails + eval-harness + k8s-deploy            | 8+ weeks        |
+| **Developer tooling**            | vscode-ext or chrome-ext + mcp-server-ts + prompt-library                                   | 2-4 weeks       |
 
 ### By technical requirement
 
-| Requirement | Template | Why |
-|---|---|---|
-| Streaming responses | agentic-loop, ts-service, next-app | Built-in streaming support |
-| Tool calling | agentic-loop, mcp-server-ts | Tool registry pattern |
-| Vector search | rag-pipeline | Full retrieval pipeline with vector store registry |
-| Multi-model support | Any with LlmProvider | Provider registry — swap models at config level |
-| Offline/local models | rag-pipeline (embedding), agentic-loop | Local provider stubs in registry |
-| Real-time updates | module-queue-ts + ts-service | Job processing with webhook delivery |
-| File handling | module-storage-ts | S3/R2/GCS/local abstraction |
-| Auth required | module-auth-ts + ts-service | JWT/Clerk/Auth0/Supabase/API key |
-| Background jobs | module-queue-ts | BullMQ/SQS/in-memory |
-| Caching layer | module-cache-ts | Redis/Valkey/in-memory |
-| Rate limiting | module-rate-limit-ts | Token bucket/sliding window |
-| Observability | module-observability-ts | OpenTelemetry traces + metrics |
-| Database | module-database-ts | Drizzle ORM with Postgres/SQLite/Turso |
-| Content safety | guardrails | Input/output filtering pipeline |
-| Multi-agent coordination | a2a-agent | Agent-to-Agent protocol |
-| CI/CD | infra-fly, infra-aws, k8s-deploy | GitHub Actions workflows included |
+| Requirement              | Template                               | Why                                                |
+| ------------------------ | -------------------------------------- | -------------------------------------------------- |
+| Streaming responses      | agentic-loop, ts-service, next-app     | Built-in streaming support                         |
+| Tool calling             | agentic-loop, mcp-server-ts            | Tool registry pattern                              |
+| Vector search            | rag-pipeline                           | Full retrieval pipeline with vector store registry |
+| Multi-model support      | Any with LlmProvider                   | Provider registry — swap models at config level    |
+| Offline/local models     | rag-pipeline (embedding), agentic-loop | Local provider stubs in registry                   |
+| Real-time updates        | module-queue-ts + ts-service           | Job processing with webhook delivery               |
+| File handling            | module-storage-ts                      | S3/R2/GCS/local abstraction                        |
+| Auth required            | module-auth-ts + ts-service            | JWT/Clerk/Auth0/Supabase/API key                   |
+| Background jobs          | module-queue-ts                        | BullMQ/SQS/in-memory                               |
+| Caching layer            | module-cache-ts                        | Redis/Valkey/in-memory                             |
+| Rate limiting            | module-rate-limit-ts                   | Token bucket/sliding window                        |
+| Observability            | module-observability-ts                | OpenTelemetry traces + metrics                     |
+| Database                 | module-database-ts                     | Drizzle ORM with Postgres/SQLite/Turso             |
+| Content safety           | guardrails                             | Input/output filtering pipeline                    |
+| Multi-agent coordination | a2a-agent                              | Agent-to-Agent protocol                            |
+| CI/CD                    | infra-fly, infra-aws, k8s-deploy       | GitHub Actions workflows included                  |
 
 ---
 

--- a/docs/composites-guide.md
+++ b/docs/composites-guide.md
@@ -10,32 +10,32 @@ Individual templates are building blocks. Composites are the blueprints that ass
 
 ## Selection guide
 
-| Composite | What it produces | Templates | Best for |
-|---|---|---|---|
-| `proof-of-concept` | Minimal AI agent with eval harness | 2 | Quick POC -- validate an idea in days, not weeks |
-| `ai-chatbot` | Full-stack chatbot with auth, evals, deployment | 6 | Customer-facing conversational AI |
-| `ai-web-app` | Next.js frontend with RAG, auth, database, observability | 8 | AI-powered web applications with document search |
-| `production-api` | TypeScript API with auth, DB, caching, rate limiting, queue, observability | 9 | Backend services that need to be production-grade from day one |
-| `enterprise-ai` | Agents, RAG, guardrails, evals, prompts, storage, K8s deploy | 15 | Full enterprise AI platform with all the operational layers |
-| `multi-agent` | A2A orchestrator, agent, MCP tools, guardrails, evals | 8 | Systems where multiple AI agents collaborate and delegate |
-| `rag-agent` | Agent with RAG pipeline, storage, database, evals | 8 | AI agents that need grounded knowledge from documents |
-| `document-intelligence` | RAG pipeline, API service, storage, database, evals | 7 | Document search and question-answering systems |
-| `background-processor` | Worker service with queue, database, storage, observability | 7 | Async job processing without synchronous HTTP |
-| `safe-ai-agent` | Agent with guardrails, evals, prompt library | 5 | Responsible AI -- input filtering, output validation, testing |
-| `eval-suite` | Eval harness, prompt library, guardrails validation | 4 | Testing AI systems without building them |
-| `go-microservice` | Go HTTP service with evals and deployment | 3 | Lightweight, single-binary Go services |
-| `mcp-toolkit` | MCP server with prompts and evals | 3 | Building tool servers for AI systems |
-| `chrome-ai-extension` | Chrome extension with MCP tools and prompt library | 3 | Browser extensions with AI sidepanel |
-| `vscode-ai-extension` | VS Code extension with MCP tools and prompt library | 3 | Editor extensions with AI integration |
-| `internal-tool` | CLI or extension backed by MCP servers | 4 | Internal team tooling |
-| `cost-optimized-ai` | LLM gateway with cost routing, semantic caching, observability | 4 | Minimizing LLM spend with smart routing and caching |
-| `ai-platform` | Monorepo with service, gateway, vectors, pipeline, auth, database, billing, monitoring | 9 | Full AI product with usage-based billing |
-| `agent-team` | Orchestrator, specialized agents, MCP tools, evals | 6 | Multi-agent systems with distinct roles |
-| `client-engagement` | Proposal, battle cards, brand guidelines, campaign brief, onboarding playbook | 5 | Non-engineering client engagement workflows |
-| `product-launch` | Next.js app, design system, tokens, test plan, acceptance criteria, PRD, campaign, runbook | 10 | Cross-functional product launches spanning eng through marketing |
-| `research-to-prototype` | PRD, agentic loop prototype, optional test plan | 3 | Research-driven prototyping from idea to validated POC |
-| `spring-boot-microservice` | Spring Boot 4 HTTP service on JDK 25 with K8s deploy, optional Grafana + Prometheus + Loki | 4 | Java services that need production posture out of the gate |
-| `identity-aware-service` | Spring Boot 4 service with Istio mesh-edge auth + Spring Security resource server | 5 | Defense-in-depth identity against a shared OIDC issuer |
+| Composite                  | What it produces                                                                           | Templates | Best for                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------ | --------- | ---------------------------------------------------------------- |
+| `proof-of-concept`         | Minimal AI agent with eval harness                                                         | 2         | Quick POC -- validate an idea in days, not weeks                 |
+| `ai-chatbot`               | Full-stack chatbot with auth, evals, deployment                                            | 6         | Customer-facing conversational AI                                |
+| `ai-web-app`               | Next.js frontend with RAG, auth, database, observability                                   | 8         | AI-powered web applications with document search                 |
+| `production-api`           | TypeScript API with auth, DB, caching, rate limiting, queue, observability                 | 9         | Backend services that need to be production-grade from day one   |
+| `enterprise-ai`            | Agents, RAG, guardrails, evals, prompts, storage, K8s deploy                               | 15        | Full enterprise AI platform with all the operational layers      |
+| `multi-agent`              | A2A orchestrator, agent, MCP tools, guardrails, evals                                      | 8         | Systems where multiple AI agents collaborate and delegate        |
+| `rag-agent`                | Agent with RAG pipeline, storage, database, evals                                          | 8         | AI agents that need grounded knowledge from documents            |
+| `document-intelligence`    | RAG pipeline, API service, storage, database, evals                                        | 7         | Document search and question-answering systems                   |
+| `background-processor`     | Worker service with queue, database, storage, observability                                | 7         | Async job processing without synchronous HTTP                    |
+| `safe-ai-agent`            | Agent with guardrails, evals, prompt library                                               | 5         | Responsible AI -- input filtering, output validation, testing    |
+| `eval-suite`               | Eval harness, prompt library, guardrails validation                                        | 4         | Testing AI systems without building them                         |
+| `go-microservice`          | Go HTTP service with evals and deployment                                                  | 3         | Lightweight, single-binary Go services                           |
+| `mcp-toolkit`              | MCP server with prompts and evals                                                          | 3         | Building tool servers for AI systems                             |
+| `chrome-ai-extension`      | Chrome extension with MCP tools and prompt library                                         | 3         | Browser extensions with AI sidepanel                             |
+| `vscode-ai-extension`      | VS Code extension with MCP tools and prompt library                                        | 3         | Editor extensions with AI integration                            |
+| `internal-tool`            | CLI or extension backed by MCP servers                                                     | 4         | Internal team tooling                                            |
+| `cost-optimized-ai`        | LLM gateway with cost routing, semantic caching, observability                             | 4         | Minimizing LLM spend with smart routing and caching              |
+| `ai-platform`              | Monorepo with service, gateway, vectors, pipeline, auth, database, billing, monitoring     | 9         | Full AI product with usage-based billing                         |
+| `agent-team`               | Orchestrator, specialized agents, MCP tools, evals                                         | 6         | Multi-agent systems with distinct roles                          |
+| `client-engagement`        | Proposal, battle cards, brand guidelines, campaign brief, onboarding playbook              | 5         | Non-engineering client engagement workflows                      |
+| `product-launch`           | Next.js app, design system, tokens, test plan, acceptance criteria, PRD, campaign, runbook | 10        | Cross-functional product launches spanning eng through marketing |
+| `research-to-prototype`    | PRD, agentic loop prototype, optional test plan                                            | 3         | Research-driven prototyping from idea to validated POC           |
+| `spring-boot-microservice` | Spring Boot 4 HTTP service on JDK 25 with K8s deploy, optional Grafana + Prometheus + Loki | 4         | Java services that need production posture out of the gate       |
+| `identity-aware-service`   | Spring Boot 4 service with Istio mesh-edge auth + Spring Security resource server          | 5         | Defense-in-depth identity against a shared OIDC issuer           |
 
 ---
 
@@ -180,32 +180,32 @@ Minimal structure:
 apiVersion: nanohype/v1
 kind: composite
 name: my-stack
-displayName: "My Stack"
+displayName: 'My Stack'
 description: >
   What this composite produces and who it is for.
-version: "0.1.0"
+version: '0.1.0'
 tags: [relevant, searchable, tags]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
 ```
 
 Key rules:

--- a/docs/platform-reference-pattern.md
+++ b/docs/platform-reference-pattern.md
@@ -15,13 +15,13 @@ A Platform Reference makes the public consumption path coherent. Anyone reading 
 
 ## The five surfaces
 
-| Surface | What it is | Audience | Mode |
-|---|---|---|---|
-| **Top-level reference doc** | Single entry point: who it's for, the repos in the stack, the catalog, the standards, the deploy contracts, "build your own client" quickstart | Human readers + agents bootstrapping fresh | Markdown |
-| **Catalog manifest** | Machine-readable index of every consumable thing (templates, composites, modules, addons — whatever your stack ships) | Agents doing discovery | JSON |
-| **Standards manifests** | The public production bar an external client must obey to produce stack-compatible output | Agents that produce work | JSON + human-readable companion README |
-| **Per-repo `AGENTS.md`** | Five-minute orientation per repo: what it gives you, contract surface, "add a new X" recipe, conventions, pointers | Agents about to touch a specific repo | Markdown |
-| **SDK + MCP server** | Programmatic surface — discovery functions, loaders for the manifests, an MCP server agents can mount | Programs (agents + tools) | TypeScript package + npm-distributed MCP server |
+| Surface                     | What it is                                                                                                                                     | Audience                                   | Mode                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------- |
+| **Top-level reference doc** | Single entry point: who it's for, the repos in the stack, the catalog, the standards, the deploy contracts, "build your own client" quickstart | Human readers + agents bootstrapping fresh | Markdown                                        |
+| **Catalog manifest**        | Machine-readable index of every consumable thing (templates, composites, modules, addons — whatever your stack ships)                          | Agents doing discovery                     | JSON                                            |
+| **Standards manifests**     | The public production bar an external client must obey to produce stack-compatible output                                                      | Agents that produce work                   | JSON + human-readable companion README          |
+| **Per-repo `AGENTS.md`**    | Five-minute orientation per repo: what it gives you, contract surface, "add a new X" recipe, conventions, pointers                             | Agents about to touch a specific repo      | Markdown                                        |
+| **SDK + MCP server**        | Programmatic surface — discovery functions, loaders for the manifests, an MCP server agents can mount                                          | Programs (agents + tools)                  | TypeScript package + npm-distributed MCP server |
 
 The five surfaces fit together: the **top-level doc** points at everything else; the **catalog** lets agents discover what exists; the **standards** name the bar; the **AGENTS.md** files are the per-repo deep links; the **SDK/MCP** is how programs read all of it without parsing markdown.
 
@@ -36,15 +36,15 @@ Heuristic: "Would publishing this let someone replicate my reference client, or 
 
 For nanohype the cut landed at:
 
-| Public | Private |
-|---|---|
-| Toolchain commands per language | The orchestration logic that dispatches them |
-| Version-currency policy (EOL, @pin, registries) | The build-verifier's TRANSCRIPTS+CITATIONS evidence contract |
-| Platform-tenant contract (Helm chart + ApplicationSet + Platform CR shape) | The 4-role merge-gate choreography that enforces it |
-| LLM policy (Bedrock-primary, model tiers, regions) | The factory-preamble prompt that primes every agent |
-| Quality-rubric *dimension names* | Rubric weights, per-reviewer assignments, specific REJECT criteria, A–F methodology |
-| Per-repo `AGENTS.md` (5-min start) | Internal runbooks, role briefs, taste-encoded instructions |
-| Reference client architecture (how it works at a high level) | Reference client source code (how it orchestrates 83 agents) |
+| Public                                                                     | Private                                                                             |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Toolchain commands per language                                            | The orchestration logic that dispatches them                                        |
+| Version-currency policy (EOL, @pin, registries)                            | The build-verifier's TRANSCRIPTS+CITATIONS evidence contract                        |
+| Platform-tenant contract (Helm chart + ApplicationSet + Platform CR shape) | The 4-role merge-gate choreography that enforces it                                 |
+| LLM policy (Bedrock-primary, model tiers, regions)                         | The factory-preamble prompt that primes every agent                                 |
+| Quality-rubric _dimension names_                                           | Rubric weights, per-reviewer assignments, specific REJECT criteria, A–F methodology |
+| Per-repo `AGENTS.md` (5-min start)                                         | Internal runbooks, role briefs, taste-encoded instructions                          |
+| Reference client architecture (how it works at a high level)               | Reference client source code (how it orchestrates 83 agents)                        |
 
 The line varies per org. The mechanics — five surfaces, two layers — are the same.
 

--- a/docs/platform-reference.md
+++ b/docs/platform-reference.md
@@ -87,29 +87,24 @@ If you're skipping straight to delivery, only `eks-agent-platform/AGENTS.md` is 
 `@nanohype/sdk` is the reference TypeScript implementation of the catalog + standards consumption pattern. One runtime dependency (a YAML parser).
 
 ```typescript
-import {
-  LocalSource,
-  loadCatalog,
-  loadStandards,
-  renderTemplate,
-} from "@nanohype/sdk";
+import { LocalSource, loadCatalog, loadStandards, renderTemplate } from '@nanohype/sdk';
 
 // Discovery
-const source = new LocalSource("/path/to/nanohype-repo");
+const source = new LocalSource('/path/to/nanohype-repo');
 const catalog = await loadCatalog(source);
 const standards = await loadStandards(source);
 
 // Selection (your client decides which template fits)
 const templateName = catalog.templates.find(
-  (t) => t.category === "ai-systems" && t.tags.includes("rag"),
+  (t) => t.category === 'ai-systems' && t.tags.includes('rag'),
 )?.name;
 
 // Render
 await renderTemplate({
   source,
   templateName,
-  outputDir: "/path/to/output",
-  variables: { ProjectName: "my-rag-bot", LlmProvider: "anthropic" },
+  outputDir: '/path/to/output',
+  variables: { ProjectName: 'my-rag-bot', LlmProvider: 'anthropic' },
 });
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,21 +8,21 @@ A template catalog for AI-focused projects. Each template produces a production-
 
 ### By problem
 
-| You need... | Start with | Add modules |
-|---|---|---|
-| An AI agent | `agentic-loop` | `eval-harness`, `mcp-server-ts` |
-| Document search / RAG | `rag-pipeline` | `module-vector-store`, `module-storage-ts` |
-| An HTTP API | `ts-service` | `module-auth-ts`, `module-database-ts` |
-| A Go HTTP API | `go-service` | — (auth + db built in) |
-| A background worker | `worker-service` | `module-queue-ts`, `module-database-ts` |
-| A CLI tool | `go-cli` | `eval-harness` |
-| A full-stack AI app | Composite: `ai-web-app` or `ai-chatbot` | — |
-| A production platform | Composite: `production-api` | — |
-| Multi-agent coordination | `a2a-agent` | `agentic-loop`, `mcp-server-ts` |
-| AI safety / content filtering | `guardrails` | `agentic-loop` |
-| A Chrome extension with AI | `chrome-ext` | `mcp-server-ts` |
-| A VS Code extension | `vscode-ext` | `mcp-server-ts`, `prompt-library` |
-| To deploy something | `infra-aws`, `infra-fly`, `infra-gcp`, `infra-vercel`, or `k8s-deploy` | — |
+| You need...                   | Start with                                                             | Add modules                                |
+| ----------------------------- | ---------------------------------------------------------------------- | ------------------------------------------ |
+| An AI agent                   | `agentic-loop`                                                         | `eval-harness`, `mcp-server-ts`            |
+| Document search / RAG         | `rag-pipeline`                                                         | `module-vector-store`, `module-storage-ts` |
+| An HTTP API                   | `ts-service`                                                           | `module-auth-ts`, `module-database-ts`     |
+| A Go HTTP API                 | `go-service`                                                           | — (auth + db built in)                     |
+| A background worker           | `worker-service`                                                       | `module-queue-ts`, `module-database-ts`    |
+| A CLI tool                    | `go-cli`                                                               | `eval-harness`                             |
+| A full-stack AI app           | Composite: `ai-web-app` or `ai-chatbot`                                | —                                          |
+| A production platform         | Composite: `production-api`                                            | —                                          |
+| Multi-agent coordination      | `a2a-agent`                                                            | `agentic-loop`, `mcp-server-ts`            |
+| AI safety / content filtering | `guardrails`                                                           | `agentic-loop`                             |
+| A Chrome extension with AI    | `chrome-ext`                                                           | `mcp-server-ts`                            |
+| A VS Code extension           | `vscode-ext`                                                           | `mcp-server-ts`, `prompt-library`          |
+| To deploy something           | `infra-aws`, `infra-fly`, `infra-gcp`, `infra-vercel`, or `k8s-deploy` | —                                          |
 
 ### Not sure?
 
@@ -67,17 +67,17 @@ This scaffolds the `ai-chatbot` composite, which assembles an `agentic-loop`, `t
 
 Available composites:
 
-| Composite | What it assembles |
-|---|---|
-| `proof-of-concept` | Agent + evals — fastest path to a working prototype |
-| `ai-chatbot` | Agent + service + auth + deployment |
-| `ai-web-app` | Next.js + RAG + auth + database + observability |
-| `document-intelligence` | RAG + storage + database |
-| `production-api` | Service + auth + database + cache + rate limiting + queue + observability |
-| `enterprise-ai` | Agents + RAG + guardrails + evals + K8s |
-| `cost-optimized-ai` | LLM gateway + semantic cache + cost monitoring |
-| `ai-platform` | Service + gateway + vectors + auth + billing + monitoring |
-| `agent-team` | Orchestrator + specialized agents + MCP tools + evals |
+| Composite               | What it assembles                                                         |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `proof-of-concept`      | Agent + evals — fastest path to a working prototype                       |
+| `ai-chatbot`            | Agent + service + auth + deployment                                       |
+| `ai-web-app`            | Next.js + RAG + auth + database + observability                           |
+| `document-intelligence` | RAG + storage + database                                                  |
+| `production-api`        | Service + auth + database + cache + rate limiting + queue + observability |
+| `enterprise-ai`         | Agents + RAG + guardrails + evals + K8s                                   |
+| `cost-optimized-ai`     | LLM gateway + semantic cache + cost monitoring                            |
+| `ai-platform`           | Service + gateway + vectors + auth + billing + monitoring                 |
+| `agent-team`            | Orchestrator + specialized agents + MCP tools + evals                     |
 
 See the full list in `composites/` or run `npx nanohype list --composites`.
 

--- a/docs/reference-architectures/agentic-systems.md
+++ b/docs/reference-architectures/agentic-systems.md
@@ -411,16 +411,16 @@ Regression suites should include edge cases: tasks that require error recovery, 
 
 ## 7. Decision Matrix: Choosing a Pattern
 
-| Factor | ReAct | Plan-and-Execute | Reflection |
-|---|---|---|---|
-| Task complexity | Low to medium | Medium to high | Any |
-| Steps known in advance | No | Roughly yes | N/A |
-| Auditability need | Medium (reasoning trace) | High (explicit plan) | Medium |
-| Latency tolerance | Low (starts immediately) | Higher (planning phase) | Higher (critique pass) |
-| Token budget | Moderate | Higher (plan + execution) | Higher (generate + critique) |
-| Error recovery | Implicit (next step adapts) | Explicit (replan) | Implicit (revise) |
-| Best for | General-purpose agents | Multi-step workflows | Quality-critical output |
-| Combine with | Reflection for quality | ReAct within each step | ReAct or Plan-and-Execute |
+| Factor                 | ReAct                       | Plan-and-Execute          | Reflection                   |
+| ---------------------- | --------------------------- | ------------------------- | ---------------------------- |
+| Task complexity        | Low to medium               | Medium to high            | Any                          |
+| Steps known in advance | No                          | Roughly yes               | N/A                          |
+| Auditability need      | Medium (reasoning trace)    | High (explicit plan)      | Medium                       |
+| Latency tolerance      | Low (starts immediately)    | Higher (planning phase)   | Higher (critique pass)       |
+| Token budget           | Moderate                    | Higher (plan + execution) | Higher (generate + critique) |
+| Error recovery         | Implicit (next step adapts) | Explicit (replan)         | Implicit (revise)            |
+| Best for               | General-purpose agents      | Multi-step workflows      | Quality-critical output      |
+| Combine with           | Reflection for quality      | ReAct within each step    | ReAct or Plan-and-Execute    |
 
 **Rules of thumb:**
 

--- a/docs/reference-architectures/mcp-ecosystem.md
+++ b/docs/reference-architectures/mcp-ecosystem.md
@@ -25,15 +25,15 @@ Before MCP, every LLM application that needed tool access had to define its own 
 
 **Library/SDK** — code imported directly into the application. Tightest coupling, best performance, no network overhead.
 
-| Criterion | MCP Server | REST API | Library |
-|---|---|---|---|
-| Discovery | Protocol-native (capability negotiation) | External (docs, OpenAPI spec) | Import statement |
-| LLM integration | Native (tools, resources, prompts) | Requires wrapper | Requires wrapper |
-| Deployment | Sidecar process or remote service | Remote service | In-process |
-| Language coupling | None (protocol-based) | None (HTTP-based) | Same language |
-| Composability | Multiple servers via multi-server clients | Manual aggregation | Manual aggregation |
-| Overhead | Process communication (stdio/HTTP) | Network (HTTP) | None (function call) |
-| Best for | LLM tool integration | General API access | Performance-critical, single-app use |
+| Criterion         | MCP Server                                | REST API                      | Library                              |
+| ----------------- | ----------------------------------------- | ----------------------------- | ------------------------------------ |
+| Discovery         | Protocol-native (capability negotiation)  | External (docs, OpenAPI spec) | Import statement                     |
+| LLM integration   | Native (tools, resources, prompts)        | Requires wrapper              | Requires wrapper                     |
+| Deployment        | Sidecar process or remote service         | Remote service                | In-process                           |
+| Language coupling | None (protocol-based)                     | None (HTTP-based)             | Same language                        |
+| Composability     | Multiple servers via multi-server clients | Manual aggregation            | Manual aggregation                   |
+| Overhead          | Process communication (stdio/HTTP)        | Network (HTTP)                | None (function call)                 |
+| Best for          | LLM tool integration                      | General API access            | Performance-critical, single-app use |
 
 **Build an MCP server** when the tool will be used by multiple LLM applications, when you want it to be discoverable and self-describing, or when the tool is I/O-bound. **Build a REST API** when the service is consumed by non-LLM applications too, or when you need HTTP semantics. **Use a library** when performance is critical, the tool is only used by one application, or you need compile-time type safety.
 
@@ -108,14 +108,14 @@ The original remote transport. Used two HTTP endpoints: a GET endpoint that open
 
 ### 3.4 Choosing a Transport
 
-| Factor | stdio | Streamable HTTP |
-|---|---|---|
-| Server location | Same machine as host | Anywhere (local or remote) |
-| Setup complexity | Low (just a command) | Medium (HTTP server) |
-| Authentication | Not needed (local process) | Required (tokens, OAuth) |
-| Scalability | One instance per host | Shared across hosts |
-| Network dependency | None | Yes |
-| Best for | Local dev tools, file access, Git | Shared services, team tools, cloud APIs |
+| Factor             | stdio                             | Streamable HTTP                         |
+| ------------------ | --------------------------------- | --------------------------------------- |
+| Server location    | Same machine as host              | Anywhere (local or remote)              |
+| Setup complexity   | Low (just a command)              | Medium (HTTP server)                    |
+| Authentication     | Not needed (local process)        | Required (tokens, OAuth)                |
+| Scalability        | One instance per host             | Shared across hosts                     |
+| Network dependency | None                              | Yes                                     |
+| Best for           | Local dev tools, file access, Git | Shared services, team tools, cloud APIs |
 
 ---
 
@@ -136,19 +136,19 @@ A tool has:
 
 ```typescript
 server.tool(
-  "search_files",
-  "Search for files matching a glob pattern in the project directory. " +
-  "Returns a list of matching file paths.",
+  'search_files',
+  'Search for files matching a glob pattern in the project directory. ' +
+    'Returns a list of matching file paths.',
   {
     pattern: z.string().describe("Glob pattern, e.g. '**/*.ts'"),
-    path: z.string().optional().describe("Directory to search in. Defaults to project root.")
+    path: z.string().optional().describe('Directory to search in. Defaults to project root.'),
   },
   async ({ pattern, path }) => {
     const results = await glob(pattern, { cwd: path ?? projectRoot });
     return {
-      content: [{ type: "text", text: results.join("\n") }]
+      content: [{ type: 'text', text: results.join('\n') }],
     };
-  }
+  },
 );
 ```
 
@@ -182,12 +182,12 @@ A resource handler returns a `contents` array, each entry with a URI, MIME type,
 
 MCP does not mandate a URI scheme. Common conventions:
 
-| Scheme | Use |
-|---|---|
-| `file:///` | Local file access |
-| `db://` | Database records |
-| `config://` | Configuration data |
-| `https://` | Web resources |
+| Scheme                               | Use                       |
+| ------------------------------------ | ------------------------- |
+| `file:///`                           | Local file access         |
+| `db://`                              | Database records          |
+| `config://`                          | Configuration data        |
+| `https://`                           | Web resources             |
 | Custom (e.g., `jira://`, `slack://`) | Domain-specific resources |
 
 ### 4.3 Prompts (Templates)
@@ -219,12 +219,14 @@ The TypeScript MCP SDK uses Zod for input validation. The Python SDK uses Pydant
 ```typescript
 // TypeScript with Zod
 const SearchInput = z.object({
-  query: z.string().min(1).max(500).describe("Search query"),
-  limit: z.number().int().min(1).max(100).default(10).describe("Max results"),
-  filters: z.object({
-    dateAfter: z.string().datetime().optional(),
-    category: z.enum(["docs", "code", "issues"]).optional()
-  }).optional()
+  query: z.string().min(1).max(500).describe('Search query'),
+  limit: z.number().int().min(1).max(100).default(10).describe('Max results'),
+  filters: z
+    .object({
+      dateAfter: z.string().datetime().optional(),
+      category: z.enum(['docs', 'code', 'issues']).optional(),
+    })
+    .optional(),
 });
 ```
 
@@ -243,21 +245,21 @@ Tool results use MCP's content format:
 ```typescript
 // Text result
 return {
-  content: [{ type: "text", text: "Search found 3 results:\n..." }]
+  content: [{ type: 'text', text: 'Search found 3 results:\n...' }],
 };
 
 // Error result
 return {
   isError: true,
-  content: [{ type: "text", text: "Search failed: connection timeout" }]
+  content: [{ type: 'text', text: 'Search failed: connection timeout' }],
 };
 
 // Multiple content blocks
 return {
   content: [
-    { type: "text", text: "Found the following image:" },
-    { type: "image", data: base64Data, mimeType: "image/png" }
-  ]
+    { type: 'text', text: 'Found the following image:' },
+    { type: 'image', data: base64Data, mimeType: 'image/png' },
+  ],
 };
 ```
 
@@ -435,19 +437,19 @@ When building an MCP server:
 The reference implementation language. Create a `McpServer` instance, register tools and resources with `server.tool()` and `server.resource()`, then connect a transport (`StdioServerTransport` for stdio, or the HTTP transport for remote). Tool inputs use Zod schemas. Tool results use the `{ content: [{ type: "text", text: "..." }] }` format.
 
 ```typescript
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
 
-const server = new McpServer({ name: "my-server", version: "1.0.0" });
+const server = new McpServer({ name: 'my-server', version: '1.0.0' });
 
 server.tool(
-  "greet",
-  "Generate a greeting for a person",
+  'greet',
+  'Generate a greeting for a person',
   { name: z.string().describe("Person's name") },
   async ({ name }) => ({
-    content: [{ type: "text", text: `Hello, ${name}!` }]
-  })
+    content: [{ type: 'text', text: `Hello, ${name}!` }],
+  }),
 );
 
 const transport = new StdioServerTransport();

--- a/docs/reference-architectures/rag-pipelines.md
+++ b/docs/reference-architectures/rag-pipelines.md
@@ -35,14 +35,14 @@ These are three approaches to getting an LLM to work with your data. They are no
 
 **Decision framework:**
 
-| Criterion | RAG | Fine-tuning | Long context |
-|---|---|---|---|
-| Knowledge base size | Any | Small-medium | Small |
-| Update frequency | High (re-index) | Low (re-train) | High (just pass it) |
-| Source attribution | Yes | No | Possible but harder |
-| Per-query cost | Moderate | Low (amortized) | High |
-| Setup complexity | Medium | High | Low |
-| Accuracy ceiling | High (with good retrieval) | High (with good data) | High (for short docs) |
+| Criterion           | RAG                        | Fine-tuning           | Long context          |
+| ------------------- | -------------------------- | --------------------- | --------------------- |
+| Knowledge base size | Any                        | Small-medium          | Small                 |
+| Update frequency    | High (re-index)            | Low (re-train)        | High (just pass it)   |
+| Source attribution  | Yes                        | No                    | Possible but harder   |
+| Per-query cost      | Moderate                   | Low (amortized)       | High                  |
+| Setup complexity    | Medium                     | High                  | Low                   |
+| Accuracy ceiling    | High (with good retrieval) | High (with good data) | High (for short docs) |
 
 Most production systems use RAG. Fine-tuning and long context are complements, not replacements.
 
@@ -162,12 +162,12 @@ Use the document's own structure — headings, sections, code blocks, table boun
 
 ### 4.5 Chunk Size Guidelines
 
-| Chunk size (tokens) | Retrieval behavior | Typical use |
-|---|---|---|
-| 128-256 | High precision, narrow context | FAQ, definitions, factoid QA |
-| 256-512 | Balanced precision and context | General-purpose RAG |
-| 512-1024 | More context per chunk, lower precision | Long-form answers, summarization |
-| 1024+ | Document-level retrieval | When you need full sections |
+| Chunk size (tokens) | Retrieval behavior                      | Typical use                      |
+| ------------------- | --------------------------------------- | -------------------------------- |
+| 128-256             | High precision, narrow context          | FAQ, definitions, factoid QA     |
+| 256-512             | Balanced precision and context          | General-purpose RAG              |
+| 512-1024            | More context per chunk, lower precision | Long-form answers, summarization |
+| 1024+               | Document-level retrieval                | When you need full sections      |
 
 Smaller chunks are better for precise retrieval (finding the exact sentence that answers a question). Larger chunks provide more context to the LLM (helpful for nuanced answers). Test with your actual data and queries.
 
@@ -179,13 +179,13 @@ Convert text chunks into dense vector representations for similarity search.
 
 ### 5.1 Model Selection
 
-| Model | Dimensions | Notes |
-|---|---|---|
-| OpenAI `text-embedding-3-small` | 1536 | Good balance of cost and quality. Supports dimension reduction. |
-| OpenAI `text-embedding-3-large` | 3072 | Higher quality, higher cost. Supports dimension reduction. |
-| Cohere `embed-v3` | 1024 | Strong multilingual support. Separate query/document modes. |
-| Voyage AI `voyage-3` | 1024 | Strong on code and technical content. |
-| Open source (`bge-large`, `e5-large-v2`) | 1024 | Self-hostable. No API dependency. Requires GPU for production throughput. |
+| Model                                    | Dimensions | Notes                                                                     |
+| ---------------------------------------- | ---------- | ------------------------------------------------------------------------- |
+| OpenAI `text-embedding-3-small`          | 1536       | Good balance of cost and quality. Supports dimension reduction.           |
+| OpenAI `text-embedding-3-large`          | 3072       | Higher quality, higher cost. Supports dimension reduction.                |
+| Cohere `embed-v3`                        | 1024       | Strong multilingual support. Separate query/document modes.               |
+| Voyage AI `voyage-3`                     | 1024       | Strong on code and technical content.                                     |
+| Open source (`bge-large`, `e5-large-v2`) | 1024       | Self-hostable. No API dependency. Requires GPU for production throughput. |
 
 **Selection criteria:**
 
@@ -223,25 +223,25 @@ Store vectors in a NumPy array or a lightweight library like FAISS. Search via b
 
 ### 6.2 Managed Services
 
-| Service | Notes |
-|---|---|
-| Pinecone | Fully managed, serverless option. Good DX. Pay per query + storage. |
-| Weaviate Cloud | Managed Weaviate. Supports hybrid search natively. |
-| Qdrant Cloud | Managed Qdrant. Strong filtering support. |
-| MongoDB Atlas Vector Search | If you already use MongoDB. |
-| Supabase (pgvector) | If you already use Supabase/Postgres. |
+| Service                     | Notes                                                               |
+| --------------------------- | ------------------------------------------------------------------- |
+| Pinecone                    | Fully managed, serverless option. Good DX. Pay per query + storage. |
+| Weaviate Cloud              | Managed Weaviate. Supports hybrid search natively.                  |
+| Qdrant Cloud                | Managed Qdrant. Strong filtering support.                           |
+| MongoDB Atlas Vector Search | If you already use MongoDB.                                         |
+| Supabase (pgvector)         | If you already use Supabase/Postgres.                               |
 
 **Use for:** production, when you do not want to manage infrastructure.
 
 ### 6.3 Self-Hosted
 
-| Option | Notes |
-|---|---|
-| pgvector (Postgres extension) | Use your existing Postgres. Good enough for most scales. Familiar SQL interface. |
-| Qdrant | Purpose-built. Excellent filtering and performance. Rust-based. |
-| Chroma | Python-native. Easy to embed in applications. Good for prototyping. |
-| Milvus | High scale. More operational complexity. |
-| FAISS (Facebook) | Library, not a database. No persistence by default. Best for read-heavy batch workloads. |
+| Option                        | Notes                                                                                    |
+| ----------------------------- | ---------------------------------------------------------------------------------------- |
+| pgvector (Postgres extension) | Use your existing Postgres. Good enough for most scales. Familiar SQL interface.         |
+| Qdrant                        | Purpose-built. Excellent filtering and performance. Rust-based.                          |
+| Chroma                        | Python-native. Easy to embed in applications. Good for prototyping.                      |
+| Milvus                        | High scale. More operational complexity.                                                 |
+| FAISS (Facebook)              | Library, not a database. No persistence by default. Best for read-heavy batch workloads. |
 
 **Use for:** production, when you need control over data locality, cost optimization at scale, or air-gapped environments.
 
@@ -451,23 +451,23 @@ Build an eval dataset, run it on every pipeline change, track metrics over time.
 
 ### 11.1 Retrieval Failures
 
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Relevant documents exist but are not retrieved | Poor chunking (answer split across chunks), embedding model mismatch | Try smaller chunks, add overlap, test a different embedding model |
-| Top results are all about the wrong topic | Query-document vocabulary mismatch | Add hybrid search (BM25), try query rewriting |
-| Retrieved chunks are relevant but too short to be useful | Chunks too small | Increase chunk size, include surrounding context |
-| Retrieved chunks are relevant but contain too much noise | Chunks too large, poor document cleaning | Decrease chunk size, improve parsing/cleaning |
-| Retrieval works for some query types but not others | Single retrieval strategy does not cover all cases | Add hybrid search, query transformation, per-query-type routing |
+| Symptom                                                  | Likely cause                                                         | Fix                                                               |
+| -------------------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Relevant documents exist but are not retrieved           | Poor chunking (answer split across chunks), embedding model mismatch | Try smaller chunks, add overlap, test a different embedding model |
+| Top results are all about the wrong topic                | Query-document vocabulary mismatch                                   | Add hybrid search (BM25), try query rewriting                     |
+| Retrieved chunks are relevant but too short to be useful | Chunks too small                                                     | Increase chunk size, include surrounding context                  |
+| Retrieved chunks are relevant but contain too much noise | Chunks too large, poor document cleaning                             | Decrease chunk size, improve parsing/cleaning                     |
+| Retrieval works for some query types but not others      | Single retrieval strategy does not cover all cases                   | Add hybrid search, query transformation, per-query-type routing   |
 
 ### 11.2 Generation Failures
 
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Answer contradicts the context | Model ignoring context (especially with strong priors) | Move context closer to the question in the prompt, increase temperature=0, add explicit instruction to only use context |
-| Answer is correct but does not cite sources | Citation instruction not strong enough or not in system prompt | Reinforce citation instruction, provide few-shot examples |
-| Answer says "I don't know" when context contains the answer | Similarity threshold too high, or context placed too far from question | Lower threshold, restructure prompt, check chunk quality |
-| Answer includes information not in the context | Hallucination, model falling back to training data | Add faithfulness check, instruct model to only use provided context, reduce temperature |
-| Answer is verbose and unfocused | Too many chunks included, no instruction on conciseness | Reduce number of chunks, add reranking, instruct model on desired length |
+| Symptom                                                     | Likely cause                                                           | Fix                                                                                                                     |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Answer contradicts the context                              | Model ignoring context (especially with strong priors)                 | Move context closer to the question in the prompt, increase temperature=0, add explicit instruction to only use context |
+| Answer is correct but does not cite sources                 | Citation instruction not strong enough or not in system prompt         | Reinforce citation instruction, provide few-shot examples                                                               |
+| Answer says "I don't know" when context contains the answer | Similarity threshold too high, or context placed too far from question | Lower threshold, restructure prompt, check chunk quality                                                                |
+| Answer includes information not in the context              | Hallucination, model falling back to training data                     | Add faithfulness check, instruct model to only use provided context, reduce temperature                                 |
+| Answer is verbose and unfocused                             | Too many chunks included, no instruction on conciseness                | Reduce number of chunks, add reranking, instruct model on desired length                                                |
 
 ### 11.3 Debugging Strategy
 

--- a/docs/spec/composite-contract.md
+++ b/docs/spec/composite-contract.md
@@ -18,13 +18,13 @@ Composites are the bridge between the template catalog and real-world project ar
 
 ## 2. Terminology
 
-| Term | Definition |
-|---|---|
-| **Composite** | A named, versioned manifest that references multiple templates and defines how they combine. |
-| **Entry** | A single template reference within a composite, including its nesting path and variable overrides. |
+| Term              | Definition                                                                                                 |
+| ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Composite**     | A named, versioned manifest that references multiple templates and defines how they combine.               |
+| **Entry**         | A single template reference within a composite, including its nesting path and variable overrides.         |
 | **Root template** | The entry marked `root: true`. Its skeleton forms the top-level directory structure. Typically `monorepo`. |
-| **Path** | The directory within the root where a non-root template's skeleton is placed. |
-| **Variable flow** | The mechanism by which a composite-level variable is passed to multiple template entries. |
+| **Path**          | The directory within the root where a non-root template's skeleton is placed.                              |
+| **Variable flow** | The mechanism by which a composite-level variable is passed to multiple template entries.                  |
 
 ---
 
@@ -47,29 +47,29 @@ Each file is a standalone composite manifest. There is no `skeleton/` directory 
 
 ### 4.1 Top-Level Fields
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `apiVersion` | string | **yes** | Must be `nanohype/v1`. |
-| `kind` | string | **yes** | Must be `composite`. |
-| `name` | string | **yes** | Kebab-case identifier, unique within the catalog. |
-| `displayName` | string | **yes** | Human-readable name. |
-| `description` | string | **yes** | What this composite produces. |
-| `version` | string | **yes** | Semver version. |
-| `tags` | string[] | **yes** | Lowercase searchable tags. |
-| `templates` | Entry[] | **yes** | Ordered list of template entries. |
-| `variables` | Variable[] | **yes** | Composite-level variables collected from the user. |
+| Field         | Type       | Required | Description                                        |
+| ------------- | ---------- | -------- | -------------------------------------------------- |
+| `apiVersion`  | string     | **yes**  | Must be `nanohype/v1`.                             |
+| `kind`        | string     | **yes**  | Must be `composite`.                               |
+| `name`        | string     | **yes**  | Kebab-case identifier, unique within the catalog.  |
+| `displayName` | string     | **yes**  | Human-readable name.                               |
+| `description` | string     | **yes**  | What this composite produces.                      |
+| `version`     | string     | **yes**  | Semver version.                                    |
+| `tags`        | string[]   | **yes**  | Lowercase searchable tags.                         |
+| `templates`   | Entry[]    | **yes**  | Ordered list of template entries.                  |
+| `variables`   | Variable[] | **yes**  | Composite-level variables collected from the user. |
 
 ### 4.2 Entry Object
 
 Each entry in `templates` references a template from the catalog:
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `template` | string | **yes** | Template name (must exist in `templates/`). |
-| `path` | string | no | Directory path within the output where this template is scaffolded. Relative to root. If omitted and `root: true`, scaffolds at the top level. |
-| `root` | boolean | no | If `true`, this entry's skeleton forms the top-level directory. At most one entry may be `root`. |
-| `variables` | object | no | Variable overrides for this entry. Keys are variable names from the referenced template. Values may reference composite variables via `${VarName}`. |
-| `condition` | string | no | Name of a composite-level bool variable. When `false`, this entry is skipped entirely. |
+| Field       | Type    | Required | Description                                                                                                                                         |
+| ----------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `template`  | string  | **yes**  | Template name (must exist in `templates/`).                                                                                                         |
+| `path`      | string  | no       | Directory path within the output where this template is scaffolded. Relative to root. If omitted and `root: true`, scaffolds at the top level.      |
+| `root`      | boolean | no       | If `true`, this entry's skeleton forms the top-level directory. At most one entry may be `root`.                                                    |
+| `variables` | object  | no       | Variable overrides for this entry. Keys are variable names from the referenced template. Values may reference composite variables via `${VarName}`. |
+| `condition` | string  | no       | Name of a composite-level bool variable. When `false`, this entry is skipped entirely.                                                              |
 
 ### 4.3 Variable Object
 
@@ -95,8 +95,8 @@ templates:
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
-      Description: "API for ${ProjectName}"
+      ProjectName: '${ProjectName}-api'
+      Description: 'API for ${ProjectName}'
 ```
 
 ### 5.2 Resolution Order
@@ -151,82 +151,82 @@ A full-stack AI chatbot composite:
 apiVersion: nanohype/v1
 kind: composite
 name: ai-chatbot
-displayName: "AI Chatbot"
+displayName: 'AI Chatbot'
 description: >
   Full-stack AI chatbot with agentic loop, HTTP service,
   authentication, evaluation harness, and deployment.
-version: "0.1.0"
+version: '0.1.0'
 tags: [ai, chatbot, fullstack, typescript]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project name used across all templates"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project name used across all templates'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for AI features"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for AI features'
+    default: 'anthropic'
 
   - name: IncludeEvals
     type: bool
-    placeholder: "__INCLUDE_EVALS__"
-    description: "Include evaluation harness"
+    placeholder: '__INCLUDE_EVALS__'
+    description: 'Include evaluation harness'
     default: true
 
   - name: DeployTarget
     type: string
-    placeholder: "__DEPLOY_TARGET__"
-    description: "Deployment target template"
-    default: "infra-fly"
+    placeholder: '__DEPLOY_TARGET__'
+    description: 'Deployment target template'
+    default: 'infra-fly'
 
 templates:
   - template: monorepo
     root: true
     variables:
-      ProjectName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
       IncludeSharedUtils: true
       IncludeSharedUi: false
 
   - template: agentic-loop
     path: packages/ai
     variables:
-      ProjectName: "${ProjectName}-ai"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-ai'
+      LlmProvider: '${LlmProvider}'
       IncludeMemory: true
       IncludeEval: false
 
   - template: ts-service
     path: apps/api
     variables:
-      ProjectName: "${ProjectName}-api"
+      ProjectName: '${ProjectName}-api'
       IncludeAuth: true
       IncludeDocker: true
 
   - template: module-auth-ts
     path: packages/auth
     variables:
-      ProjectName: "${ProjectName}-auth"
-      AuthProvider: "jwt"
+      ProjectName: '${ProjectName}-auth'
+      AuthProvider: 'jwt'
 
   - template: eval-harness
     path: packages/evals
     condition: IncludeEvals
     variables:
-      ProjectName: "${ProjectName}-evals"
-      LlmProvider: "${LlmProvider}"
+      ProjectName: '${ProjectName}-evals'
+      LlmProvider: '${LlmProvider}'
 
   - template: infra-fly
     path: infra
     variables:
-      ProjectName: "${ProjectName}"
-      AppName: "${ProjectName}"
+      ProjectName: '${ProjectName}'
+      AppName: '${ProjectName}'
       IncludeCi: true
 ```
 

--- a/docs/spec/consumer-guide.md
+++ b/docs/spec/consumer-guide.md
@@ -116,15 +116,15 @@ See the [composite contract](composite-contract.md) for full details on variable
 
 A conformant consumer needs exactly these capabilities:
 
-| Capability | Purpose |
-|---|---|
-| YAML parser | Read template.yaml and composite manifests |
-| JSON Schema validator | Validate manifest against schema |
-| Interactive prompts | Collect variable values from the user |
-| File tree walker | Recursively copy skeleton/ |
-| String replacer | Find-and-replace placeholders in content and paths |
-| Shell executor | Run hook commands (optional — hooks are advisory) |
-| Path checker | Verify prerequisites exist on $PATH (optional) |
+| Capability            | Purpose                                            |
+| --------------------- | -------------------------------------------------- |
+| YAML parser           | Read template.yaml and composite manifests         |
+| JSON Schema validator | Validate manifest against schema                   |
+| Interactive prompts   | Collect variable values from the user              |
+| File tree walker      | Recursively copy skeleton/                         |
+| String replacer       | Find-and-replace placeholders in content and paths |
+| Shell executor        | Run hook commands (optional — hooks are advisory)  |
+| Path checker          | Verify prerequisites exist on $PATH (optional)     |
 
 No template engine, no AST manipulation, no language-specific tooling. The entire rendering algorithm is string replacement.
 

--- a/docs/spec/template-contract.md
+++ b/docs/spec/template-contract.md
@@ -18,15 +18,15 @@ The contract is intentionally tool-agnostic. It specifies _what_ a template decl
 
 ## 2. Terminology
 
-| Term | Definition |
-|---|---|
-| **Template** | A named, versioned unit in the catalog. Contains a manifest and a skeleton. |
-| **Manifest** | The `template.yaml` file. Declares metadata, variables, conditionals, hooks, composition hints, and prerequisites. |
-| **Skeleton** | The `skeleton/` directory. Contains files and directories exactly as they should appear in the generated output, with placeholder tokens standing in for variable values. |
+| Term            | Definition                                                                                                                                                                                                                               |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Template**    | A named, versioned unit in the catalog. Contains a manifest and a skeleton.                                                                                                                                                              |
+| **Manifest**    | The `template.yaml` file. Declares metadata, variables, conditionals, hooks, composition hints, and prerequisites.                                                                                                                       |
+| **Skeleton**    | The `skeleton/` directory. Contains files and directories exactly as they should appear in the generated output, with placeholder tokens standing in for variable values.                                                                |
 | **Placeholder** | A literal string (e.g. `__PROJECT_NAME__`) that appears in skeleton file content or file/directory names. Each variable declares its own placeholder. Consumers perform textual find-and-replace — no template engine syntax is imposed. |
-| **Contract** | This specification. The set of guarantees a template makes to consumers and vice versa. |
-| **Consumer** | Any tool that reads a template manifest, collects variable values from the user, and produces output by copying the skeleton with placeholders resolved. |
-| **Catalog** | The collection of all templates in a nanohype repository. |
+| **Contract**    | This specification. The set of guarantees a template makes to consumers and vice versa.                                                                                                                                                  |
+| **Consumer**    | Any tool that reads a template manifest, collects variable values from the user, and produces output by copying the skeleton with placeholders resolved.                                                                                 |
+| **Catalog**     | The collection of all templates in a nanohype repository.                                                                                                                                                                                |
 
 ---
 
@@ -63,23 +63,23 @@ The manifest is a YAML document. The root object has the following fields:
 
 ### 4.1 Top-Level Fields
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `apiVersion` | string | **yes** | Schema version. MUST be `nanohype/v1`. |
-| `kind` | string | no | Execution mode: `template` (default) or `brief`. See [4.1.1 Kind](#411-kind). |
-| `name` | string | **yes** | Template identifier. Kebab-case (`^[a-z][a-z0-9-]*$`). Unique within the catalog. |
-| `displayName` | string | **yes** | Human-readable name. Used in UIs and listings. |
-| `description` | string | **yes** | Multi-line description of what the template produces. |
-| `version` | string | **yes** | Template version. MUST be valid semver (e.g. `"0.1.0"`). |
-| `license` | string | no | SPDX license identifier for the _scaffolded output_ (not the template itself). |
-| `persona` | array of strings | no | Who this template serves (e.g. `[engineering]`, `[qa, engineering]`). See [4.1.2 Persona](#412-persona). |
-| `category` | string | no | Catalog grouping (e.g. `ai-systems`, `design`, `operations`). See [4.1.3 Category](#413-category). |
-| `tags` | array of strings | **yes** | Lowercase, searchable tags. Minimum one tag. |
-| `variables` | array of [Variable](#42-variable-object) | **yes** | Ordered list of template variables. MAY be empty (`[]`). |
-| `conditionals` | array of [Conditional](#43-conditional-object) | no | File inclusion/exclusion rules. |
-| `hooks` | [Hooks](#44-hooks-object) | no | Lifecycle commands. |
-| `composition` | [Composition](#45-composition-object) | no | Advisory relationships to other templates. |
-| `prerequisites` | array of [Prerequisite](#46-prerequisite-object) | no | External tool requirements. |
+| Field           | Type                                             | Required | Description                                                                                              |
+| --------------- | ------------------------------------------------ | -------- | -------------------------------------------------------------------------------------------------------- |
+| `apiVersion`    | string                                           | **yes**  | Schema version. MUST be `nanohype/v1`.                                                                   |
+| `kind`          | string                                           | no       | Execution mode: `template` (default) or `brief`. See [4.1.1 Kind](#411-kind).                            |
+| `name`          | string                                           | **yes**  | Template identifier. Kebab-case (`^[a-z][a-z0-9-]*$`). Unique within the catalog.                        |
+| `displayName`   | string                                           | **yes**  | Human-readable name. Used in UIs and listings.                                                           |
+| `description`   | string                                           | **yes**  | Multi-line description of what the template produces.                                                    |
+| `version`       | string                                           | **yes**  | Template version. MUST be valid semver (e.g. `"0.1.0"`).                                                 |
+| `license`       | string                                           | no       | SPDX license identifier for the _scaffolded output_ (not the template itself).                           |
+| `persona`       | array of strings                                 | no       | Who this template serves (e.g. `[engineering]`, `[qa, engineering]`). See [4.1.2 Persona](#412-persona). |
+| `category`      | string                                           | no       | Catalog grouping (e.g. `ai-systems`, `design`, `operations`). See [4.1.3 Category](#413-category).       |
+| `tags`          | array of strings                                 | **yes**  | Lowercase, searchable tags. Minimum one tag.                                                             |
+| `variables`     | array of [Variable](#42-variable-object)         | **yes**  | Ordered list of template variables. MAY be empty (`[]`).                                                 |
+| `conditionals`  | array of [Conditional](#43-conditional-object)   | no       | File inclusion/exclusion rules.                                                                          |
+| `hooks`         | [Hooks](#44-hooks-object)                        | no       | Lifecycle commands.                                                                                      |
+| `composition`   | [Composition](#45-composition-object)            | no       | Advisory relationships to other templates.                                                               |
+| `prerequisites` | array of [Prerequisite](#46-prerequisite-object) | no       | External tool requirements.                                                                              |
 
 #### 4.1.1 Kind
 
@@ -110,67 +110,67 @@ Consumers MAY use this field for catalog organization and filtering. There is no
 
 Each entry in `variables` describes one user-supplied value and how it maps into the skeleton.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `name` | string | **yes** | Variable identifier. PascalCase (`^[A-Z][a-zA-Z0-9]*$`). Unique within the template. |
-| `type` | string | **yes** | One of: `string`, `bool`, `enum`, `int`. |
-| `placeholder` | string | **yes** | The literal token to find-and-replace in skeleton files and paths. |
-| `description` | string | **yes** | What this variable controls. |
-| `prompt` | string | no | Human-friendly prompt text. Consumers MAY use this when interactively collecting values. Defaults to `description` if absent. |
-| `default` | (varies) | no | Default value. Type must match `type`. See [5.3 Defaults](#53-defaults). |
-| `required` | boolean | no | Whether the user must supply a value. Defaults to `false`. When `true` and no `default` is set, the consumer MUST obtain a value before proceeding. |
-| `validation` | [Validation](#421-validation-object) | no | Constraints on the value. |
-| `options` | array of strings | conditional | **Required** when `type` is `enum`. The allowed values. MUST NOT be present when `type` is not `enum`. |
+| Field         | Type                                 | Required    | Description                                                                                                                                         |
+| ------------- | ------------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | string                               | **yes**     | Variable identifier. PascalCase (`^[A-Z][a-zA-Z0-9]*$`). Unique within the template.                                                                |
+| `type`        | string                               | **yes**     | One of: `string`, `bool`, `enum`, `int`.                                                                                                            |
+| `placeholder` | string                               | **yes**     | The literal token to find-and-replace in skeleton files and paths.                                                                                  |
+| `description` | string                               | **yes**     | What this variable controls.                                                                                                                        |
+| `prompt`      | string                               | no          | Human-friendly prompt text. Consumers MAY use this when interactively collecting values. Defaults to `description` if absent.                       |
+| `default`     | (varies)                             | no          | Default value. Type must match `type`. See [5.3 Defaults](#53-defaults).                                                                            |
+| `required`    | boolean                              | no          | Whether the user must supply a value. Defaults to `false`. When `true` and no `default` is set, the consumer MUST obtain a value before proceeding. |
+| `validation`  | [Validation](#421-validation-object) | no          | Constraints on the value.                                                                                                                           |
+| `options`     | array of strings                     | conditional | **Required** when `type` is `enum`. The allowed values. MUST NOT be present when `type` is not `enum`.                                              |
 
 #### 4.2.1 Validation Object
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `pattern` | string | no | ECMAScript regular expression. Applicable to `string` and `int` types. The full value must match (anchored). |
-| `message` | string | no | Human-readable error message when validation fails. |
+| Field     | Type   | Required | Description                                                                                                  |
+| --------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `pattern` | string | no       | ECMAScript regular expression. Applicable to `string` and `int` types. The full value must match (anchored). |
+| `message` | string | no       | Human-readable error message when validation fails.                                                          |
 
 ### 4.3 Conditional Object
 
 Each entry controls whether a skeleton path is included in the output.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `path` | string | **yes** | Relative path from `skeleton/` root. May refer to a file or a directory. |
-| `when` | string | **yes** | Name of a variable. MUST reference a variable of type `bool`. |
+| Field  | Type   | Required | Description                                                              |
+| ------ | ------ | -------- | ------------------------------------------------------------------------ |
+| `path` | string | **yes**  | Relative path from `skeleton/` root. May refer to a file or a directory. |
+| `when` | string | **yes**  | Name of a variable. MUST reference a variable of type `bool`.            |
 
 ### 4.4 Hooks Object
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `pre` | array of [Hook](#441-hook-object) | no | Commands run before skeleton expansion. |
-| `post` | array of [Hook](#441-hook-object) | no | Commands run after skeleton expansion. |
+| Field  | Type                              | Required | Description                             |
+| ------ | --------------------------------- | -------- | --------------------------------------- |
+| `pre`  | array of [Hook](#441-hook-object) | no       | Commands run before skeleton expansion. |
+| `post` | array of [Hook](#441-hook-object) | no       | Commands run after skeleton expansion.  |
 
 #### 4.4.1 Hook Object
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `name` | string | **yes** | Identifier for the hook (for logging and user confirmation). |
-| `description` | string | **yes** | What this hook does. |
-| `run` | string | **yes** | Shell command to execute. Interpreted by the system shell (`sh -c`). |
-| `workdir` | string | no | Working directory, relative to the output root. Defaults to `"."`. |
+| Field         | Type   | Required | Description                                                          |
+| ------------- | ------ | -------- | -------------------------------------------------------------------- |
+| `name`        | string | **yes**  | Identifier for the hook (for logging and user confirmation).         |
+| `description` | string | **yes**  | What this hook does.                                                 |
+| `run`         | string | **yes**  | Shell command to execute. Interpreted by the system shell (`sh -c`). |
+| `workdir`     | string | no       | Working directory, relative to the output root. Defaults to `"."`.   |
 
 ### 4.5 Composition Object
 
 All fields are advisory. Consumers MAY surface this information to users but MUST NOT enforce it.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `pairsWith` | array of strings | no | Template `name` values that complement this template. |
-| `nestsInside` | array of strings | no | Template `name` values that this template can be scaffolded within. |
+| Field         | Type             | Required | Description                                                         |
+| ------------- | ---------------- | -------- | ------------------------------------------------------------------- |
+| `pairsWith`   | array of strings | no       | Template `name` values that complement this template.               |
+| `nestsInside` | array of strings | no       | Template `name` values that this template can be scaffolded within. |
 
 ### 4.6 Prerequisite Object
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `name` | string | **yes** | Binary or tool name (as it would appear on `$PATH`). |
-| `version` | string | no | Semver range (e.g. `">=1.22"`, `"^3.0.0"`). |
-| `purpose` | string | **yes** | Why this prerequisite is needed. |
-| `optional` | boolean | no | If `true`, the consumer SHOULD warn but MUST NOT block. Defaults to `false`. |
+| Field      | Type    | Required | Description                                                                  |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------- |
+| `name`     | string  | **yes**  | Binary or tool name (as it would appear on `$PATH`).                         |
+| `version`  | string  | no       | Semver range (e.g. `">=1.22"`, `"^3.0.0"`).                                  |
+| `purpose`  | string  | **yes**  | Why this prerequisite is needed.                                             |
+| `optional` | boolean | no       | If `true`, the consumer SHOULD warn but MUST NOT block. Defaults to `false`. |
 
 ---
 
@@ -178,12 +178,12 @@ All fields are advisory. Consumers MAY surface this information to users but MUS
 
 ### 5.1 Types
 
-| Type | YAML representation | Placeholder substitution |
-|---|---|---|
-| `string` | scalar string | Literal text replacement. |
-| `bool` | `true` / `false` | Replaced with the string `"true"` or `"false"`. Primary use is in conditionals; placeholder substitution in file content is permitted but uncommon. |
-| `int` | integer scalar | Replaced with the decimal string representation. |
-| `enum` | scalar string (one of `options`) | Literal text replacement, same as `string`. |
+| Type     | YAML representation              | Placeholder substitution                                                                                                                            |
+| -------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `string` | scalar string                    | Literal text replacement.                                                                                                                           |
+| `bool`   | `true` / `false`                 | Replaced with the string `"true"` or `"false"`. Primary use is in conditionals; placeholder substitution in file content is permitted but uncommon. |
+| `int`    | integer scalar                   | Replaced with the decimal string representation.                                                                                                    |
+| `enum`   | scalar string (one of `options`) | Literal text replacement, same as `string`.                                                                                                         |
 
 ### 5.2 Placeholders
 
@@ -254,14 +254,14 @@ Conditionals control which skeleton files appear in the output.
 variables:
   - name: IncludeRelease
     type: bool
-    placeholder: "__INCLUDE_RELEASE__"
-    description: "Include GoReleaser configuration"
+    placeholder: '__INCLUDE_RELEASE__'
+    description: 'Include GoReleaser configuration'
     default: false
 
 conditionals:
-  - path: ".goreleaser.yaml"
+  - path: '.goreleaser.yaml'
     when: IncludeRelease
-  - path: "scripts/release.sh"
+  - path: 'scripts/release.sh'
     when: IncludeRelease
 ```
 
@@ -307,10 +307,10 @@ This model treats the user as the trust boundary. The template declares intent; 
 
 Consumers SHOULD make the following environment variables available to hooks:
 
-| Variable | Value |
-|---|---|
-| `NANOHYPE_TEMPLATE_NAME` | The template `name`. |
-| `NANOHYPE_OUTPUT_DIR` | Absolute path to the output root. |
+| Variable                 | Value                             |
+| ------------------------ | --------------------------------- |
+| `NANOHYPE_TEMPLATE_NAME` | The template `name`.              |
+| `NANOHYPE_OUTPUT_DIR`    | Absolute path to the output root. |
 
 Consumers MAY expose resolved template variables as environment variables (e.g. `NANOHYPE_VAR_ProjectName`). This is optional and not guaranteed — hook authors SHOULD NOT depend on it without checking.
 
@@ -354,10 +354,10 @@ Consumers SHOULD check prerequisites **before running hooks** (step 4 in the lif
 
 ### 9.3 Failure Behavior
 
-| `optional` | Prerequisite missing | Behavior |
-|---|---|---|
-| `false` (default) | yes | Consumer MUST warn the user. Consumer SHOULD block and MAY proceed if the user explicitly overrides. |
-| `true` | yes | Consumer MUST warn the user. Consumer MUST NOT block. |
+| `optional`        | Prerequisite missing | Behavior                                                                                             |
+| ----------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `false` (default) | yes                  | Consumer MUST warn the user. Consumer SHOULD block and MAY proceed if the user explicitly overrides. |
+| `true`            | yes                  | Consumer MUST warn the user. Consumer MUST NOT block.                                                |
 
 The warning MUST include the `purpose` field so the user understands what will not work.
 
@@ -415,83 +415,83 @@ A complete `template.yaml` for a Go CLI application:
 apiVersion: nanohype/v1
 
 name: go-cli
-displayName: "Go CLI Application"
+displayName: 'Go CLI Application'
 description: >
   Scaffolds a Go CLI application using Cobra for command structure,
   Viper for configuration management, and log/slog for structured logging.
   Produces a buildable binary with a root command, version subcommand,
   config file support, and a Makefile. Optionally includes GoReleaser
   configuration and a GitHub Actions release workflow.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 tags: [go, cli, cobra, viper, slog]
 
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as binary name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as binary name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Org
     type: string
-    placeholder: "__ORG__"
-    description: "GitHub organization or username"
-    prompt: "GitHub org/username"
+    placeholder: '__ORG__'
+    description: 'GitHub organization or username'
+    prompt: 'GitHub org/username'
     required: true
     validation:
-      pattern: "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
-      message: "Must be a valid GitHub org or username"
+      pattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*$'
+      message: 'Must be a valid GitHub org or username'
 
   - name: GoModule
     type: string
-    placeholder: "__GO_MODULE__"
-    description: "Full Go module path"
-    prompt: "Go module path"
-    default: "github.com/${Org}/${ProjectName}"
+    placeholder: '__GO_MODULE__'
+    description: 'Full Go module path'
+    prompt: 'Go module path'
+    default: 'github.com/${Org}/${ProjectName}'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9./-]*$"
-      message: "Must be a valid Go module path"
+      pattern: '^[a-z][a-z0-9./-]*$'
+      message: 'Must be a valid Go module path'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for help text and README"
-    prompt: "Project description"
-    default: "A CLI application"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for help text and README'
+    prompt: 'Project description'
+    default: 'A CLI application'
 
   - name: IncludeRelease
     type: bool
-    placeholder: "__INCLUDE_RELEASE__"
-    description: "Include GoReleaser configuration and GitHub Actions release workflow"
-    prompt: "Include release automation?"
+    placeholder: '__INCLUDE_RELEASE__'
+    description: 'Include GoReleaser configuration and GitHub Actions release workflow'
+    prompt: 'Include release automation?'
     default: true
 
   - name: LogFormat
     type: enum
-    placeholder: "__LOG_FORMAT__"
-    description: "Default structured log output format"
-    prompt: "Log format"
-    default: "json"
-    options: ["json", "text", "pretty"]
+    placeholder: '__LOG_FORMAT__'
+    description: 'Default structured log output format'
+    prompt: 'Log format'
+    default: 'json'
+    options: ['json', 'text', 'pretty']
 
 conditionals:
-  - path: ".goreleaser.yaml"
+  - path: '.goreleaser.yaml'
     when: IncludeRelease
-  - path: ".github/workflows/release.yml"
+  - path: '.github/workflows/release.yml'
     when: IncludeRelease
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Initialize Go module and tidy dependencies"
-      run: "go mod tidy"
-      workdir: "."
+      description: 'Initialize Go module and tidy dependencies'
+      run: 'go mod tidy'
+      workdir: '.'
 
 composition:
   pairsWith: [eval-harness, infra-fly]
@@ -499,12 +499,12 @@ composition:
 
 prerequisites:
   - name: go
-    version: ">=1.24"
-    purpose: "Go compilation and module management"
+    version: '>=1.24'
+    purpose: 'Go compilation and module management'
     optional: false
   - name: goreleaser
-    version: ">=2.0"
-    purpose: "Automated release builds (only needed if release config is included)"
+    version: '>=2.0'
+    purpose: 'Automated release builds (only needed if release config is included)'
     optional: true
 ```
 

--- a/library/runtime/README.md
+++ b/library/runtime/README.md
@@ -6,13 +6,13 @@ as the `tenant-chart-base` library chart.
 
 ## Modules
 
-| Module | What it is |
-| --- | --- |
-| `src/circuit-breaker.ts` | Pure, timer-less sliding-window circuit breaker with an injectable `now()` clock, single half-open probe, `onOpen` trip hook, and operator `reset()` |
-| `src/resilience.ts` | `withTimeout` (deadline race → `TimeoutError`) and `withRetry` (jittered exponential backoff, injectable sleep) |
-| `src/registry.ts` | `createRegistry<T>` — the provider-registry convention for pluggable seams (LLM, embeddings, vector stores, aggregators) |
-| `src/workos-directory.ts` | Typed WorkOS Directory Sync client: port-injected `fetch`, bounded cursor pagination, find-by-email / custom-attribute / group / created-since |
-| `src/pii.ts` | PII redaction over the union category set: secrets and tokens, SSN and cards, compensation, HR cases, health, DOB, contact info, AWS accounts, customer and infrastructure identifiers |
+| Module                    | What it is                                                                                                                                                                             |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/circuit-breaker.ts`  | Pure, timer-less sliding-window circuit breaker with an injectable `now()` clock, single half-open probe, `onOpen` trip hook, and operator `reset()`                                   |
+| `src/resilience.ts`       | `withTimeout` (deadline race → `TimeoutError`) and `withRetry` (jittered exponential backoff, injectable sleep)                                                                        |
+| `src/registry.ts`         | `createRegistry<T>` — the provider-registry convention for pluggable seams (LLM, embeddings, vector stores, aggregators)                                                               |
+| `src/workos-directory.ts` | Typed WorkOS Directory Sync client: port-injected `fetch`, bounded cursor pagination, find-by-email / custom-attribute / group / created-since                                         |
+| `src/pii.ts`              | PII redaction over the union category set: secrets and tokens, SSN and cards, compensation, HR cases, health, DOB, contact info, AWS accounts, customer and infrastructure identifiers |
 
 Every module is dependency-free (native `fetch` types only) and side-effect
 free at import time. Observability is deliberately left to the consumer: the

--- a/library/runtime/src/circuit-breaker.test.ts
+++ b/library/runtime/src/circuit-breaker.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { createCircuitBreaker, CircuitOpenError } from "./circuit-breaker.js";
+import { describe, it, expect, vi } from 'vitest';
+import { createCircuitBreaker, CircuitOpenError } from './circuit-breaker.js';
 
 /** Synchronous fake clock — the breaker reads time only through `now()`. */
 function makeClock(start = 1_000) {
@@ -12,96 +12,96 @@ function makeClock(start = 1_000) {
   };
 }
 
-const fail = () => Promise.reject(new Error("boom"));
-const ok = () => Promise.resolve("ok");
+const fail = () => Promise.reject(new Error('boom'));
+const ok = () => Promise.resolve('ok');
 
-const baseConfig = { name: "test", failureThreshold: 3, windowMs: 60_000, halfOpenAfterMs: 30_000 };
+const baseConfig = { name: 'test', failureThreshold: 3, windowMs: 60_000, halfOpenAfterMs: 30_000 };
 
-describe("circuit breaker", () => {
-  it("passes results through while closed", async () => {
+describe('circuit breaker', () => {
+  it('passes results through while closed', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, now: clock.now });
 
-    await expect(cb.exec(ok)).resolves.toBe("ok");
-    expect(cb.state()).toBe("closed");
+    await expect(cb.exec(ok)).resolves.toBe('ok');
+    expect(cb.state()).toBe('closed');
   });
 
-  it("opens after failureThreshold failures within the window", async () => {
+  it('opens after failureThreshold failures within the window', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, now: clock.now });
 
     for (let i = 0; i < 3; i++) {
-      await expect(cb.exec(fail)).rejects.toThrow("boom");
+      await expect(cb.exec(fail)).rejects.toThrow('boom');
     }
-    expect(cb.state()).toBe("open");
+    expect(cb.state()).toBe('open');
   });
 
-  it("fast-fails with CircuitOpenError while open, without invoking the function", async () => {
+  it('fast-fails with CircuitOpenError while open, without invoking the function', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
 
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("open");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('open');
 
     const probe = vi.fn(ok);
     await expect(cb.exec(probe)).rejects.toBeInstanceOf(CircuitOpenError);
-    await expect(cb.exec(probe)).rejects.toThrow("circuit open: test");
+    await expect(cb.exec(probe)).rejects.toThrow('circuit open: test');
     expect(probe).not.toHaveBeenCalled();
   });
 
-  it("decays failures that age out of the sliding window", async () => {
+  it('decays failures that age out of the sliding window', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, now: clock.now });
 
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("closed");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('closed');
 
     // Age the first two failures out of the window.
     clock.tick(61_000);
 
     // Two more failures — only 2 in the current window, still under threshold.
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("closed");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('closed');
 
     // Third within the window trips it.
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("open");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('open');
   });
 
-  it("allows a half-open probe after the cooldown; success closes and clears the window", async () => {
+  it('allows a half-open probe after the cooldown; success closes and clears the window', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
 
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("open");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('open');
 
     clock.tick(30_000);
-    await expect(cb.exec(ok)).resolves.toBe("ok");
-    expect(cb.state()).toBe("closed");
+    await expect(cb.exec(ok)).resolves.toBe('ok');
+    expect(cb.state()).toBe('closed');
 
     // Window was cleared — a single new failure trips again only because
     // threshold is 1; with a higher threshold the slate is clean.
     const cb2 = createCircuitBreaker({ ...baseConfig, now: clock.now });
-    for (let i = 0; i < 3; i++) await expect(cb2.exec(fail)).rejects.toThrow("boom");
+    for (let i = 0; i < 3; i++) await expect(cb2.exec(fail)).rejects.toThrow('boom');
     clock.tick(30_000);
-    await expect(cb2.exec(ok)).resolves.toBe("ok");
-    await expect(cb2.exec(fail)).rejects.toThrow("boom");
-    await expect(cb2.exec(fail)).rejects.toThrow("boom");
-    expect(cb2.state()).toBe("closed"); // 2 of 3 — clean slate after recovery
+    await expect(cb2.exec(ok)).resolves.toBe('ok');
+    await expect(cb2.exec(fail)).rejects.toThrow('boom');
+    await expect(cb2.exec(fail)).rejects.toThrow('boom');
+    expect(cb2.state()).toBe('closed'); // 2 of 3 — clean slate after recovery
   });
 
-  it("re-opens with a fresh openedAt when the probe fails", async () => {
+  it('re-opens with a fresh openedAt when the probe fails', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
 
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
     clock.tick(30_000);
 
     // Probe fails — straight back to open.
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("open");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('open');
 
     // The cooldown restarted: half the cooldown later it is still open.
     clock.tick(15_000);
@@ -109,15 +109,15 @@ describe("circuit breaker", () => {
 
     // Full cooldown elapsed — probe allowed again.
     clock.tick(15_000);
-    await expect(cb.exec(ok)).resolves.toBe("ok");
-    expect(cb.state()).toBe("closed");
+    await expect(cb.exec(ok)).resolves.toBe('ok');
+    expect(cb.state()).toBe('closed');
   });
 
-  it("rejects concurrent calls while a half-open probe is in flight", async () => {
+  it('rejects concurrent calls while a half-open probe is in flight', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
 
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
     clock.tick(30_000);
 
     let release!: (v: string) => void;
@@ -128,19 +128,19 @@ describe("circuit breaker", () => {
     const probe = cb.exec(() => gate);
     await expect(cb.exec(ok)).rejects.toBeInstanceOf(CircuitOpenError);
 
-    release("recovered");
-    await expect(probe).resolves.toBe("recovered");
-    expect(cb.state()).toBe("closed");
+    release('recovered');
+    await expect(probe).resolves.toBe('recovered');
+    expect(cb.state()).toBe('closed');
   });
 
-  it("fires onOpen exactly once per closed→open transition", async () => {
+  it('fires onOpen exactly once per closed→open transition', async () => {
     const clock = makeClock();
     const onOpen = vi.fn();
     const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now, onOpen });
 
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
     expect(onOpen).toHaveBeenCalledTimes(1);
-    expect(onOpen).toHaveBeenCalledWith("test");
+    expect(onOpen).toHaveBeenCalledWith('test');
 
     // Rejections while already open do not re-fire.
     await expect(cb.exec(ok)).rejects.toBeInstanceOf(CircuitOpenError);
@@ -149,25 +149,30 @@ describe("circuit breaker", () => {
 
     // A failed probe is a fresh trip.
     clock.tick(30_000);
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
     expect(onOpen).toHaveBeenCalledTimes(2);
   });
 
-  it("reset() force-closes and clears failure history", async () => {
+  it('reset() force-closes and clears failure history', async () => {
     const clock = makeClock();
     const cb = createCircuitBreaker({ ...baseConfig, failureThreshold: 1, now: clock.now });
 
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("open");
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('open');
 
     cb.reset();
-    expect(cb.state()).toBe("closed");
-    await expect(cb.exec(ok)).resolves.toBe("ok");
+    expect(cb.state()).toBe('closed');
+    await expect(cb.exec(ok)).resolves.toBe('ok');
   });
 
-  it("defaults to Date.now when no clock is injected", async () => {
-    const cb = createCircuitBreaker({ name: "wall-clock", failureThreshold: 1, windowMs: 60_000, halfOpenAfterMs: 30_000 });
-    await expect(cb.exec(fail)).rejects.toThrow("boom");
-    expect(cb.state()).toBe("open");
+  it('defaults to Date.now when no clock is injected', async () => {
+    const cb = createCircuitBreaker({
+      name: 'wall-clock',
+      failureThreshold: 1,
+      windowMs: 60_000,
+      halfOpenAfterMs: 30_000,
+    });
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(cb.state()).toBe('open');
   });
 });

--- a/library/runtime/src/circuit-breaker.ts
+++ b/library/runtime/src/circuit-breaker.ts
@@ -30,12 +30,12 @@
  * `onOpen` into whatever metrics surface the consumer has.
  */
 
-export type CircuitState = "closed" | "open" | "half_open";
+export type CircuitState = 'closed' | 'open' | 'half_open';
 
 export class CircuitOpenError extends Error {
   constructor(name: string) {
     super(`circuit open: ${name}`);
-    this.name = "CircuitOpenError";
+    this.name = 'CircuitOpenError';
   }
 }
 
@@ -64,7 +64,7 @@ export interface CircuitBreakerConfig {
 export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker {
   const now = cfg.now ?? (() => Date.now());
 
-  let state: CircuitState = "closed";
+  let state: CircuitState = 'closed';
   let failures: number[] = [];
   let openedAt = 0;
   let halfOpenInFlight = false;
@@ -77,16 +77,16 @@ export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker 
   }
 
   function tripOpen(t: number): void {
-    state = "open";
+    state = 'open';
     openedAt = t;
     failures = [];
     cfg.onOpen?.(cfg.name);
   }
 
   function maybeEnterHalfOpen(t: number): void {
-    if (state !== "open") return;
+    if (state !== 'open') return;
     if (t - openedAt >= cfg.halfOpenAfterMs) {
-      state = "half_open";
+      state = 'half_open';
       halfOpenInFlight = false;
     }
   }
@@ -95,7 +95,7 @@ export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker 
     state: () => state,
 
     reset(): void {
-      state = "closed";
+      state = 'closed';
       failures = [];
       halfOpenInFlight = false;
     },
@@ -103,14 +103,14 @@ export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker 
     async exec<T>(fn: () => Promise<T>): Promise<T> {
       const t = now();
 
-      if (state === "open") {
+      if (state === 'open') {
         maybeEnterHalfOpen(t);
-        if (state === "open") {
+        if (state === 'open') {
           throw new CircuitOpenError(cfg.name);
         }
       }
 
-      if (state === "half_open") {
+      if (state === 'half_open') {
         if (halfOpenInFlight) {
           // Only one probe at a time — reject fast so we don't pile on the
           // downstream while waiting for the canary to resolve.
@@ -119,7 +119,7 @@ export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker 
         halfOpenInFlight = true;
         try {
           const result = await fn();
-          state = "closed";
+          state = 'closed';
           failures = [];
           halfOpenInFlight = false;
           return result;

--- a/library/runtime/src/pii.test.ts
+++ b/library/runtime/src/pii.test.ts
@@ -1,294 +1,294 @@
-import { describe, it, expect } from "vitest";
-import { redact, scan, assertNoPii, PiiDetectedError, REDACTION_PATTERNS } from "./pii.js";
+import { describe, it, expect } from 'vitest';
+import { redact, scan, assertNoPii, PiiDetectedError, REDACTION_PATTERNS } from './pii.js';
 
-describe("secrets", () => {
-  it("redacts JWTs", () => {
+describe('secrets', () => {
+  it('redacts JWTs', () => {
     const jwt =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
-    expect(redact(`token ${jwt} leaked`)).toBe("token [JWT] leaked");
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    expect(redact(`token ${jwt} leaked`)).toBe('token [JWT] leaked');
   });
 
-  it("redacts AWS access key ids (AKIA and ASIA)", () => {
-    expect(redact("key AKIAIOSFODNN7EXAMPLE in logs")).toBe("key [AWS_KEY] in logs");
-    expect(redact("sts key ASIAIOSFODNN7EXAMPLE")).toBe("sts key [AWS_KEY]");
+  it('redacts AWS access key ids (AKIA and ASIA)', () => {
+    expect(redact('key AKIAIOSFODNN7EXAMPLE in logs')).toBe('key [AWS_KEY] in logs');
+    expect(redact('sts key ASIAIOSFODNN7EXAMPLE')).toBe('sts key [AWS_KEY]');
   });
 
-  it("redacts GitHub PATs", () => {
-    expect(redact("ghp_abcdefghijklmnopqrstuvwxyz0123456789")).toBe("[GITHUB_PAT]");
+  it('redacts GitHub PATs', () => {
+    expect(redact('ghp_abcdefghijklmnopqrstuvwxyz0123456789')).toBe('[GITHUB_PAT]');
   });
 
-  it("redacts Slack tokens", () => {
-    expect(redact("xoxb-123456789012-abcdefGHIJKL")).toBe("[SLACK_TOKEN]");
+  it('redacts Slack tokens', () => {
+    expect(redact('xoxb-123456789012-abcdefGHIJKL')).toBe('[SLACK_TOKEN]');
   });
 
-  it("redacts generic API keys (sk-, pk_live_, Bearer)", () => {
-    expect(redact("sk-abcdefghijklmnopqrstuvwxyz")).toBe("[API_KEY]");
-    expect(redact("pk_live_abcdefghijklmnopqrst")).toBe("[API_KEY]");
-    expect(redact("Authorization: Bearer abcdefghijklmnopqrstuv")).toBe("Authorization: [API_KEY]");
-  });
-});
-
-describe("financial identifiers", () => {
-  it("redacts dashed SSNs", () => {
-    expect(redact("ssn 123-45-6789 on file")).toBe("ssn [SSN] on file");
-  });
-
-  it("does NOT redact non-dashed 9-digit runs (deliberate false-positive guard)", () => {
-    expect(redact("order 123456789 shipped")).toBe("order 123456789 shipped");
-  });
-
-  it("redacts scheme-valid card numbers", () => {
-    expect(redact("visa 4111111111111111")).toBe("visa [PAYMENT]");
-    expect(redact("mc 5500005555555559")).toBe("mc [PAYMENT]");
-    expect(redact("amex 340000000000009")).toBe("amex [PAYMENT]");
-  });
-
-  it("redacts separator-grouped card numbers", () => {
-    expect(redact("card 4111 1111 1111 1111 charged")).toBe("card [PAYMENT] charged");
-    expect(redact("card 4111-1111-1111-1111 charged")).toBe("card [PAYMENT] charged");
+  it('redacts generic API keys (sk-, pk_live_, Bearer)', () => {
+    expect(redact('sk-abcdefghijklmnopqrstuvwxyz')).toBe('[API_KEY]');
+    expect(redact('pk_live_abcdefghijklmnopqrst')).toBe('[API_KEY]');
+    expect(redact('Authorization: Bearer abcdefghijklmnopqrstuv')).toBe('Authorization: [API_KEY]');
   });
 });
 
-describe("compensation", () => {
-  it("redacts currency amounts adjacent to comp keywords (both orders)", () => {
-    expect(redact("her $150,000 base")).toContain("[COMPENSATION]");
-    expect(redact("salary of £80,000 agreed")).toContain("[COMPENSATION]");
-    expect(redact("€90k bonus this year")).toContain("[COMPENSATION]");
+describe('financial identifiers', () => {
+  it('redacts dashed SSNs', () => {
+    expect(redact('ssn 123-45-6789 on file')).toBe('ssn [SSN] on file');
   });
 
-  it("redacts bare-number amounts adjacent to comp keywords", () => {
-    expect(redact("base 95k for the role")).toContain("[COMPENSATION]");
-    expect(redact("bonus 12000 approved")).toContain("[COMPENSATION]");
+  it('does NOT redact non-dashed 9-digit runs (deliberate false-positive guard)', () => {
+    expect(redact('order 123456789 shipped')).toBe('order 123456789 shipped');
   });
 
-  it("redacts annual-cadence amounts regardless of keyword", () => {
-    expect(redact("she makes 120k annually")).toContain("[COMPENSATION]");
-    expect(redact("£80,000 per year offer")).toContain("[COMPENSATION]");
+  it('redacts scheme-valid card numbers', () => {
+    expect(redact('visa 4111111111111111')).toBe('visa [PAYMENT]');
+    expect(redact('mc 5500005555555559')).toBe('mc [PAYMENT]');
+    expect(redact('amex 340000000000009')).toBe('amex [PAYMENT]');
   });
 
-  it("redacts comp phrases", () => {
-    expect(redact("discussed total comp at the offsite")).toContain("[COMPENSATION]");
-  });
-});
-
-describe("performance / HR", () => {
-  it("redacts PIP mentions (uppercase only)", () => {
-    expect(redact("moved to a PIP last month")).toBe("moved to a [HR] last month");
-    expect(redact("pipeline pip install")).toBe("pipeline pip install");
-  });
-
-  it("redacts performance-process phrases", () => {
-    expect(redact("on a performance improvement plan")).toContain("[HR]");
-    expect(redact("pending disciplinary action")).toContain("[HR]");
-    expect(redact("issued a written warning")).toContain("[HR]");
-    expect(redact("sent the termination notice")).toContain("[HR]");
-    expect(redact("performance corrective steps")).toContain("[HR]");
-  });
-
-  it("redacts HR case, case-number, and ticket identifiers", () => {
-    expect(redact("see HR-4821 for details")).toBe("see [HR_CASE] for details");
-    expect(redact("escalated case #1234")).toBe("escalated [HR_CASE]");
-    expect(redact("tracked in ticket #ABC123")).toBe("tracked in [HR_CASE]");
+  it('redacts separator-grouped card numbers', () => {
+    expect(redact('card 4111 1111 1111 1111 charged')).toBe('card [PAYMENT] charged');
+    expect(redact('card 4111-1111-1111-1111 charged')).toBe('card [PAYMENT] charged');
   });
 });
 
-describe("health", () => {
-  it("redacts strong standalone signals", () => {
-    expect(redact("approved FMLA request")).toBe("approved [HEALTH] request");
-    expect(redact("she was diagnosed recently")).toBe("she was [HEALTH] recently");
+describe('compensation', () => {
+  it('redacts currency amounts adjacent to comp keywords (both orders)', () => {
+    expect(redact('her $150,000 base')).toContain('[COMPENSATION]');
+    expect(redact('salary of £80,000 agreed')).toContain('[COMPENSATION]');
+    expect(redact('€90k bonus this year')).toContain('[COMPENSATION]');
   });
 
-  it("redacts medical/health phrases", () => {
-    expect(redact("out on medical leave")).toContain("[HEALTH]");
-    expect(redact("a mental health day")).toContain("[HEALTH]");
-    expect(redact("ongoing health condition")).toContain("[HEALTH]");
-    expect(redact("short-term disability paperwork")).toContain("[HEALTH]");
-    expect(redact("disability accommodation approved")).toContain("[HEALTH]");
-    expect(redact("accommodation request filed")).toContain("[HEALTH]");
-    expect(redact("on parental leave until June")).toContain("[HEALTH]");
-    expect(redact("took a leave of absence")).toContain("[HEALTH]");
-    expect(redact("workers comp claim filed")).toContain("[HEALTH]");
-    expect(redact("in therapy for burnout")).toContain("[HEALTH]");
+  it('redacts bare-number amounts adjacent to comp keywords', () => {
+    expect(redact('base 95k for the role')).toContain('[COMPENSATION]');
+    expect(redact('bonus 12000 approved')).toContain('[COMPENSATION]');
   });
 
-  it("leaves benign words alone", () => {
-    expect(redact("the health of the service improved")).toBe("the health of the service improved");
-    expect(redact("please leave feedback")).toBe("please leave feedback");
+  it('redacts annual-cadence amounts regardless of keyword', () => {
+    expect(redact('she makes 120k annually')).toContain('[COMPENSATION]');
+    expect(redact('£80,000 per year offer')).toContain('[COMPENSATION]');
+  });
+
+  it('redacts comp phrases', () => {
+    expect(redact('discussed total comp at the offsite')).toContain('[COMPENSATION]');
   });
 });
 
-describe("date of birth", () => {
-  it("redacts labeled DOB values", () => {
-    expect(redact("DOB: 01/02/1990")).toBe("[DOB]");
-    expect(redact("date of birth 1-2-90 confirmed")).toBe("[DOB] confirmed");
-    expect(redact("born on 12/31/1985")).toBe("[DOB]");
+describe('performance / HR', () => {
+  it('redacts PIP mentions (uppercase only)', () => {
+    expect(redact('moved to a PIP last month')).toBe('moved to a [HR] last month');
+    expect(redact('pipeline pip install')).toBe('pipeline pip install');
   });
 
-  it("leaves unlabeled dates alone", () => {
-    expect(redact("shipped on 01/02/2026")).toBe("shipped on 01/02/2026");
-  });
-});
-
-describe("contact info", () => {
-  it("redacts emails", () => {
-    expect(redact("ping alice@example.com please")).toBe("ping [EMAIL] please");
+  it('redacts performance-process phrases', () => {
+    expect(redact('on a performance improvement plan')).toContain('[HR]');
+    expect(redact('pending disciplinary action')).toContain('[HR]');
+    expect(redact('issued a written warning')).toContain('[HR]');
+    expect(redact('sent the termination notice')).toContain('[HR]');
+    expect(redact('performance corrective steps')).toContain('[HR]');
   });
 
-  it("redacts US phone numbers", () => {
-    expect(redact("call 415-555-1234 now")).toBe("call [PHONE] now");
-    expect(redact("call (415) 555-1234 now")).toBe("call ([PHONE] now");
-  });
-
-  it("redacts international phone numbers", () => {
-    expect(redact("mobile +44 20 7946 0958")).toBe("mobile [PHONE]");
-    expect(redact("or +919876543210")).toBe("or [PHONE]");
-  });
-
-  it("redacts street addresses", () => {
-    expect(redact("lives at 742 Evergreen Way")).toBe("lives at [ADDRESS]");
+  it('redacts HR case, case-number, and ticket identifiers', () => {
+    expect(redact('see HR-4821 for details')).toBe('see [HR_CASE] for details');
+    expect(redact('escalated case #1234')).toBe('escalated [HR_CASE]');
+    expect(redact('tracked in ticket #ABC123')).toBe('tracked in [HR_CASE]');
   });
 });
 
-describe("aws account ids", () => {
-  it("redacts 12-digit runs followed by aws/account context", () => {
-    expect(redact("123456789012 aws")).toBe("[AWS_ACCOUNT] aws");
-    expect(redact("in 123456789012 account")).toBe("in [AWS_ACCOUNT] account");
+describe('health', () => {
+  it('redacts strong standalone signals', () => {
+    expect(redact('approved FMLA request')).toBe('approved [HEALTH] request');
+    expect(redact('she was diagnosed recently')).toBe('she was [HEALTH] recently');
   });
 
-  it("leaves context-free 12-digit runs alone", () => {
-    expect(redact("tracking 123456789012 arrived")).toBe("tracking 123456789012 arrived");
-  });
-});
-
-describe("customer / infrastructure identifiers", () => {
-  it("redacts customer ids", () => {
-    expect(redact("affects cust-99231 only")).toBe("affects [CUSTOMER_ID] only");
-  });
-
-  it("redacts account-id fields", () => {
-    expect(redact("account_id:ac-4451 flagged")).toBe("[ACCOUNT_ID] flagged");
-    expect(redact("account-id=xyz9")).toBe("[ACCOUNT_ID]");
+  it('redacts medical/health phrases', () => {
+    expect(redact('out on medical leave')).toContain('[HEALTH]');
+    expect(redact('a mental health day')).toContain('[HEALTH]');
+    expect(redact('ongoing health condition')).toContain('[HEALTH]');
+    expect(redact('short-term disability paperwork')).toContain('[HEALTH]');
+    expect(redact('disability accommodation approved')).toContain('[HEALTH]');
+    expect(redact('accommodation request filed')).toContain('[HEALTH]');
+    expect(redact('on parental leave until June')).toContain('[HEALTH]');
+    expect(redact('took a leave of absence')).toContain('[HEALTH]');
+    expect(redact('workers comp claim filed')).toContain('[HEALTH]');
+    expect(redact('in therapy for burnout')).toContain('[HEALTH]');
   });
 
-  it("redacts RFC1918 addresses and leaves public ones", () => {
-    expect(redact("pod at 10.0.12.5 crashed")).toBe("pod at [INTERNAL_IP] crashed");
-    expect(redact("node 172.20.1.9 drained")).toBe("node [INTERNAL_IP] drained");
-    expect(redact("gw 192.168.1.1 up")).toBe("gw [INTERNAL_IP] up");
-    expect(redact("resolver 8.8.8.8 fine")).toBe("resolver 8.8.8.8 fine");
-    expect(redact("host 172.15.0.1 is public")).toBe("host 172.15.0.1 is public");
-  });
-
-  it("redacts prod hostnames and db identifiers", () => {
-    expect(redact("on prod-api-7.internal now")).toBe("on [INTERNAL_HOST] now");
-    expect(redact("failing over db-orders-primary")).toBe("failing over [INTERNAL_HOST]");
+  it('leaves benign words alone', () => {
+    expect(redact('the health of the service improved')).toBe('the health of the service improved');
+    expect(redact('please leave feedback')).toBe('please leave feedback');
   });
 });
 
-describe("redact", () => {
-  it("handles mixed text in one pass", () => {
+describe('date of birth', () => {
+  it('redacts labeled DOB values', () => {
+    expect(redact('DOB: 01/02/1990')).toBe('[DOB]');
+    expect(redact('date of birth 1-2-90 confirmed')).toBe('[DOB] confirmed');
+    expect(redact('born on 12/31/1985')).toBe('[DOB]');
+  });
+
+  it('leaves unlabeled dates alone', () => {
+    expect(redact('shipped on 01/02/2026')).toBe('shipped on 01/02/2026');
+  });
+});
+
+describe('contact info', () => {
+  it('redacts emails', () => {
+    expect(redact('ping alice@example.com please')).toBe('ping [EMAIL] please');
+  });
+
+  it('redacts US phone numbers', () => {
+    expect(redact('call 415-555-1234 now')).toBe('call [PHONE] now');
+    expect(redact('call (415) 555-1234 now')).toBe('call ([PHONE] now');
+  });
+
+  it('redacts international phone numbers', () => {
+    expect(redact('mobile +44 20 7946 0958')).toBe('mobile [PHONE]');
+    expect(redact('or +919876543210')).toBe('or [PHONE]');
+  });
+
+  it('redacts street addresses', () => {
+    expect(redact('lives at 742 Evergreen Way')).toBe('lives at [ADDRESS]');
+  });
+});
+
+describe('aws account ids', () => {
+  it('redacts 12-digit runs followed by aws/account context', () => {
+    expect(redact('123456789012 aws')).toBe('[AWS_ACCOUNT] aws');
+    expect(redact('in 123456789012 account')).toBe('in [AWS_ACCOUNT] account');
+  });
+
+  it('leaves context-free 12-digit runs alone', () => {
+    expect(redact('tracking 123456789012 arrived')).toBe('tracking 123456789012 arrived');
+  });
+});
+
+describe('customer / infrastructure identifiers', () => {
+  it('redacts customer ids', () => {
+    expect(redact('affects cust-99231 only')).toBe('affects [CUSTOMER_ID] only');
+  });
+
+  it('redacts account-id fields', () => {
+    expect(redact('account_id:ac-4451 flagged')).toBe('[ACCOUNT_ID] flagged');
+    expect(redact('account-id=xyz9')).toBe('[ACCOUNT_ID]');
+  });
+
+  it('redacts RFC1918 addresses and leaves public ones', () => {
+    expect(redact('pod at 10.0.12.5 crashed')).toBe('pod at [INTERNAL_IP] crashed');
+    expect(redact('node 172.20.1.9 drained')).toBe('node [INTERNAL_IP] drained');
+    expect(redact('gw 192.168.1.1 up')).toBe('gw [INTERNAL_IP] up');
+    expect(redact('resolver 8.8.8.8 fine')).toBe('resolver 8.8.8.8 fine');
+    expect(redact('host 172.15.0.1 is public')).toBe('host 172.15.0.1 is public');
+  });
+
+  it('redacts prod hostnames and db identifiers', () => {
+    expect(redact('on prod-api-7.internal now')).toBe('on [INTERNAL_HOST] now');
+    expect(redact('failing over db-orders-primary')).toBe('failing over [INTERNAL_HOST]');
+  });
+});
+
+describe('redact', () => {
+  it('handles mixed text in one pass', () => {
     const input =
-      "IC update: cust-441 (contact bob@example.com, +1 415-555-0100) hit by db-users-3 at 10.1.2.3; " +
-      "key AKIAIOSFODNN7EXAMPLE rotated, see HR-77 and case #12";
+      'IC update: cust-441 (contact bob@example.com, +1 415-555-0100) hit by db-users-3 at 10.1.2.3; ' +
+      'key AKIAIOSFODNN7EXAMPLE rotated, see HR-77 and case #12';
     const output = redact(input);
 
-    expect(output).not.toContain("bob@example.com");
-    expect(output).not.toContain("AKIAIOSFODNN7EXAMPLE");
-    expect(output).not.toContain("cust-441");
-    expect(output).not.toContain("10.1.2.3");
-    expect(output).toContain("[EMAIL]");
-    expect(output).toContain("[PHONE]");
-    expect(output).toContain("[AWS_KEY]");
-    expect(output).toContain("[CUSTOMER_ID]");
-    expect(output).toContain("[INTERNAL_HOST]");
-    expect(output).toContain("[INTERNAL_IP]");
-    expect(output).toContain("[HR_CASE]");
+    expect(output).not.toContain('bob@example.com');
+    expect(output).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(output).not.toContain('cust-441');
+    expect(output).not.toContain('10.1.2.3');
+    expect(output).toContain('[EMAIL]');
+    expect(output).toContain('[PHONE]');
+    expect(output).toContain('[AWS_KEY]');
+    expect(output).toContain('[CUSTOMER_ID]');
+    expect(output).toContain('[INTERNAL_HOST]');
+    expect(output).toContain('[INTERNAL_IP]');
+    expect(output).toContain('[HR_CASE]');
   });
 
-  it("restricts to the requested categories", () => {
-    const input = "email alice@example.com token xoxb-123456789012-abcdefGHIJKL";
+  it('restricts to the requested categories', () => {
+    const input = 'email alice@example.com token xoxb-123456789012-abcdefGHIJKL';
 
-    const secretsOnly = redact(input, { categories: ["secrets"] });
-    expect(secretsOnly).toContain("alice@example.com");
-    expect(secretsOnly).toContain("[SLACK_TOKEN]");
+    const secretsOnly = redact(input, { categories: ['secrets'] });
+    expect(secretsOnly).toContain('alice@example.com');
+    expect(secretsOnly).toContain('[SLACK_TOKEN]');
 
-    const contactOnly = redact(input, { categories: ["contact"] });
-    expect(contactOnly).toContain("[EMAIL]");
-    expect(contactOnly).toContain("xoxb-123456789012-abcdefGHIJKL");
+    const contactOnly = redact(input, { categories: ['contact'] });
+    expect(contactOnly).toContain('[EMAIL]');
+    expect(contactOnly).toContain('xoxb-123456789012-abcdefGHIJKL');
   });
 
-  it("returns clean text unchanged", () => {
-    const clean = "Deployed v1.4.2 to staging; error rate back under 0.1%.";
+  it('returns clean text unchanged', () => {
+    const clean = 'Deployed v1.4.2 to staging; error rate back under 0.1%.';
     expect(redact(clean)).toBe(clean);
   });
 });
 
-describe("scan", () => {
-  it("reports category, label, and matches without mutating text", () => {
-    const findings = scan("ssn 123-45-6789 and email a@b.co");
+describe('scan', () => {
+  it('reports category, label, and matches without mutating text', () => {
+    const findings = scan('ssn 123-45-6789 and email a@b.co');
 
     expect(findings).toEqual([
-      { category: "financial", label: "ssn", matches: ["123-45-6789"] },
-      { category: "contact", label: "email", matches: ["a@b.co"] },
+      { category: 'financial', label: 'ssn', matches: ['123-45-6789'] },
+      { category: 'contact', label: 'email', matches: ['a@b.co'] },
     ]);
   });
 
-  it("returns an empty list for clean text", () => {
-    expect(scan("all quiet")).toEqual([]);
+  it('returns an empty list for clean text', () => {
+    expect(scan('all quiet')).toEqual([]);
   });
 
-  it("is stateless across repeated calls (no shared lastIndex)", () => {
-    const text = "a@b.co";
+  it('is stateless across repeated calls (no shared lastIndex)', () => {
+    const text = 'a@b.co';
     expect(scan(text)).toHaveLength(1);
     expect(scan(text)).toHaveLength(1);
   });
 });
 
-describe("assertNoPii", () => {
-  it("passes on clean text", () => {
-    expect(() => assertNoPii("nothing to see", "run-1")).not.toThrow();
+describe('assertNoPii', () => {
+  it('passes on clean text', () => {
+    expect(() => assertNoPii('nothing to see', 'run-1')).not.toThrow();
   });
 
-  it("throws PiiDetectedError naming the findings and context", () => {
-    expect(() => assertNoPii("ssn 123-45-6789", "run-42")).toThrowError(PiiDetectedError);
-    expect(() => assertNoPii("ssn 123-45-6789", "run-42")).toThrow(
-      "[run-42] PII detected: financial/ssn",
+  it('throws PiiDetectedError naming the findings and context', () => {
+    expect(() => assertNoPii('ssn 123-45-6789', 'run-42')).toThrowError(PiiDetectedError);
+    expect(() => assertNoPii('ssn 123-45-6789', 'run-42')).toThrow(
+      '[run-42] PII detected: financial/ssn',
     );
-    expect(() => assertNoPii("ssn 123-45-6789")).toThrow("PII detected: financial/ssn");
+    expect(() => assertNoPii('ssn 123-45-6789')).toThrow('PII detected: financial/ssn');
   });
 
-  it("exposes structured findings on the error", () => {
+  it('exposes structured findings on the error', () => {
     try {
-      assertNoPii("card 4111111111111111", "run-7");
+      assertNoPii('card 4111111111111111', 'run-7');
       expect.unreachable();
     } catch (err) {
       expect(err).toBeInstanceOf(PiiDetectedError);
       expect((err as PiiDetectedError).findings[0]).toMatchObject({
-        category: "financial",
-        label: "credit_card",
+        category: 'financial',
+        label: 'credit_card',
       });
     }
   });
 });
 
-describe("pattern catalog", () => {
+describe('pattern catalog', () => {
   it("covers the union of the fleet's category sets", () => {
     const categories = new Set(REDACTION_PATTERNS.map((p) => p.category));
     expect([...categories].sort()).toEqual([
-      "aws",
-      "compensation",
-      "contact",
-      "customer",
-      "dob",
-      "financial",
-      "health",
-      "hr",
-      "secrets",
+      'aws',
+      'compensation',
+      'contact',
+      'customer',
+      'dob',
+      'financial',
+      'health',
+      'hr',
+      'secrets',
     ]);
   });
 
-  it("declares every pattern global so redact replaces all occurrences", () => {
+  it('declares every pattern global so redact replaces all occurrences', () => {
     for (const { label, pattern } of REDACTION_PATTERNS) {
-      expect(pattern.flags, `${label} must be global`).toContain("g");
+      expect(pattern.flags, `${label} must be global`).toContain('g');
     }
   });
 });

--- a/library/runtime/src/pii.ts
+++ b/library/runtime/src/pii.ts
@@ -24,15 +24,15 @@
  */
 
 export type PiiCategory =
-  | "secrets"
-  | "financial"
-  | "compensation"
-  | "hr"
-  | "health"
-  | "dob"
-  | "contact"
-  | "aws"
-  | "customer";
+  | 'secrets'
+  | 'financial'
+  | 'compensation'
+  | 'hr'
+  | 'health'
+  | 'dob'
+  | 'contact'
+  | 'aws'
+  | 'customer';
 
 export interface RedactionPattern {
   category: PiiCategory;
@@ -42,283 +42,289 @@ export interface RedactionPattern {
 }
 
 // Compensation keywords reused across the currency-agnostic patterns below.
-const COMP_KEYWORD = "(?:salary|compensation|comp|pay|bonus|equity|RSUs?|raise|offer|base|stipend)";
+const COMP_KEYWORD = '(?:salary|compensation|comp|pay|bonus|equity|RSUs?|raise|offer|base|stipend)';
 // A monetary amount: optional currency symbol, optional magnitude/cadence suffix.
 const MONEY_AMOUNT =
-  "(?:[$£€¥₹]\\s?)?[\\d,]+(?:\\.\\d{1,2})?(?:\\s*(?:k|K|thousand|million|m|/\\s*year|/\\s*yr|per\\s+annum|annually))?";
+  '(?:[$£€¥₹]\\s?)?[\\d,]+(?:\\.\\d{1,2})?(?:\\s*(?:k|K|thousand|million|m|/\\s*year|/\\s*yr|per\\s+annum|annually))?';
 
 export const REDACTION_PATTERNS: readonly RedactionPattern[] = [
   // ── Secrets / tokens ─────────────────────────────────────────────
   {
-    category: "secrets",
-    label: "jwt",
+    category: 'secrets',
+    label: 'jwt',
     pattern: /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
-    replacement: "[JWT]",
+    replacement: '[JWT]',
   },
   {
-    category: "secrets",
-    label: "aws_access_key",
+    category: 'secrets',
+    label: 'aws_access_key',
     pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
-    replacement: "[AWS_KEY]",
+    replacement: '[AWS_KEY]',
   },
   {
-    category: "secrets",
-    label: "github_pat",
+    category: 'secrets',
+    label: 'github_pat',
     pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,255}\b/g,
-    replacement: "[GITHUB_PAT]",
+    replacement: '[GITHUB_PAT]',
   },
   {
-    category: "secrets",
-    label: "slack_token",
+    category: 'secrets',
+    label: 'slack_token',
     pattern: /\bxox[bpasr]-[A-Za-z0-9-]{10,}\b/g,
-    replacement: "[SLACK_TOKEN]",
+    replacement: '[SLACK_TOKEN]',
   },
   {
-    category: "secrets",
-    label: "api_key_generic",
+    category: 'secrets',
+    label: 'api_key_generic',
     pattern: /\b(?:sk-|pk_live_|Bearer\s)[A-Za-z0-9_-]{20,}\b/g,
-    replacement: "[API_KEY]",
+    replacement: '[API_KEY]',
   },
 
   // ── Financial identifiers ────────────────────────────────────────
   {
-    category: "financial",
-    label: "ssn",
+    category: 'financial',
+    label: 'ssn',
     pattern: /\b\d{3}-\d{2}-\d{4}\b/g,
-    replacement: "[SSN]",
+    replacement: '[SSN]',
   },
   {
-    category: "financial",
-    label: "credit_card",
+    category: 'financial',
+    label: 'credit_card',
     pattern:
       /\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12})\b/g,
-    replacement: "[PAYMENT]",
+    replacement: '[PAYMENT]',
   },
   {
-    category: "financial",
-    label: "credit_card_separated",
+    category: 'financial',
+    label: 'credit_card_separated',
     pattern: /\b\d{4}[\s-]\d{4}[\s-]\d{4}[\s-]\d{4}\b/g,
-    replacement: "[PAYMENT]",
+    replacement: '[PAYMENT]',
   },
 
   // ── Compensation ─────────────────────────────────────────────────
   {
-    category: "compensation",
-    label: "amount_before_keyword",
+    category: 'compensation',
+    label: 'amount_before_keyword',
     pattern: new RegExp(
       `[$£€¥₹]\\s?[\\d,]+(?:\\.\\d{1,2})?(?:\\s*(?:k|K|thousand|million|m))?\\s*${COMP_KEYWORD}`,
-      "gi",
+      'gi',
     ),
-    replacement: "[COMPENSATION]",
+    replacement: '[COMPENSATION]',
   },
   {
-    category: "compensation",
-    label: "keyword_before_currency_amount",
-    pattern: new RegExp(`${COMP_KEYWORD}\\s*(?:of|is|was|at|:)?\\s*[$£€¥₹]\\s?[\\d,]+`, "gi"),
-    replacement: "[COMPENSATION]",
+    category: 'compensation',
+    label: 'keyword_before_currency_amount',
+    pattern: new RegExp(`${COMP_KEYWORD}\\s*(?:of|is|was|at|:)?\\s*[$£€¥₹]\\s?[\\d,]+`, 'gi'),
+    replacement: '[COMPENSATION]',
   },
   {
-    category: "compensation",
-    label: "keyword_before_bare_amount",
-    pattern: new RegExp(`${COMP_KEYWORD}\\s*(?:of|is|was|at|:)?\\s*${MONEY_AMOUNT}`, "gi"),
-    replacement: "[COMPENSATION]",
+    category: 'compensation',
+    label: 'keyword_before_bare_amount',
+    pattern: new RegExp(`${COMP_KEYWORD}\\s*(?:of|is|was|at|:)?\\s*${MONEY_AMOUNT}`, 'gi'),
+    replacement: '[COMPENSATION]',
   },
   {
-    category: "compensation",
-    label: "bare_amount_before_keyword",
-    pattern: new RegExp(`${MONEY_AMOUNT}\\s*${COMP_KEYWORD}`, "gi"),
-    replacement: "[COMPENSATION]",
+    category: 'compensation',
+    label: 'bare_amount_before_keyword',
+    pattern: new RegExp(`${MONEY_AMOUNT}\\s*${COMP_KEYWORD}`, 'gi'),
+    replacement: '[COMPENSATION]',
   },
   {
-    category: "compensation",
-    label: "annual_cadence_amount",
+    category: 'compensation',
+    label: 'annual_cadence_amount',
     pattern:
       /(?:[$£€¥₹]\s?)?[\d,]+(?:\.\d{1,2})?\s*[kKmM]?\s*(?:per\s+annum|annually|\/\s*year|\/\s*yr|per\s+year|a\s+year)\b/gi,
-    replacement: "[COMPENSATION]",
+    replacement: '[COMPENSATION]',
   },
   {
-    category: "compensation",
-    label: "comp_phrase",
+    category: 'compensation',
+    label: 'comp_phrase',
     pattern: /\b(?:annual|base|total)\s+(?:comp|compensation|salary|pay)\b/gi,
-    replacement: "[COMPENSATION]",
+    replacement: '[COMPENSATION]',
   },
 
   // ── Performance / HR ─────────────────────────────────────────────
-  { category: "hr", label: "pip", pattern: /\bPIP\b/g, replacement: "[HR]" },
+  { category: 'hr', label: 'pip', pattern: /\bPIP\b/g, replacement: '[HR]' },
   {
-    category: "hr",
-    label: "performance_process",
+    category: 'hr',
+    label: 'performance_process',
     pattern: /performance\s+(?:improvement|management|plan|review|warning)/gi,
-    replacement: "[HR]",
+    replacement: '[HR]',
   },
   {
-    category: "hr",
-    label: "disciplinary",
+    category: 'hr',
+    label: 'disciplinary',
     pattern: /disciplinary\s+(?:action|proceeding|process)/gi,
-    replacement: "[HR]",
+    replacement: '[HR]',
   },
-  { category: "hr", label: "written_warning", pattern: /written\s+warning/gi, replacement: "[HR]" },
+  { category: 'hr', label: 'written_warning', pattern: /written\s+warning/gi, replacement: '[HR]' },
   {
-    category: "hr",
-    label: "termination_notice",
+    category: 'hr',
+    label: 'termination_notice',
     pattern: /termination\s+notice/gi,
-    replacement: "[HR]",
+    replacement: '[HR]',
   },
   {
-    category: "hr",
-    label: "performance_corrective",
+    category: 'hr',
+    label: 'performance_corrective',
     pattern: /performance\s+corrective/gi,
-    replacement: "[HR]",
+    replacement: '[HR]',
   },
-  { category: "hr", label: "hr_case_id", pattern: /HR-\d+/gi, replacement: "[HR_CASE]" },
-  { category: "hr", label: "case_number", pattern: /case\s+#?\d+/gi, replacement: "[HR_CASE]" },
+  { category: 'hr', label: 'hr_case_id', pattern: /HR-\d+/gi, replacement: '[HR_CASE]' },
+  { category: 'hr', label: 'case_number', pattern: /case\s+#?\d+/gi, replacement: '[HR_CASE]' },
   {
-    category: "hr",
-    label: "ticket_number",
+    category: 'hr',
+    label: 'ticket_number',
     pattern: /ticket\s+#?[A-Z0-9]+/gi,
-    replacement: "[HR_CASE]",
+    replacement: '[HR_CASE]',
   },
 
   // ── Health ───────────────────────────────────────────────────────
-  { category: "health", label: "fmla", pattern: /\bFMLA\b/gi, replacement: "[HEALTH]" },
+  { category: 'health', label: 'fmla', pattern: /\bFMLA\b/gi, replacement: '[HEALTH]' },
   {
-    category: "health",
-    label: "diagnosis",
+    category: 'health',
+    label: 'diagnosis',
     pattern: /\bdiagnos(?:is|ed|es)\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "medical_phrase",
+    category: 'health',
+    label: 'medical_phrase',
     pattern: /\bmedical\s+(?:leave|condition|emergency|appointment|record|history|note)\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
-  { category: "health", label: "mental_health", pattern: /\bmental\s+health\b/gi, replacement: "[HEALTH]" },
   {
-    category: "health",
-    label: "health_phrase",
+    category: 'health',
+    label: 'mental_health',
+    pattern: /\bmental\s+health\b/gi,
+    replacement: '[HEALTH]',
+  },
+  {
+    category: 'health',
+    label: 'health_phrase',
     pattern: /\bhealth\s+(?:condition|issue|concern|record|emergency)\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "term_disability",
+    category: 'health',
+    label: 'term_disability',
     pattern: /\b(?:short|long)[\s-]term\s+disability\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "disability_phrase",
+    category: 'health',
+    label: 'disability_phrase',
     pattern: /\bdisability\s+(?:accommodation|leave|claim|benefits?|status)\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "accommodation",
+    category: 'health',
+    label: 'accommodation',
     pattern: /\b(?:reasonable\s+)?accommodation\s+(?:request|for)\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "leave_type",
+    category: 'health',
+    label: 'leave_type',
     pattern: /\b(?:sick|medical|maternity|paternity|parental|bereavement)\s+leave\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "leave_of_absence",
+    category: 'health',
+    label: 'leave_of_absence',
     pattern: /\bleave\s+of\s+absence\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "workers_comp",
+    category: 'health',
+    label: 'workers_comp',
     pattern: /\bworkers?['’\s]?\s*comp(?:ensation)?\s+(?:claim|case|injury)\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
   {
-    category: "health",
-    label: "treatment_for",
+    category: 'health',
+    label: 'treatment_for',
     pattern: /\b(?:treatment|therapy|prescription|hospitaliz(?:ed|ation)|surgery)\s+for\b/gi,
-    replacement: "[HEALTH]",
+    replacement: '[HEALTH]',
   },
 
   // ── Date of birth ────────────────────────────────────────────────
   {
-    category: "dob",
-    label: "dob_phrase",
+    category: 'dob',
+    label: 'dob_phrase',
     pattern: /\b(?:date of birth|dob|born on)\s*:?\s*\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/gi,
-    replacement: "[DOB]",
+    replacement: '[DOB]',
   },
 
   // ── Contact info ─────────────────────────────────────────────────
   {
-    category: "contact",
-    label: "email",
+    category: 'contact',
+    label: 'email',
     pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
-    replacement: "[EMAIL]",
+    replacement: '[EMAIL]',
   },
   {
-    category: "contact",
-    label: "phone_us",
+    category: 'contact',
+    label: 'phone_us',
     pattern: /\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s][0-9]{3}[-.\s][0-9]{4}\b/g,
-    replacement: "[PHONE]",
+    replacement: '[PHONE]',
   },
   {
-    category: "contact",
-    label: "phone_intl",
+    category: 'contact',
+    label: 'phone_intl',
     // E.164 / international: leading "+" country code then 7-14 more digits
     // with optional space/dash/dot grouping. The required "+" keeps it from
     // matching bare digit runs handled by other patterns.
     pattern: /\+\d{1,3}(?:[\s\-.]?\d){7,14}\b/g,
-    replacement: "[PHONE]",
+    replacement: '[PHONE]',
   },
   {
-    category: "contact",
-    label: "street_address",
+    category: 'contact',
+    label: 'street_address',
     pattern: /\b\d{1,5}\s+[A-Z][a-z]+\s+(?:St|Ave|Blvd|Dr|Rd|Ln|Way|Court|Ct|Place|Pl)\b/gi,
-    replacement: "[ADDRESS]",
+    replacement: '[ADDRESS]',
   },
 
   // ── AWS account ──────────────────────────────────────────────────
   {
-    category: "aws",
-    label: "aws_account_id",
+    category: 'aws',
+    label: 'aws_account_id',
     pattern: /\b\d{12}\b(?=\s*(?:aws|account))/gi,
-    replacement: "[AWS_ACCOUNT]",
+    replacement: '[AWS_ACCOUNT]',
   },
 
   // ── Customer / infrastructure identifiers ────────────────────────
   {
-    category: "customer",
-    label: "customer_id",
+    category: 'customer',
+    label: 'customer_id',
     pattern: /\bcust-[0-9]+\b/gi,
-    replacement: "[CUSTOMER_ID]",
+    replacement: '[CUSTOMER_ID]',
   },
   {
-    category: "customer",
-    label: "account_id_field",
+    category: 'customer',
+    label: 'account_id_field',
     pattern: /\baccount[-_]?id[:=\s][^\s,]+/gi,
-    replacement: "[ACCOUNT_ID]",
+    replacement: '[ACCOUNT_ID]',
   },
   {
-    category: "customer",
-    label: "internal_ip",
+    category: 'customer',
+    label: 'internal_ip',
     // RFC1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16.
-    pattern: /\b(?:10\.(?:\d{1,3}\.){2}\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3}\.)\d{1,3}|192\.168\.(?:\d{1,3}\.)\d{1,3})\b/g,
-    replacement: "[INTERNAL_IP]",
+    pattern:
+      /\b(?:10\.(?:\d{1,3}\.){2}\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3}\.)\d{1,3}|192\.168\.(?:\d{1,3}\.)\d{1,3})\b/g,
+    replacement: '[INTERNAL_IP]',
   },
   {
-    category: "customer",
-    label: "prod_hostname",
+    category: 'customer',
+    label: 'prod_hostname',
     pattern: /\bprod-[a-z0-9-]+\.[a-z]+\b/gi,
-    replacement: "[INTERNAL_HOST]",
+    replacement: '[INTERNAL_HOST]',
   },
   {
-    category: "customer",
-    label: "db_identifier",
+    category: 'customer',
+    label: 'db_identifier',
     pattern: /\bdb-[a-z0-9-]+\b/gi,
-    replacement: "[INTERNAL_HOST]",
+    replacement: '[INTERNAL_HOST]',
   },
 ];
 
@@ -333,9 +339,9 @@ export class PiiDetectedError extends Error {
     public readonly findings: PiiFinding[],
     context?: string,
   ) {
-    const labels = findings.map((f) => `${f.category}/${f.label}`).join(", ");
-    super(`${context ? `[${context}] ` : ""}PII detected: ${labels}`);
-    this.name = "PiiDetectedError";
+    const labels = findings.map((f) => `${f.category}/${f.label}`).join(', ');
+    super(`${context ? `[${context}] ` : ''}PII detected: ${labels}`);
+    this.name = 'PiiDetectedError';
   }
 }
 

--- a/library/runtime/src/registry.test.ts
+++ b/library/runtime/src/registry.test.ts
@@ -1,73 +1,73 @@
-import { describe, it, expect } from "vitest";
-import { createRegistry } from "./registry.js";
+import { describe, it, expect } from 'vitest';
+import { createRegistry } from './registry.js';
 
 interface FakeProvider {
   kind: string;
 }
 
-describe("createRegistry", () => {
-  it("registers and resolves providers by name", () => {
-    const registry = createRegistry<FakeProvider>("llm");
-    registry.register("bedrock", () => ({ kind: "bedrock" }));
+describe('createRegistry', () => {
+  it('registers and resolves providers by name', () => {
+    const registry = createRegistry<FakeProvider>('llm');
+    registry.register('bedrock', () => ({ kind: 'bedrock' }));
 
-    expect(registry.get("bedrock")).toEqual({ kind: "bedrock" });
+    expect(registry.get('bedrock')).toEqual({ kind: 'bedrock' });
   });
 
-  it("invokes the factory on every get (fresh instance per lookup)", () => {
-    const registry = createRegistry<FakeProvider>("llm");
-    registry.register("bedrock", () => ({ kind: "bedrock" }));
+  it('invokes the factory on every get (fresh instance per lookup)', () => {
+    const registry = createRegistry<FakeProvider>('llm');
+    registry.register('bedrock', () => ({ kind: 'bedrock' }));
 
-    const a = registry.get("bedrock");
-    const b = registry.get("bedrock");
+    const a = registry.get('bedrock');
+    const b = registry.get('bedrock');
     expect(a).not.toBe(b);
     expect(a).toEqual(b);
   });
 
-  it("throws an actionable error naming the kind and available providers", () => {
-    const registry = createRegistry<FakeProvider>("embedding");
-    registry.register("bedrock", () => ({ kind: "bedrock" }));
-    registry.register("openai", () => ({ kind: "openai" }));
+  it('throws an actionable error naming the kind and available providers', () => {
+    const registry = createRegistry<FakeProvider>('embedding');
+    registry.register('bedrock', () => ({ kind: 'bedrock' }));
+    registry.register('openai', () => ({ kind: 'openai' }));
 
-    expect(() => registry.get("cohere")).toThrow(
+    expect(() => registry.get('cohere')).toThrow(
       'Unknown embedding provider "cohere". Available: bedrock, openai',
     );
   });
 
-  it("reports <none> when the registry is empty", () => {
-    const registry = createRegistry<FakeProvider>("vector-store");
+  it('reports <none> when the registry is empty', () => {
+    const registry = createRegistry<FakeProvider>('vector-store');
 
-    expect(() => registry.get("pgvector")).toThrow(
+    expect(() => registry.get('pgvector')).toThrow(
       'Unknown vector-store provider "pgvector". Available: <none>',
     );
   });
 
-  it("answers has() without invoking factories", () => {
-    const registry = createRegistry<FakeProvider>("llm");
+  it('answers has() without invoking factories', () => {
+    const registry = createRegistry<FakeProvider>('llm');
     let invoked = 0;
-    registry.register("bedrock", () => {
+    registry.register('bedrock', () => {
       invoked++;
-      return { kind: "bedrock" };
+      return { kind: 'bedrock' };
     });
 
-    expect(registry.has("bedrock")).toBe(true);
-    expect(registry.has("openai")).toBe(false);
+    expect(registry.has('bedrock')).toBe(true);
+    expect(registry.has('openai')).toBe(false);
     expect(invoked).toBe(0);
   });
 
-  it("lists registered names in registration order", () => {
-    const registry = createRegistry<FakeProvider>("llm");
-    registry.register("bedrock", () => ({ kind: "bedrock" }));
-    registry.register("anthropic", () => ({ kind: "anthropic" }));
+  it('lists registered names in registration order', () => {
+    const registry = createRegistry<FakeProvider>('llm');
+    registry.register('bedrock', () => ({ kind: 'bedrock' }));
+    registry.register('anthropic', () => ({ kind: 'anthropic' }));
 
-    expect(registry.names()).toEqual(["bedrock", "anthropic"]);
+    expect(registry.names()).toEqual(['bedrock', 'anthropic']);
   });
 
-  it("lets a later registration override an earlier one", () => {
-    const registry = createRegistry<FakeProvider>("llm");
-    registry.register("bedrock", () => ({ kind: "v1" }));
-    registry.register("bedrock", () => ({ kind: "v2" }));
+  it('lets a later registration override an earlier one', () => {
+    const registry = createRegistry<FakeProvider>('llm');
+    registry.register('bedrock', () => ({ kind: 'v1' }));
+    registry.register('bedrock', () => ({ kind: 'v2' }));
 
-    expect(registry.get("bedrock")).toEqual({ kind: "v2" });
-    expect(registry.names()).toEqual(["bedrock"]);
+    expect(registry.get('bedrock')).toEqual({ kind: 'v2' });
+    expect(registry.names()).toEqual(['bedrock']);
   });
 });

--- a/library/runtime/src/registry.ts
+++ b/library/runtime/src/registry.ts
@@ -28,7 +28,7 @@ export function createRegistry<T>(kind: string): ProviderRegistry<T> {
     get(name) {
       const factory = factories.get(name);
       if (!factory) {
-        const available = [...factories.keys()].join(", ") || "<none>";
+        const available = [...factories.keys()].join(', ') || '<none>';
         throw new Error(`Unknown ${kind} provider "${name}". Available: ${available}`);
       }
       return factory();

--- a/library/runtime/src/resilience.test.ts
+++ b/library/runtime/src/resilience.test.ts
@@ -1,115 +1,129 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { withTimeout, withRetry, TimeoutError } from "./resilience.js";
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { withTimeout, withRetry, TimeoutError } from './resilience.js';
 
 afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("withTimeout", () => {
-  it("resolves when the promise settles before the deadline", async () => {
+describe('withTimeout', () => {
+  it('resolves when the promise settles before the deadline', async () => {
     await expect(withTimeout(Promise.resolve(42), 1_000)).resolves.toBe(42);
   });
 
-  it("propagates the underlying rejection", async () => {
-    await expect(withTimeout(Promise.reject(new Error("boom")), 1_000)).rejects.toThrow("boom");
+  it('propagates the underlying rejection', async () => {
+    await expect(withTimeout(Promise.reject(new Error('boom')), 1_000)).rejects.toThrow('boom');
   });
 
-  it("rejects with TimeoutError when the deadline wins", async () => {
+  it('rejects with TimeoutError when the deadline wins', async () => {
     vi.useFakeTimers();
     const never = new Promise<never>(() => {});
 
-    const result = withTimeout(never, 50, "slack.pin");
+    const result = withTimeout(never, 50, 'slack.pin');
     const assertion = expect(result).rejects.toMatchObject({
-      name: "TimeoutError",
-      message: "slack.pin timed out after 50ms",
+      name: 'TimeoutError',
+      message: 'slack.pin timed out after 50ms',
     });
     await vi.advanceTimersByTimeAsync(50);
     await assertion;
   });
 
-  it("labels the error with a default when no label is given", async () => {
+  it('labels the error with a default when no label is given', async () => {
     vi.useFakeTimers();
     const never = new Promise<never>(() => {});
 
     const result = withTimeout(never, 10);
-    const assertion = expect(result).rejects.toThrow("operation timed out after 10ms");
+    const assertion = expect(result).rejects.toThrow('operation timed out after 10ms');
     await vi.advanceTimersByTimeAsync(10);
     await assertion;
     await expect(result).rejects.toBeInstanceOf(TimeoutError);
   });
 
-  it("clears the timer when the promise settles first", async () => {
+  it('clears the timer when the promise settles first', async () => {
     vi.useFakeTimers();
-    await withTimeout(Promise.resolve("ok"), 5_000);
+    await withTimeout(Promise.resolve('ok'), 5_000);
     expect(vi.getTimerCount()).toBe(0);
   });
 });
 
-describe("withRetry", () => {
+describe('withRetry', () => {
   /** Records requested delays instead of sleeping. */
   function makeSleepRecorder() {
     const delays: number[] = [];
     return { delays, sleep: (ms: number) => (delays.push(ms), Promise.resolve()) };
   }
 
-  it("returns the first successful result without sleeping", async () => {
+  it('returns the first successful result without sleeping', async () => {
     const { delays, sleep } = makeSleepRecorder();
-    const factory = vi.fn(async () => "ok");
+    const factory = vi.fn(async () => 'ok');
 
-    await expect(withRetry(factory, { attempts: 3, initialDelayMs: 100, jitter: false, sleep })).resolves.toBe("ok");
+    await expect(
+      withRetry(factory, { attempts: 3, initialDelayMs: 100, jitter: false, sleep }),
+    ).resolves.toBe('ok');
     expect(factory).toHaveBeenCalledTimes(1);
     expect(delays).toEqual([]);
   });
 
-  it("retries with exponential backoff until success", async () => {
+  it('retries with exponential backoff until success', async () => {
     const { delays, sleep } = makeSleepRecorder();
     const factory = vi
       .fn<() => Promise<string>>()
-      .mockRejectedValueOnce(new Error("first"))
-      .mockRejectedValueOnce(new Error("second"))
-      .mockResolvedValueOnce("third time lucky");
+      .mockRejectedValueOnce(new Error('first'))
+      .mockRejectedValueOnce(new Error('second'))
+      .mockResolvedValueOnce('third time lucky');
 
-    await expect(withRetry(factory, { attempts: 3, initialDelayMs: 100, jitter: false, sleep })).resolves.toBe(
-      "third time lucky",
-    );
+    await expect(
+      withRetry(factory, { attempts: 3, initialDelayMs: 100, jitter: false, sleep }),
+    ).resolves.toBe('third time lucky');
     expect(factory).toHaveBeenCalledTimes(3);
     expect(delays).toEqual([100, 200]);
   });
 
-  it("caps the backoff at maxDelayMs", async () => {
+  it('caps the backoff at maxDelayMs', async () => {
     const { delays, sleep } = makeSleepRecorder();
     const factory = vi.fn(async () => {
-      throw new Error("always");
+      throw new Error('always');
     });
 
     await expect(
-      withRetry(factory, { attempts: 5, initialDelayMs: 100, maxDelayMs: 250, jitter: false, sleep }),
-    ).rejects.toThrow("always");
+      withRetry(factory, {
+        attempts: 5,
+        initialDelayMs: 100,
+        maxDelayMs: 250,
+        jitter: false,
+        sleep,
+      }),
+    ).rejects.toThrow('always');
     expect(delays).toEqual([100, 200, 250, 250]);
   });
 
-  it("throws the last error on exhaustion", async () => {
+  it('throws the last error on exhaustion', async () => {
     const { sleep } = makeSleepRecorder();
     const factory = vi
       .fn<() => Promise<string>>()
-      .mockRejectedValueOnce(new Error("first"))
-      .mockRejectedValueOnce(new Error("last"));
+      .mockRejectedValueOnce(new Error('first'))
+      .mockRejectedValueOnce(new Error('last'));
 
-    await expect(withRetry(factory, { attempts: 2, initialDelayMs: 10, jitter: false, sleep })).rejects.toThrow(
-      "last",
-    );
+    await expect(
+      withRetry(factory, { attempts: 2, initialDelayMs: 10, jitter: false, sleep }),
+    ).rejects.toThrow('last');
     expect(factory).toHaveBeenCalledTimes(2);
   });
 
-  it("jitters each delay to 50-100% of the computed backoff", async () => {
+  it('jitters each delay to 50-100% of the computed backoff', async () => {
     const { delays, sleep } = makeSleepRecorder();
     const factory = vi.fn(async () => {
-      throw new Error("always");
+      throw new Error('always');
     });
 
     await expect(
-      withRetry(factory, { attempts: 4, initialDelayMs: 100, maxDelayMs: 5_000, jitter: true, sleep }),
-    ).rejects.toThrow("always");
+      withRetry(factory, {
+        attempts: 4,
+        initialDelayMs: 100,
+        maxDelayMs: 5_000,
+        jitter: true,
+        sleep,
+      }),
+    ).rejects.toThrow('always');
 
     expect(delays).toHaveLength(3);
     const bases = [100, 200, 400];

--- a/library/runtime/src/resilience.ts
+++ b/library/runtime/src/resilience.ts
@@ -18,7 +18,7 @@
 export class TimeoutError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "TimeoutError";
+    this.name = 'TimeoutError';
   }
 }
 
@@ -26,7 +26,11 @@ export class TimeoutError extends Error {
  * Rejects with `TimeoutError` if `promise` does not settle within `ms`.
  * `label` names the operation in the error message for actionable logs.
  */
-export async function withTimeout<T>(promise: Promise<T>, ms: number, label = "operation"): Promise<T> {
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label = 'operation',
+): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new TimeoutError(`${label} timed out after ${ms}ms`)), ms);

--- a/library/runtime/src/workos-directory.test.ts
+++ b/library/runtime/src/workos-directory.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { createWorkOsDirectoryClient } from "./workos-directory.js";
+import { describe, it, expect, vi } from 'vitest';
+import { createWorkOsDirectoryClient } from './workos-directory.js';
 
 interface RawUser {
   id: string;
@@ -8,7 +8,7 @@ interface RawUser {
   first_name?: string | null;
   last_name?: string | null;
   job_title?: string | null;
-  state?: "active" | "suspended" | "inactive";
+  state?: 'active' | 'suspended' | 'inactive';
   custom_attributes?: Record<string, unknown>;
   created_at?: string;
 }
@@ -17,7 +17,7 @@ function jsonResponse(body: unknown, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
-    statusText: status === 200 ? "OK" : "Error",
+    statusText: status === 200 ? 'OK' : 'Error',
     json: async () => body,
   } as unknown as Response;
 }
@@ -27,27 +27,27 @@ function page(data: RawUser[], after?: string) {
 }
 
 const alice: RawUser = {
-  id: "directory_user_alice",
-  email: "alice@example.com",
-  first_name: "Alice",
-  last_name: "Anders",
-  job_title: "Staff Engineer",
-  state: "active",
-  custom_attributes: { githubLogin: "alicehub", department: "Platform" },
-  created_at: "2026-06-01T00:00:00.000Z",
+  id: 'directory_user_alice',
+  email: 'alice@example.com',
+  first_name: 'Alice',
+  last_name: 'Anders',
+  job_title: 'Staff Engineer',
+  state: 'active',
+  custom_attributes: { githubLogin: 'alicehub', department: 'Platform' },
+  created_at: '2026-06-01T00:00:00.000Z',
 };
 
 const bob: RawUser = {
-  id: "directory_user_bob",
+  id: 'directory_user_bob',
   emails: [
-    { primary: false, value: "bob-alias@example.com" },
-    { primary: true, value: "bob@example.com" },
+    { primary: false, value: 'bob-alias@example.com' },
+    { primary: true, value: 'bob@example.com' },
   ],
-  first_name: "Bob",
-  last_name: "Bristow",
-  state: "suspended",
-  custom_attributes: { slackUserId: "U0BOB" },
-  created_at: "2026-01-15T00:00:00.000Z",
+  first_name: 'Bob',
+  last_name: 'Bristow',
+  state: 'suspended',
+  custom_attributes: { slackUserId: 'U0BOB' },
+  created_at: '2026-01-15T00:00:00.000Z',
 };
 
 function makeClient(pages: Array<{ data: RawUser[]; list_metadata: { after: string | null } }>) {
@@ -56,132 +56,132 @@ function makeClient(pages: Array<{ data: RawUser[]; list_metadata: { after: stri
     jsonResponse(pages[Math.min(call++, pages.length - 1)]),
   );
   const client = createWorkOsDirectoryClient({
-    apiKey: "sk_test_123",
-    directoryId: "directory_01",
+    apiKey: 'sk_test_123',
+    directoryId: 'directory_01',
     fetchImpl: fetchImpl as unknown as typeof fetch,
   });
   return { client, fetchImpl };
 }
 
-describe("createWorkOsDirectoryClient", () => {
-  it("sends the bearer key, directory id, and page size on every request", async () => {
+describe('createWorkOsDirectoryClient', () => {
+  it('sends the bearer key, directory id, and page size on every request', async () => {
     const { client, fetchImpl } = makeClient([page([alice])]);
 
-    await client.findByEmail("alice@example.com");
+    await client.findByEmail('alice@example.com');
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const parsed = new URL(url);
-    expect(parsed.origin + parsed.pathname).toBe("https://api.workos.com/directory_users");
-    expect(parsed.searchParams.get("directory")).toBe("directory_01");
-    expect(parsed.searchParams.get("limit")).toBe("100");
-    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer sk_test_123");
+    expect(parsed.origin + parsed.pathname).toBe('https://api.workos.com/directory_users');
+    expect(parsed.searchParams.get('directory')).toBe('directory_01');
+    expect(parsed.searchParams.get('limit')).toBe('100');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer sk_test_123');
   });
 
-  it("follows the after cursor across pages", async () => {
-    const { client, fetchImpl } = makeClient([page([bob], "cursor-2"), page([alice])]);
+  it('follows the after cursor across pages', async () => {
+    const { client, fetchImpl } = makeClient([page([bob], 'cursor-2'), page([alice])]);
 
-    const found = await client.findByEmail("alice@example.com");
+    const found = await client.findByEmail('alice@example.com');
 
-    expect(found?.id).toBe("directory_user_alice");
+    expect(found?.id).toBe('directory_user_alice');
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     const secondUrl = new URL(fetchImpl.mock.calls[1][0] as unknown as string);
-    expect(secondUrl.searchParams.get("after")).toBe("cursor-2");
+    expect(secondUrl.searchParams.get('after')).toBe('cursor-2');
   });
 
-  it("matches email case-insensitively and falls back to the primary emails[] entry", async () => {
+  it('matches email case-insensitively and falls back to the primary emails[] entry', async () => {
     const { client } = makeClient([page([bob])]);
 
-    const found = await client.findByEmail("BOB@example.com");
+    const found = await client.findByEmail('BOB@example.com');
 
     expect(found).toMatchObject({
-      id: "directory_user_bob",
-      email: "bob@example.com",
-      displayName: "Bob Bristow",
-      state: "suspended",
+      id: 'directory_user_bob',
+      email: 'bob@example.com',
+      displayName: 'Bob Bristow',
+      state: 'suspended',
     });
   });
 
-  it("returns null when no user matches", async () => {
+  it('returns null when no user matches', async () => {
     const { client } = makeClient([page([alice, bob])]);
 
-    await expect(client.findByEmail("nobody@example.com")).resolves.toBeNull();
+    await expect(client.findByEmail('nobody@example.com')).resolves.toBeNull();
   });
 
-  it("finds users by custom attribute", async () => {
+  it('finds users by custom attribute', async () => {
     const { client } = makeClient([page([alice, bob])]);
 
-    const byGithub = await client.findByCustomAttribute("githubLogin", "alicehub");
-    expect(byGithub?.id).toBe("directory_user_alice");
-    expect(byGithub?.department).toBe("Platform");
-    expect(byGithub?.title).toBe("Staff Engineer");
+    const byGithub = await client.findByCustomAttribute('githubLogin', 'alicehub');
+    expect(byGithub?.id).toBe('directory_user_alice');
+    expect(byGithub?.department).toBe('Platform');
+    expect(byGithub?.title).toBe('Staff Engineer');
 
-    await expect(client.findByCustomAttribute("githubLogin", "nobody")).resolves.toBeNull();
+    await expect(client.findByCustomAttribute('githubLogin', 'nobody')).resolves.toBeNull();
   });
 
-  it("lists users created at or after the cutoff", async () => {
+  it('lists users created at or after the cutoff', async () => {
     const { client } = makeClient([page([alice, bob])]);
 
-    const joiners = await client.listUsersSince(new Date("2026-05-01T00:00:00.000Z"));
+    const joiners = await client.listUsersSince(new Date('2026-05-01T00:00:00.000Z'));
 
-    expect(joiners.map((u) => u.id)).toEqual(["directory_user_alice"]);
+    expect(joiners.map((u) => u.id)).toEqual(['directory_user_alice']);
   });
 
-  it("scopes group listings with the group param and maps every member", async () => {
+  it('scopes group listings with the group param and maps every member', async () => {
     const { client, fetchImpl } = makeClient([page([alice, bob])]);
 
-    const members = await client.listUsersInGroup("group_oncall");
+    const members = await client.listUsersInGroup('group_oncall');
 
     expect(members).toHaveLength(2);
     const url = new URL(fetchImpl.mock.calls[0][0] as unknown as string);
-    expect(url.searchParams.get("group")).toBe("group_oncall");
+    expect(url.searchParams.get('group')).toBe('group_oncall');
   });
 
-  it("throws on a non-ok response with the status in the message", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({ message: "nope" }, 401));
+  it('throws on a non-ok response with the status in the message', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ message: 'nope' }, 401));
     const client = createWorkOsDirectoryClient({
-      apiKey: "bad",
-      directoryId: "directory_01",
+      apiKey: 'bad',
+      directoryId: 'directory_01',
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    await expect(client.findByEmail("alice@example.com")).rejects.toThrow(
-      "WorkOS directory list failed (401 Error)",
+    await expect(client.findByEmail('alice@example.com')).rejects.toThrow(
+      'WorkOS directory list failed (401 Error)',
     );
   });
 
-  it("bounds pagination at maxPages so a misbehaving API cannot loop forever", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse(page([bob], "always-more")));
+  it('bounds pagination at maxPages so a misbehaving API cannot loop forever', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(page([bob], 'always-more')));
     const client = createWorkOsDirectoryClient({
-      apiKey: "sk_test_123",
-      directoryId: "directory_01",
+      apiKey: 'sk_test_123',
+      directoryId: 'directory_01',
       fetchImpl: fetchImpl as unknown as typeof fetch,
       maxPages: 3,
     });
 
-    await expect(client.findByEmail("alice@example.com")).resolves.toBeNull();
+    await expect(client.findByEmail('alice@example.com')).resolves.toBeNull();
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
-  it("falls back to custom displayName, then id, when names are absent", async () => {
-    const anon: RawUser = { id: "directory_user_anon", custom_attributes: {} };
+  it('falls back to custom displayName, then id, when names are absent', async () => {
+    const anon: RawUser = { id: 'directory_user_anon', custom_attributes: {} };
     const branded: RawUser = {
-      id: "directory_user_branded",
-      custom_attributes: { displayName: "The Brand" },
+      id: 'directory_user_branded',
+      custom_attributes: { displayName: 'The Brand' },
     };
     const { client } = makeClient([page([anon, branded])]);
 
-    const members = await client.listUsersInGroup("group_x");
+    const members = await client.listUsersInGroup('group_x');
 
-    expect(members.map((u) => u.displayName)).toEqual(["directory_user_anon", "The Brand"]);
+    expect(members.map((u) => u.displayName)).toEqual(['directory_user_anon', 'The Brand']);
   });
 
-  it("excludes users without a parseable created_at from since-listings", async () => {
-    const anon: RawUser = { id: "directory_user_anon" };
+  it('excludes users without a parseable created_at from since-listings', async () => {
+    const anon: RawUser = { id: 'directory_user_anon' };
     const { client } = makeClient([page([anon, alice])]);
 
     const users = await client.listUsersSince(new Date(0));
 
-    expect(users.map((u) => u.id)).toEqual(["directory_user_alice"]);
+    expect(users.map((u) => u.id)).toEqual(['directory_user_alice']);
   });
 });

--- a/library/runtime/src/workos-directory.ts
+++ b/library/runtime/src/workos-directory.ts
@@ -32,7 +32,7 @@ export interface DirectoryUser {
   displayName: string;
   title?: string;
   department?: string;
-  state?: "active" | "suspended" | "inactive";
+  state?: 'active' | 'suspended' | 'inactive';
   customAttributes: Record<string, unknown>;
   /** ISO 8601 from WorkOS. */
   createdAt?: string;
@@ -69,7 +69,7 @@ interface RawDirectoryUser {
   first_name?: string | null;
   last_name?: string | null;
   job_title?: string | null;
-  state?: "active" | "suspended" | "inactive";
+  state?: 'active' | 'suspended' | 'inactive';
   custom_attributes?: Record<string, unknown>;
   created_at?: string;
 }
@@ -88,21 +88,21 @@ function primaryEmailOf(raw: RawDirectoryUser): string | undefined {
 function toDirectoryUser(raw: RawDirectoryUser): DirectoryUser {
   const attrs = raw.custom_attributes ?? {};
   const displayName =
-    [raw.first_name, raw.last_name].filter(Boolean).join(" ").trim() ||
+    [raw.first_name, raw.last_name].filter(Boolean).join(' ').trim() ||
     String(attrs.displayName ?? raw.id);
   const email = primaryEmailOf(raw);
   return {
     id: raw.id,
     ...(email !== undefined ? { email } : {}),
-    firstName: raw.first_name ?? "",
-    lastName: raw.last_name ?? "",
+    firstName: raw.first_name ?? '',
+    lastName: raw.last_name ?? '',
     displayName,
     ...(raw.job_title != null
       ? { title: raw.job_title }
-      : typeof attrs.title === "string"
+      : typeof attrs.title === 'string'
         ? { title: attrs.title }
         : {}),
-    ...(typeof attrs.department === "string" ? { department: attrs.department } : {}),
+    ...(typeof attrs.department === 'string' ? { department: attrs.department } : {}),
     ...(raw.state !== undefined ? { state: raw.state } : {}),
     customAttributes: attrs,
     ...(raw.created_at !== undefined ? { createdAt: raw.created_at } : {}),
@@ -111,22 +111,22 @@ function toDirectoryUser(raw: RawDirectoryUser): DirectoryUser {
 
 export function createWorkOsDirectoryClient(config: WorkOsDirectoryConfig): WorkOsDirectoryClient {
   const fetchImpl = config.fetchImpl ?? fetch;
-  const baseUrl = (config.baseUrl ?? "https://api.workos.com").replace(/\/$/, "");
+  const baseUrl = (config.baseUrl ?? 'https://api.workos.com').replace(/\/$/, '');
   const pageSize = config.pageSize ?? 100;
   const maxPages = config.maxPages ?? 50;
   const headers = {
     Authorization: `Bearer ${config.apiKey}`,
-    Accept: "application/json",
+    Accept: 'application/json',
   };
 
   async function* walk(params: { group?: string } = {}): AsyncGenerator<RawDirectoryUser> {
     let after: string | null | undefined;
     for (let page = 0; page < maxPages; page++) {
       const url = new URL(`${baseUrl}/directory_users`);
-      url.searchParams.set("directory", config.directoryId);
-      url.searchParams.set("limit", String(pageSize));
-      if (params.group) url.searchParams.set("group", params.group);
-      if (after) url.searchParams.set("after", after);
+      url.searchParams.set('directory', config.directoryId);
+      url.searchParams.set('limit', String(pageSize));
+      if (params.group) url.searchParams.set('group', params.group);
+      if (after) url.searchParams.set('after', after);
 
       const response = await fetchImpl(url.toString(), { headers });
       if (!response.ok) {
@@ -152,7 +152,7 @@ export function createWorkOsDirectoryClient(config: WorkOsDirectoryConfig): Work
     async findByCustomAttribute(attribute, value) {
       for await (const raw of walk()) {
         const attr = raw.custom_attributes?.[attribute];
-        if (typeof attr === "string" && attr === value) return toDirectoryUser(raw);
+        if (typeof attr === 'string' && attr === value) return toDirectoryUser(raw);
       }
       return null;
     },

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,37 +6,37 @@ Use it when you're building an AI client (Bedrock agent, Claude Desktop assistan
 
 ## Resources
 
-| URI | What it returns | MIME |
-|---|---|---|
-| `nanohype://catalog` | Full `catalog.json` (templates + composites with metadata) | `application/json` |
-| `nanohype://standards` | All five standards files bundled | `application/json` |
-| `nanohype://standards/{name}` | One standards file. `name` ∈ `language-toolchain` / `version-currency` / `platform-tenant-contract` / `llm-policy` / `quality-rubric-dimensions` | `application/json` |
-| `nanohype://contracts/{repo}` | One repo's `AGENTS.md`. `repo` ∈ `nanohype` / `landing-zone` / `eks-gitops` / `eks-agent-platform` / `kx` / `cloudgov` / `fab` / `portal` / `eks-fleet` | `text/markdown` |
-| `nanohype://template/{name}` | One template's full manifest (variables, conditionals, hooks, composition) | `application/json` |
-| `nanohype://composite/{name}` | One composite's full manifest (multi-template orchestration) | `application/json` |
+| URI                           | What it returns                                                                                                                                         | MIME               |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `nanohype://catalog`          | Full `catalog.json` (templates + composites with metadata)                                                                                              | `application/json` |
+| `nanohype://standards`        | All five standards files bundled                                                                                                                        | `application/json` |
+| `nanohype://standards/{name}` | One standards file. `name` ∈ `language-toolchain` / `version-currency` / `platform-tenant-contract` / `llm-policy` / `quality-rubric-dimensions`        | `application/json` |
+| `nanohype://contracts/{repo}` | One repo's `AGENTS.md`. `repo` ∈ `nanohype` / `landing-zone` / `eks-gitops` / `eks-agent-platform` / `kx` / `cloudgov` / `fab` / `portal` / `eks-fleet` | `text/markdown`    |
+| `nanohype://template/{name}`  | One template's full manifest (variables, conditionals, hooks, composition)                                                                              | `application/json` |
+| `nanohype://composite/{name}` | One composite's full manifest (multi-template orchestration)                                                                                            | `application/json` |
 
 ## Tools
 
-| Tool | Inputs | What it does |
-|---|---|---|
+| Tool               | Inputs                                               | What it does                                                                   |
+| ------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------ |
 | `search_templates` | `query` (required), `category?`, `persona?`, `kind?` | Filter the catalog. Substring match on name + displayName + description + tags |
-| `get_template` | `name` | Full template manifest |
-| `get_composite` | `name` | Full composite manifest |
-| `list_standards` | — | Names of the five published standards |
-| `get_standard` | `name` | One standards file's JSON |
-| `get_contract` | `repo` | One repo's `AGENTS.md` content as markdown |
+| `get_template`     | `name`                                               | Full template manifest                                                         |
+| `get_composite`    | `name`                                               | Full composite manifest                                                        |
+| `list_standards`   | —                                                    | Names of the five published standards                                          |
+| `get_standard`     | `name`                                               | One standards file's JSON                                                      |
+| `get_contract`     | `repo`                                               | One repo's `AGENTS.md` content as markdown                                     |
 
 ## Configuration
 
 Environment variables (all optional):
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `NANOHYPE_SOURCE` | `github` | `github` reads from the GitHub API. `local` reads from a local checkout |
-| `NANOHYPE_ROOT` | — | Path to a local `nanohype/nanohype` checkout. Required when `NANOHYPE_SOURCE=local` |
-| `NANOHYPE_REPO` | `nanohype/nanohype` | GitHub repo (owner/name) when using the github source |
-| `NANOHYPE_REF` | `main` | Git ref to read from |
-| `NANOHYPE_GITHUB_TOKEN` | — | Optional GitHub API token. Lifts the public-rate-limit ceiling and unlocks private repos if the catalog ever moves |
+| Variable                | Default             | Purpose                                                                                                            |
+| ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `NANOHYPE_SOURCE`       | `github`            | `github` reads from the GitHub API. `local` reads from a local checkout                                            |
+| `NANOHYPE_ROOT`         | —                   | Path to a local `nanohype/nanohype` checkout. Required when `NANOHYPE_SOURCE=local`                                |
+| `NANOHYPE_REPO`         | `nanohype/nanohype` | GitHub repo (owner/name) when using the github source                                                              |
+| `NANOHYPE_REF`          | `main`              | Git ref to read from                                                                                               |
+| `NANOHYPE_GITHUB_TOKEN` | —                   | Optional GitHub API token. Lifts the public-rate-limit ceiling and unlocks private repos if the catalog ever moves |
 
 ## Claude Desktop
 
@@ -47,9 +47,9 @@ Add to `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claud
   "mcpServers": {
     "nanohype": {
       "command": "npx",
-      "args": ["-y", "@nanohype/mcp"]
-    }
-  }
+      "args": ["-y", "@nanohype/mcp"],
+    },
+  },
 }
 ```
 
@@ -65,10 +65,10 @@ To run against a local checkout instead of GitHub:
       "args": ["-y", "@nanohype/mcp"],
       "env": {
         "NANOHYPE_SOURCE": "local",
-        "NANOHYPE_ROOT": "/path/to/nanohype/nanohype"
-      }
-    }
-  }
+        "NANOHYPE_ROOT": "/path/to/nanohype/nanohype",
+      },
+    },
+  },
 }
 ```
 
@@ -77,25 +77,25 @@ To run against a local checkout instead of GitHub:
 Run the MCP server as a subprocess and mount its tools into a Claude API session via the Anthropic SDK's MCP support:
 
 ```ts
-import Anthropic from "@anthropic-ai/sdk";
+import Anthropic from '@anthropic-ai/sdk';
 
 const client = new Anthropic();
 const message = await client.messages.create({
-  model: "claude-sonnet-4-6",
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   mcp_servers: [
     {
-      type: "stdio",
-      name: "nanohype",
-      command: "npx",
-      args: ["-y", "@nanohype/mcp"],
+      type: 'stdio',
+      name: 'nanohype',
+      command: 'npx',
+      args: ['-y', '@nanohype/mcp'],
     },
   ],
   messages: [
     {
-      role: "user",
+      role: 'user',
       content:
-        "I need a RAG pipeline template. List the matching options in the catalog, then fetch the full manifest for the best one.",
+        'I need a RAG pipeline template. List the matching options in the catalog, then fetch the full manifest for the best one.',
     },
   ],
 });

--- a/mcp-server/__tests__/tools.test.ts
+++ b/mcp-server/__tests__/tools.test.ts
@@ -185,7 +185,11 @@ describe('callTool argument validation', () => {
 
   describe('get_template / get_composite names', () => {
     it('rejects path traversal', async () => {
-      await expectToolError('get_template', { name: '../../../etc/passwd' }, /not a valid catalog name/);
+      await expectToolError(
+        'get_template',
+        { name: '../../../etc/passwd' },
+        /not a valid catalog name/,
+      );
       await expectToolError('get_composite', { name: '../secrets' }, /not a valid catalog name/);
     });
 
@@ -198,7 +202,11 @@ describe('callTool argument validation', () => {
     });
 
     it('rejects URL metacharacters', async () => {
-      await expectToolError('get_template', { name: 'go-cli?ref=evil' }, /not a valid catalog name/);
+      await expectToolError(
+        'get_template',
+        { name: 'go-cli?ref=evil' },
+        /not a valid catalog name/,
+      );
       await expectToolError('get_composite', { name: 'a/b' }, /not a valid catalog name/);
     });
 
@@ -230,7 +238,11 @@ describe('callTool argument validation', () => {
 
     it('rejects traversal attempts', async () => {
       await expectToolError('get_contract', { repo: '../../etc' }, /not a known contract repo/);
-      await expectToolError('get_contract', { repo: 'nanohype/../evil' }, /not a known contract repo/);
+      await expectToolError(
+        'get_contract',
+        { repo: 'nanohype/../evil' },
+        /not a known contract repo/,
+      );
     });
 
     it('rejects missing repos', async () => {
@@ -244,12 +256,24 @@ describe('callTool argument validation', () => {
     });
 
     it('rejects non-string filters', async () => {
-      await expectToolError('search_templates', { query: '', category: 3 }, /'category': expected a string/);
-      await expectToolError('search_templates', { query: '', persona: {} }, /'persona': expected a string/);
+      await expectToolError(
+        'search_templates',
+        { query: '', category: 3 },
+        /'category': expected a string/,
+      );
+      await expectToolError(
+        'search_templates',
+        { query: '', persona: {} },
+        /'persona': expected a string/,
+      );
     });
 
     it('rejects kind values outside the enum', async () => {
-      await expectToolError('search_templates', { query: '', kind: 'bogus' }, /'kind'.*expected 'template' or 'brief'/);
+      await expectToolError(
+        'search_templates',
+        { query: '', kind: 'bogus' },
+        /'kind'.*expected 'template' or 'brief'/,
+      );
     });
 
     it('still accepts the full valid filter set', async () => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -42,7 +42,7 @@ export function makeSource(env: NodeJS.ProcessEnv = process.env): CatalogSource 
     const rootDir = env.NANOHYPE_ROOT;
     if (!rootDir) {
       throw new Error(
-        "NANOHYPE_SOURCE=local requires NANOHYPE_ROOT to point at a local nanohype checkout",
+        'NANOHYPE_SOURCE=local requires NANOHYPE_ROOT to point at a local nanohype checkout',
       );
     }
     return new LocalSource({ rootDir });
@@ -73,8 +73,7 @@ async function main(): Promise<void> {
 
 // Run as bin when invoked directly; do nothing on import (tests).
 const invokedAsBin =
-  import.meta.url === `file://${process.argv[1]}` ||
-  process.argv[1]?.endsWith('nanohype-mcp');
+  import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('nanohype-mcp');
 if (invokedAsBin) {
   main().catch((err: unknown) => {
     console.error('[@nanohype/mcp] fatal:', err);

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -55,7 +55,8 @@ export function listResources(): StaticResource[] {
   }
 
   for (const { repo, visibility } of CONTRACT_REPOS) {
-    const access = visibility === 'private' ? ' (private — requires a GitHub token to resolve)' : '';
+    const access =
+      visibility === 'private' ? ' (private — requires a GitHub token to resolve)' : '';
     resources.push({
       uri: `nanohype://contracts/${repo}`,
       name: `contract: ${repo}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "js-yaml": "^4.2.0",
-        "markdownlint-cli2": "^0.22.1"
+        "markdownlint-cli2": "^0.22.1",
+        "prettier": "^3.9.4"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1271,6 +1272,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode.js": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,16 @@
     "verify:catalog": "node scripts/generate-catalog.mjs && git diff --exit-code -I generated_at catalog.json",
     "sync:library": "node scripts/sync-library.mjs",
     "verify:library": "node scripts/sync-library.mjs --check",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint:docs": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!templates/*/skeleton/**' '!.github/ISSUE_DRAFTS/**' '!.plans/**'"
   },
   "devDependencies": {
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "js-yaml": "^4.2.0",
-    "markdownlint-cli2": "^0.22.1"
+    "markdownlint-cli2": "^0.22.1",
+    "prettier": "^3.9.4"
   },
   "overrides": {
     "fast-json-patch": "^3.1.1",

--- a/schemas/catalog.schema.json
+++ b/schemas/catalog.schema.json
@@ -34,7 +34,16 @@
   "$defs": {
     "CatalogTemplate": {
       "type": "object",
-      "required": ["name", "displayName", "description", "version", "category", "tags", "kind", "path"],
+      "required": [
+        "name",
+        "displayName",
+        "description",
+        "version",
+        "category",
+        "tags",
+        "kind",
+        "path"
+      ],
       "additionalProperties": false,
       "properties": {
         "name": {

--- a/schemas/standards.schema.json
+++ b/schemas/standards.schema.json
@@ -56,7 +56,17 @@
                 },
                 "additionalProperties": {
                   "type": "object",
-                  "required": ["install", "build", "lint", "test", "docs", "lockfile", "manifest", "registry", "versionLookup"],
+                  "required": [
+                    "install",
+                    "build",
+                    "lint",
+                    "test",
+                    "docs",
+                    "lockfile",
+                    "manifest",
+                    "registry",
+                    "versionLookup"
+                  ],
                   "properties": {
                     "install": { "type": "string" },
                     "build": { "type": "string" },
@@ -104,12 +114,19 @@
       }
     },
     {
-      "if": { "properties": { "kind": { "const": "nanohype/standards/platform-tenant-contract" } } },
+      "if": {
+        "properties": { "kind": { "const": "nanohype/standards/platform-tenant-contract" } }
+      },
       "then": {
         "properties": {
           "content": {
             "type": "object",
-            "required": ["required_artifacts", "platform_cr_shape", "otel_resource_attrs", "do_not"],
+            "required": [
+              "required_artifacts",
+              "platform_cr_shape",
+              "otel_resource_attrs",
+              "do_not"
+            ],
             "properties": {
               "required_artifacts": {
                 "type": "array",
@@ -147,7 +164,13 @@
         "properties": {
           "content": {
             "type": "object",
-            "required": ["primary_provider", "models", "regions_preferred", "sdk_by_language", "requirements"],
+            "required": [
+              "primary_provider",
+              "models",
+              "regions_preferred",
+              "sdk_by_language",
+              "requirements"
+            ],
             "properties": {
               "primary_provider": { "type": "string" },
               "models": {
@@ -178,7 +201,9 @@
       }
     },
     {
-      "if": { "properties": { "kind": { "const": "nanohype/standards/quality-rubric-dimensions" } } },
+      "if": {
+        "properties": { "kind": { "const": "nanohype/standards/quality-rubric-dimensions" } }
+      },
       "then": {
         "properties": {
           "content": {
@@ -256,7 +281,10 @@
                 "properties": {
                   "k8s": { "type": "array", "items": { "type": "string" } },
                   "otel": { "type": "array", "items": { "type": "string" } },
-                  "app_extension": { "type": "object", "additionalProperties": { "type": "string" } }
+                  "app_extension": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                  }
                 }
               },
               "dimensions": {
@@ -329,7 +357,11 @@
                       "properties": {
                         "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
                         "good_over_valid": { "type": "string" },
-                        "default_objective": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1 },
+                        "default_objective": {
+                          "type": "number",
+                          "exclusiveMinimum": 0,
+                          "exclusiveMaximum": 1
+                        },
                         "default_threshold_seconds": { "type": "number", "exclusiveMinimum": 0 }
                       }
                     }

--- a/schemas/template.schema.json
+++ b/schemas/template.schema.json
@@ -4,15 +4,7 @@
   "title": "nanohype Template",
   "description": "Schema for nanohype template catalog template.yaml files.",
   "type": "object",
-  "required": [
-    "apiVersion",
-    "name",
-    "displayName",
-    "description",
-    "version",
-    "tags",
-    "variables"
-  ],
+  "required": ["apiVersion", "name", "displayName", "description", "version", "tags", "variables"],
   "additionalProperties": false,
   "properties": {
     "apiVersion": {

--- a/scripts/check-slo-constants.mjs
+++ b/scripts/check-slo-constants.mjs
@@ -12,56 +12,56 @@
 //
 // Usage: node scripts/check-slo-constants.mjs <eks-gitops-alerting-dir>
 
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
 
-const STANDARD = 'standards/observability-slo.json'
-const alertDir = process.argv[2]
+const STANDARD = 'standards/observability-slo.json';
+const alertDir = process.argv[2];
 if (!alertDir) {
-  console.error('usage: check-slo-constants.mjs <eks-gitops-alerting-dir>')
-  process.exit(2)
+  console.error('usage: check-slo-constants.mjs <eks-gitops-alerting-dir>');
+  process.exit(2);
 }
 
-const c = JSON.parse(readFileSync(STANDARD, 'utf-8')).content
+const c = JSON.parse(readFileSync(STANDARD, 'utf-8')).content;
 
 // Burn-rate factors from the standard. Page-tier are the ones the prod ruler
 // actually implements; ticket-tier (3, 1) are defined but not alerted in prod.
-const windows = c.burn_rate_alerts.windows
-const allFactors = new Set(windows.map((w) => w.factor))
-const pageFactors = new Set(windows.filter((w) => w.severity === 'page').map((w) => w.factor))
+const windows = c.burn_rate_alerts.windows;
+const allFactors = new Set(windows.map((w) => w.factor));
+const pageFactors = new Set(windows.filter((w) => w.severity === 'page').map((w) => w.factor));
 
 // Objective denominators = 1 - objective, rounded to kill float dust (0.999 -> 0.001).
-const round = (n) => Math.round(n * 1e6) / 1e6
-const denominators = new Set(c.slo.sli_types.map((t) => round(1 - t.default_objective)))
+const round = (n) => Math.round(n * 1e6) / 1e6;
+const denominators = new Set(c.slo.sli_types.map((t) => round(1 - t.default_objective)));
 
-const files = readdirSync(alertDir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+const files = readdirSync(alertDir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
 if (files.length === 0) {
-  console.error(`no alert files under ${alertDir}`)
-  process.exit(2)
+  console.error(`no alert files under ${alertDir}`);
+  process.exit(2);
 }
 
-const errors = []
-const usedFactors = new Set()
+const errors = [];
+const usedFactors = new Set();
 
 for (const f of files) {
-  const text = readFileSync(join(alertDir, f), 'utf-8')
+  const text = readFileSync(join(alertDir, f), 'utf-8');
   // "> bool <factor>" is the multi-window/multi-burn-rate comparison.
   for (const m of text.matchAll(/> bool ([0-9]+(?:\.[0-9]+)?)/g)) {
-    const factor = Number(m[1])
-    usedFactors.add(factor)
+    const factor = Number(m[1]);
+    usedFactors.add(factor);
     if (!allFactors.has(factor)) {
       errors.push(
         `${f}: burn-rate factor ${factor} ("> bool ${m[1]}") is not a factor in ${STANDARD} (defined: ${[...allFactors].sort((a, b) => a - b).join(', ')})`,
-      )
+      );
     }
   }
   // "/ 0.0xx" is the error ratio divided by (1 - objective) to get the burn rate.
   for (const m of text.matchAll(/\/ (0\.0[0-9]+)/g)) {
-    const denom = round(Number(m[1]))
+    const denom = round(Number(m[1]));
     if (!denominators.has(denom)) {
       errors.push(
         `${f}: objective denominator ${m[1]} is not (1 - objective) for any SLI in ${STANDARD} (defined: ${[...denominators].sort((a, b) => a - b).join(', ')})`,
-      )
+      );
     }
   }
 }
@@ -69,20 +69,22 @@ for (const f of files) {
 // Every page-tier factor must be implemented by at least one alert.
 for (const pf of pageFactors) {
   if (!usedFactors.has(pf)) {
-    errors.push(`page-tier burn-rate factor ${pf} from ${STANDARD} is not used in any alert expr`)
+    errors.push(`page-tier burn-rate factor ${pf} from ${STANDARD} is not used in any alert expr`);
   }
 }
 
 if (errors.length) {
-  console.error('SLO-constants drift detected:')
-  for (const e of errors) console.error(`  - ${e}`)
+  console.error('SLO-constants drift detected:');
+  for (const e of errors) console.error(`  - ${e}`);
   console.error(
     `\nThe alert PromQL inlines the burn-rate factors + objective denominators from ${STANDARD}.`,
-  )
-  console.error('When the standard changes, update the eks-gitops alert exprs to match (or vice versa).')
-  process.exit(1)
+  );
+  console.error(
+    'When the standard changes, update the eks-gitops alert exprs to match (or vice versa).',
+  );
+  process.exit(1);
 }
 
 console.log(
   `SLO-constants OK: alert factors {${[...usedFactors].sort((a, b) => a - b).join(', ')}} and objective denominators all match ${STANDARD}.`,
-)
+);

--- a/scripts/check-tagging-standard.mjs
+++ b/scripts/check-tagging-standard.mjs
@@ -20,7 +20,8 @@ const std = JSON.parse(readFileSync(path, 'utf-8'));
 const { dimensions, required_by_surface } = std.content;
 const errors = [];
 
-const setEq = (a, b) => a.length === b.length && [...a].sort().join('|') === [...b].sort().join('|');
+const setEq = (a, b) =>
+  a.length === b.length && [...a].sort().join('|') === [...b].sort().join('|');
 
 // Full-derivation surfaces: required_by_surface must equal the rendered required dims exactly.
 for (const surface of ['aws', 'azure', 'gcp']) {

--- a/scripts/generate-catalog.mjs
+++ b/scripts/generate-catalog.mjs
@@ -13,41 +13,41 @@
  * Run with: npm run generate:catalog
  */
 
-import { readFile, readdir, writeFile } from "node:fs/promises";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import yaml from "js-yaml";
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = join(__dirname, "..");
-const TEMPLATES_DIR = join(ROOT, "templates");
-const COMPOSITES_DIR = join(ROOT, "composites");
-const OUTPUT_PATH = join(ROOT, "catalog.json");
+const ROOT = join(__dirname, '..');
+const TEMPLATES_DIR = join(ROOT, 'templates');
+const COMPOSITES_DIR = join(ROOT, 'composites');
+const OUTPUT_PATH = join(ROOT, 'catalog.json');
 
 async function loadTemplates() {
   const entries = await readdir(TEMPLATES_DIR, { withFileTypes: true });
   const out = [];
   for (const e of entries) {
     if (!e.isDirectory()) continue;
-    const manifestPath = join(TEMPLATES_DIR, e.name, "template.yaml");
+    const manifestPath = join(TEMPLATES_DIR, e.name, 'template.yaml');
     let raw;
     try {
-      raw = await readFile(manifestPath, "utf8");
+      raw = await readFile(manifestPath, 'utf8');
     } catch (err) {
-      if (err.code === "ENOENT") continue;
+      if (err.code === 'ENOENT') continue;
       throw err;
     }
     const parsed = yaml.load(raw);
-    if (!parsed || typeof parsed !== "object") continue;
+    if (!parsed || typeof parsed !== 'object') continue;
     out.push({
       name: parsed.name,
       displayName: parsed.displayName ?? parsed.name,
-      description: oneLine(parsed.description ?? ""),
-      version: String(parsed.version ?? "0.0.0"),
-      category: parsed.category ?? "uncategorized",
+      description: oneLine(parsed.description ?? ''),
+      version: String(parsed.version ?? '0.0.0'),
+      category: parsed.category ?? 'uncategorized',
       persona: normalizePersona(parsed.persona),
       tags: Array.isArray(parsed.tags) ? parsed.tags : [],
-      kind: parsed.kind === "brief" ? "brief" : "template",
+      kind: parsed.kind === 'brief' ? 'brief' : 'template',
       path: `templates/${e.name}`,
     });
   }
@@ -60,22 +60,22 @@ async function loadComposites() {
   try {
     entries = await readdir(COMPOSITES_DIR);
   } catch (err) {
-    if (err.code === "ENOENT") return [];
+    if (err.code === 'ENOENT') return [];
     throw err;
   }
   const out = [];
   for (const file of entries) {
-    if (!file.endsWith(".yaml")) continue;
+    if (!file.endsWith('.yaml')) continue;
     const manifestPath = join(COMPOSITES_DIR, file);
-    const raw = await readFile(manifestPath, "utf8");
+    const raw = await readFile(manifestPath, 'utf8');
     const parsed = yaml.load(raw);
-    if (!parsed || typeof parsed !== "object") continue;
-    if (parsed.kind !== "composite") continue;
+    if (!parsed || typeof parsed !== 'object') continue;
+    if (parsed.kind !== 'composite') continue;
     out.push({
       name: parsed.name,
       displayName: parsed.displayName ?? parsed.name,
-      description: oneLine(parsed.description ?? ""),
-      version: String(parsed.version ?? "0.0.0"),
+      description: oneLine(parsed.description ?? ''),
+      version: String(parsed.version ?? '0.0.0'),
       tags: Array.isArray(parsed.tags) ? parsed.tags : [],
       path: `composites/${file}`,
     });
@@ -86,12 +86,12 @@ async function loadComposites() {
 
 function normalizePersona(value) {
   if (Array.isArray(value)) return value.map(String);
-  if (typeof value === "string") return [value];
+  if (typeof value === 'string') return [value];
   return [];
 }
 
 function oneLine(s) {
-  return String(s).replace(/\s+/g, " ").trim();
+  return String(s).replace(/\s+/g, ' ').trim();
 }
 
 function byName(a, b) {
@@ -109,20 +109,20 @@ async function stableTimestamp() {
     const secs = parseInt(process.env.SOURCE_DATE_EPOCH, 10);
     if (Number.isFinite(secs)) return new Date(secs * 1000).toISOString();
   }
-  const { stat } = await import("node:fs/promises");
+  const { stat } = await import('node:fs/promises');
   const entries = await readdir(TEMPLATES_DIR, { withFileTypes: true });
   let latest = 0;
   for (const e of entries) {
     if (!e.isDirectory()) continue;
     try {
-      const s = await stat(join(TEMPLATES_DIR, e.name, "template.yaml"));
+      const s = await stat(join(TEMPLATES_DIR, e.name, 'template.yaml'));
       if (s.mtimeMs > latest) latest = s.mtimeMs;
     } catch {}
   }
   try {
     const files = await readdir(COMPOSITES_DIR);
     for (const f of files) {
-      if (!f.endsWith(".yaml")) continue;
+      if (!f.endsWith('.yaml')) continue;
       const s = await stat(join(COMPOSITES_DIR, f));
       if (s.mtimeMs > latest) latest = s.mtimeMs;
     }
@@ -135,16 +135,18 @@ async function main() {
   const templates = await loadTemplates();
   const composites = await loadComposites();
   const catalog = {
-    $schema: "./schemas/catalog.schema.json",
-    kind: "nanohype/catalog",
-    version: "1",
+    $schema: './schemas/catalog.schema.json',
+    kind: 'nanohype/catalog',
+    version: '1',
     generated_at: await stableTimestamp(),
     templates,
     composites,
   };
-  const json = JSON.stringify(catalog, null, 2) + "\n";
-  await writeFile(OUTPUT_PATH, json, "utf8");
-  console.log(`wrote ${OUTPUT_PATH} (${templates.length} templates, ${composites.length} composites)`);
+  const json = JSON.stringify(catalog, null, 2) + '\n';
+  await writeFile(OUTPUT_PATH, json, 'utf8');
+  console.log(
+    `wrote ${OUTPUT_PATH} (${templates.length} templates, ${composites.length} composites)`,
+  );
 }
 
 main().catch((err) => {

--- a/scripts/local-cluster/README.md
+++ b/scripts/local-cluster/README.md
@@ -17,10 +17,10 @@ make -C scripts/local-cluster down RECIPE=istio
 
 ## Recipes
 
-| Recipe | Use it to validate | Extras on top of plain k8s |
-|---|---|---|
-| `istio` | `k8s-deploy`, `istio-policy`, service composites | Istio demo profile, `apps` namespace with sidecar injection |
-| `monitoring` | `monitoring-stack` | Pre-created `monitoring` namespace; no operators yet (monitoring-stack ships its own CRDs) |
+| Recipe       | Use it to validate                               | Extras on top of plain k8s                                                                 |
+| ------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `istio`      | `k8s-deploy`, `istio-policy`, service composites | Istio demo profile, `apps` namespace with sidecar injection                                |
+| `monitoring` | `monitoring-stack`                               | Pre-created `monitoring` namespace; no operators yet (monitoring-stack ships its own CRDs) |
 
 Add a new recipe by creating `recipes/<name>/` with `up.sh`, `down.sh`, `status.sh`, `README.md`, and (typically) `kind-config.yaml`. The Makefile discovers it automatically.
 
@@ -56,13 +56,13 @@ Useful when you've already got a render from a previous `nanohype scaffold` invo
 
 Every recipe is a directory under `recipes/` with four executables and a config:
 
-| File | Purpose |
-|---|---|
-| `kind-config.yaml` | kind cluster configuration (node count, port mappings) |
-| `up.sh` | Create the cluster and install any baseline components (Istio, operators, etc). Idempotent. |
-| `down.sh` | Delete the cluster. Idempotent. |
-| `status.sh` | Report what's running. Useful for debugging. |
-| `README.md` | Documents the recipe's footprint, port mappings, and evolution plan. |
+| File               | Purpose                                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| `kind-config.yaml` | kind cluster configuration (node count, port mappings)                                      |
+| `up.sh`            | Create the cluster and install any baseline components (Istio, operators, etc). Idempotent. |
+| `down.sh`          | Delete the cluster. Idempotent.                                                             |
+| `status.sh`        | Report what's running. Useful for debugging.                                                |
+| `README.md`        | Documents the recipe's footprint, port mappings, and evolution plan.                        |
 
 Recipes source `../../lib/common.sh` for color output helpers, tool-presence checks, and the `nanohype-<recipe>` cluster-naming convention.
 

--- a/scripts/local-cluster/recipes/istio/README.md
+++ b/scripts/local-cluster/recipes/istio/README.md
@@ -12,12 +12,12 @@ Teardown reclaims everything — kind clusters leave no trace on the host.
 
 ## Contents
 
-| Component | Purpose |
-|---|---|
-| kind control-plane | Kubernetes API server + kubelet |
-| `istio-system` namespace | istiod + ingress/egress gateways (demo profile) |
-| `apps` namespace | Where to apply workload + policy manifests; sidecar injection enabled |
-| Port mappings | host `8081` → node `30080`, host `8443` → node `30443` — available for NodePort-style demos |
+| Component                | Purpose                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------- |
+| kind control-plane       | Kubernetes API server + kubelet                                                             |
+| `istio-system` namespace | istiod + ingress/egress gateways (demo profile)                                             |
+| `apps` namespace         | Where to apply workload + policy manifests; sidecar injection enabled                       |
+| Port mappings            | host `8081` → node `30080`, host `8443` → node `30443` — available for NodePort-style demos |
 
 ## Prerequisites
 

--- a/scripts/sync-library.mjs
+++ b/scripts/sync-library.mjs
@@ -42,7 +42,8 @@ async function findConsumers() {
         if (e.name === 'node_modules' || e.name === 'charts') continue; // don't descend into vendored copies
         await walk(p);
       } else if (e.name === 'Chart.yaml') {
-        if ((await readFile(p, 'utf8')).includes(`file://charts/${LIB_NAME}`)) dirs.push(dirname(p));
+        if ((await readFile(p, 'utf8')).includes(`file://charts/${LIB_NAME}`))
+          dirs.push(dirname(p));
       }
     }
   }
@@ -82,8 +83,10 @@ async function main() {
         copyFiles.join('\n') === srcFiles.join('\n') &&
         (
           await Promise.all(
-            srcFiles.map(async (f) =>
-              (await readFile(join(LIB_SRC, f), 'utf8')) === (await readFile(join(dest, f), 'utf8')),
+            srcFiles.map(
+              async (f) =>
+                (await readFile(join(LIB_SRC, f), 'utf8')) ===
+                (await readFile(join(dest, f), 'utf8')),
             ),
           )
         ).every(Boolean);

--- a/scripts/validate-schema.mjs
+++ b/scripts/validate-schema.mjs
@@ -9,13 +9,13 @@
 //
 //   node scripts/validate-schema.mjs --schema <schema.json> --data <glob> [--data <glob>...]
 
-import { readFile, readdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { extname } from "node:path";
+import { readFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { extname } from 'node:path';
 
-import _Ajv2020 from "ajv/dist/2020.js";
-import _addFormats from "ajv-formats";
-import jsYaml from "js-yaml";
+import _Ajv2020 from 'ajv/dist/2020.js';
+import _addFormats from 'ajv-formats';
+import jsYaml from 'js-yaml';
 
 const Ajv2020 = _Ajv2020.default ?? _Ajv2020;
 const addFormats = _addFormats.default ?? _addFormats;
@@ -25,11 +25,13 @@ function parseArgs(argv) {
   const schema = [];
   const data = [];
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--schema" || argv[i] === "-s") schema.push(argv[++i]);
-    else if (argv[i] === "--data" || argv[i] === "-d") data.push(argv[++i]);
+    if (argv[i] === '--schema' || argv[i] === '-s') schema.push(argv[++i]);
+    else if (argv[i] === '--data' || argv[i] === '-d') data.push(argv[++i]);
   }
   if (schema.length !== 1 || data.length === 0) {
-    console.error("usage: validate-schema.mjs --schema <schema.json> --data <glob> [--data <glob>...]");
+    console.error(
+      'usage: validate-schema.mjs --schema <schema.json> --data <glob> [--data <glob>...]',
+    );
     process.exit(2);
   }
   return { schema: schema[0], dataGlobs: data };
@@ -39,19 +41,22 @@ function parseArgs(argv) {
 // segment, matched against a single directory level. Avoids both a dependency
 // and the experimental fs.glob API.
 async function expandGlob(pattern) {
-  let matches = [""];
-  for (const seg of pattern.split("/")) {
+  let matches = [''];
+  for (const seg of pattern.split('/')) {
     const next = [];
     for (const base of matches) {
-      if (seg.includes("*")) {
-        const re = new RegExp("^" + seg.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$");
+      if (seg.includes('*')) {
+        const re = new RegExp(
+          '^' + seg.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
+        );
         let entries;
         try {
-          entries = await readdir(base || ".", { withFileTypes: true });
+          entries = await readdir(base || '.', { withFileTypes: true });
         } catch {
           continue;
         }
-        for (const e of entries) if (re.test(e.name)) next.push(base ? `${base}/${e.name}` : e.name);
+        for (const e of entries)
+          if (re.test(e.name)) next.push(base ? `${base}/${e.name}` : e.name);
       } else {
         const p = base ? `${base}/${seg}` : seg;
         if (existsSync(p)) next.push(p);
@@ -63,8 +68,8 @@ async function expandGlob(pattern) {
 }
 
 async function loadDataFile(file) {
-  const text = await readFile(file, "utf8");
-  return extname(file) === ".json" ? JSON.parse(text) : parseYaml(text);
+  const text = await readFile(file, 'utf8');
+  return extname(file) === '.json' ? JSON.parse(text) : parseYaml(text);
 }
 
 async function main() {
@@ -72,7 +77,7 @@ async function main() {
 
   const ajv = new Ajv2020({ strict: false, allErrors: true });
   addFormats(ajv);
-  const validate = ajv.compile(JSON.parse(await readFile(schema, "utf8")));
+  const validate = ajv.compile(JSON.parse(await readFile(schema, 'utf8')));
 
   let checked = 0;
   let failures = 0;
@@ -93,14 +98,14 @@ async function main() {
         failures++;
         console.error(`✗ ${file}`);
         for (const e of validate.errors ?? []) {
-          console.error(`    ${e.instancePath || "/"} ${e.message}`);
+          console.error(`    ${e.instancePath || '/'} ${e.message}`);
         }
       }
     }
   }
 
   if (checked === 0) {
-    console.error(`no files matched: ${dataGlobs.join(", ")}`);
+    console.error(`no files matched: ${dataGlobs.join(', ')}`);
     process.exit(2);
   }
   if (failures > 0) {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -20,10 +20,10 @@ Reads templates from a GitHub repository via the GitHub API. Supports optional a
 import { GitHubSource } from '@nanohype/sdk';
 
 const source = new GitHubSource({
-  repo: 'nanohype/nanohype',   // default
-  ref: 'main',                  // default
+  repo: 'nanohype/nanohype', // default
+  ref: 'main', // default
   token: process.env.GITHUB_TOKEN, // optional, for rate limits
-  cacheTtl: 5 * 60 * 1000,     // 5 minutes, default
+  cacheTtl: 5 * 60 * 1000, // 5 minutes, default
 });
 
 // List all templates in the catalog
@@ -100,10 +100,14 @@ import { LocalSource, renderComposite } from '@nanohype/sdk';
 const source = new LocalSource({ rootDir: './nanohype' });
 const composite = await source.fetchComposite('ai-chatbot');
 
-const result = await renderComposite(composite, {
-  ProjectName: 'my-bot',
-  IncludeAuth: true,
-}, source);
+const result = await renderComposite(
+  composite,
+  {
+    ProjectName: 'my-bot',
+    IncludeAuth: true,
+  },
+  source,
+);
 
 // result.files    — merged SkeletonFile[] from all included templates
 // result.warnings — file collisions, prerequisite notices
@@ -146,29 +150,29 @@ Throws `VariableResolutionError` on missing required values, circular references
 
 Key interfaces exported from `@nanohype/sdk`:
 
-| Type | Description |
-|---|---|
-| `TemplateManifest` | Parsed `template.yaml` — metadata, variables, conditionals, hooks, prerequisites, composition hints |
-| `TemplateVariable` | Variable declaration — name, type (`string`, `bool`, `enum`, `int`), placeholder, default, validation |
-| `SkeletonFile` | A file in the skeleton tree — `{ path, content }` |
-| `CatalogEntry` | Summary of a template for listing — name, displayName, description, version, tags |
-| `RenderResult` | Output of `renderTemplate` — rendered files, warnings, hooks |
-| `CompositeManifest` | Parsed composite YAML — variables, template entries with conditions and path overrides |
-| `CompositeEntry` | A single template reference within a composite — template name, path, root flag, variables, condition |
-| `CompositeCatalogEntry` | Summary of a composite for listing — includes `templateCount` |
-| `CompositeRenderResult` | Output of `renderComposite` — merged files, warnings, hooks, per-entry metadata |
-| `CatalogSource` | Interface for template/composite discovery and fetching |
-| `GitHubSourceOptions` | Constructor options for `GitHubSource` — repo, ref, token, cacheTtl |
-| `LocalSourceOptions` | Constructor options for `LocalSource` — rootDir |
+| Type                    | Description                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `TemplateManifest`      | Parsed `template.yaml` — metadata, variables, conditionals, hooks, prerequisites, composition hints   |
+| `TemplateVariable`      | Variable declaration — name, type (`string`, `bool`, `enum`, `int`), placeholder, default, validation |
+| `SkeletonFile`          | A file in the skeleton tree — `{ path, content }`                                                     |
+| `CatalogEntry`          | Summary of a template for listing — name, displayName, description, version, tags                     |
+| `RenderResult`          | Output of `renderTemplate` — rendered files, warnings, hooks                                          |
+| `CompositeManifest`     | Parsed composite YAML — variables, template entries with conditions and path overrides                |
+| `CompositeEntry`        | A single template reference within a composite — template name, path, root flag, variables, condition |
+| `CompositeCatalogEntry` | Summary of a composite for listing — includes `templateCount`                                         |
+| `CompositeRenderResult` | Output of `renderComposite` — merged files, warnings, hooks, per-entry metadata                       |
+| `CatalogSource`         | Interface for template/composite discovery and fetching                                               |
+| `GitHubSourceOptions`   | Constructor options for `GitHubSource` — repo, ref, token, cacheTtl                                   |
+| `LocalSourceOptions`    | Constructor options for `LocalSource` — rootDir                                                       |
 
 ## Errors
 
 All SDK errors extend `NanohypeError`:
 
-| Error | Thrown by |
-|---|---|
-| `NanohypeError` | Base class — source fetch failures, unsupported API versions |
-| `ManifestValidationError` | `validateManifest`, `validateCompositeManifest` — structural violations |
+| Error                     | Thrown by                                                                                          |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| `NanohypeError`           | Base class — source fetch failures, unsupported API versions                                       |
+| `ManifestValidationError` | `validateManifest`, `validateCompositeManifest` — structural violations                            |
 | `VariableResolutionError` | `resolveVariables`, `renderTemplate`, `renderComposite` — missing values, bad types, circular refs |
 
 ## License

--- a/sdk/__tests__/composite.test.ts
+++ b/sdk/__tests__/composite.test.ts
@@ -28,9 +28,7 @@ function mockTemplate(
   };
 }
 
-function mockSource(
-  templates: Record<string, ReturnType<typeof mockTemplate>>,
-): CatalogSource {
+function mockSource(templates: Record<string, ReturnType<typeof mockTemplate>>): CatalogSource {
   return {
     async listTemplates(): Promise<CatalogEntry[]> {
       return Object.keys(templates).map((name) => ({
@@ -58,9 +56,7 @@ function mockSource(
 describe('renderComposite', () => {
   it('renders a single root entry at output root', async () => {
     const source = mockSource({
-      'my-template': mockTemplate('my-template', [], [
-        { path: 'README.md', content: 'hello' },
-      ]),
+      'my-template': mockTemplate('my-template', [], [{ path: 'README.md', content: 'hello' }]),
     });
     const manifest: CompositeManifest = {
       apiVersion: 'nanohype/v1',
@@ -144,7 +140,12 @@ describe('renderComposite', () => {
       version: '0.1.0',
       tags: ['test'],
       variables: [
-        { name: 'IncludeOptional', type: 'bool', placeholder: '__INCLUDE__', description: 'Include' },
+        {
+          name: 'IncludeOptional',
+          type: 'bool',
+          placeholder: '__INCLUDE__',
+          description: 'Include',
+        },
       ],
       templates: [
         { template: 'always' },
@@ -162,7 +163,14 @@ describe('renderComposite', () => {
     const source = mockSource({
       tmpl: mockTemplate(
         'tmpl',
-        [{ name: 'ProjectName', type: 'string', placeholder: '__PROJECT_NAME__', description: 'Name' }],
+        [
+          {
+            name: 'ProjectName',
+            type: 'string',
+            placeholder: '__PROJECT_NAME__',
+            description: 'Name',
+          },
+        ],
         [{ path: 'README.md', content: '# __PROJECT_NAME__' }],
       ),
     });
@@ -174,12 +182,8 @@ describe('renderComposite', () => {
       description: 'Test',
       version: '0.1.0',
       tags: ['test'],
-      variables: [
-        { name: 'Name', type: 'string', placeholder: '__NAME__', description: 'Name' },
-      ],
-      templates: [
-        { template: 'tmpl', root: true, variables: { ProjectName: '${Name}' } },
-      ],
+      variables: [{ name: 'Name', type: 'string', placeholder: '__NAME__', description: 'Name' }],
+      templates: [{ template: 'tmpl', root: true, variables: { ProjectName: '${Name}' } }],
     };
 
     const result = await renderComposite(manifest, { Name: 'my-project' }, source);
@@ -200,10 +204,7 @@ describe('renderComposite', () => {
       version: '0.1.0',
       tags: ['test'],
       variables: [],
-      templates: [
-        { template: 'first', root: true },
-        { template: 'second' },
-      ],
+      templates: [{ template: 'first', root: true }, { template: 'second' }],
     };
 
     const result = await renderComposite(manifest, {}, source);

--- a/sdk/__tests__/conditions.test.ts
+++ b/sdk/__tests__/conditions.test.ts
@@ -18,9 +18,9 @@ describe('evalCondition', () => {
 
   it('evaluates || (RDS-needs-VPC dependency)', () => {
     expect(evalCondition('IncludeVpc || IncludeRds', r)).toBe(true);
-    expect(evalCondition('IncludeVpc || IncludeRds', { IncludeVpc: 'false', IncludeRds: 'false' })).toBe(
-      false,
-    );
+    expect(
+      evalCondition('IncludeVpc || IncludeRds', { IncludeVpc: 'false', IncludeRds: 'false' }),
+    ).toBe(false);
   });
 
   it('evaluates &&, !, and parentheses with precedence', () => {
@@ -42,21 +42,35 @@ describe('applyContentConditionals', () => {
   });
 
   it('keeps a block (dropping markers) when the condition is true', () => {
-    const src = ['before', '// #if IncludeRds', 'import { Db } from "./db";', '// #endif', 'after'].join(
-      '\n',
+    const src = [
+      'before',
+      '// #if IncludeRds',
+      'import { Db } from "./db";',
+      '// #endif',
+      'after',
+    ].join('\n');
+    expect(applyContentConditionals(src, resolved)).toBe(
+      ['before', 'import { Db } from "./db";', 'after'].join('\n'),
     );
-    expect(applyContentConditionals(src, resolved)).toBe(['before', 'import { Db } from "./db";', 'after'].join('\n'));
   });
 
   it('drops a block entirely when the condition is false', () => {
-    const src = ['before', '// #if IncludeVpc', 'import { Vpc } from "./vpc";', '// #endif', 'after'].join(
-      '\n',
-    );
+    const src = [
+      'before',
+      '// #if IncludeVpc',
+      'import { Vpc } from "./vpc";',
+      '// #endif',
+      'after',
+    ].join('\n');
     expect(applyContentConditionals(src, resolved)).toBe(['before', 'after'].join('\n'));
   });
 
   it('evaluates expression conditions (RDS keeps a VPC import)', () => {
-    const src = ['// #if IncludeVpc || IncludeRds', 'import { Vpc } from "./vpc";', '// #endif'].join('\n');
+    const src = [
+      '// #if IncludeVpc || IncludeRds',
+      'import { Vpc } from "./vpc";',
+      '// #endif',
+    ].join('\n');
     expect(applyContentConditionals(src, resolved)).toBe('import { Vpc } from "./vpc";');
   });
 
@@ -87,9 +101,14 @@ describe('applyContentConditionals', () => {
   });
 
   it('recognizes hash-comment markers too', () => {
-    const src = ['# #if IncludeRds', 'rds: true', '# #endif', '# #if IncludeVpc', 'vpc: true', '# #endif'].join(
-      '\n',
-    );
+    const src = [
+      '# #if IncludeRds',
+      'rds: true',
+      '# #endif',
+      '# #if IncludeVpc',
+      'vpc: true',
+      '# #endif',
+    ].join('\n');
     expect(applyContentConditionals(src, resolved)).toBe('rds: true');
   });
 

--- a/sdk/__tests__/contracts.test.ts
+++ b/sdk/__tests__/contracts.test.ts
@@ -67,7 +67,8 @@ describe('loadAllContracts', () => {
     // (404). The load must degrade, not throw.
     const partial = {
       async fetchContract(repo: string) {
-        if (repo === 'eks-fleet') throw new NanohypeError('AGENTS.md for repo \'eks-fleet\' not found: 404');
+        if (repo === 'eks-fleet')
+          throw new NanohypeError("AGENTS.md for repo 'eks-fleet' not found: 404");
         return `# ${repo} — agent entry point\n\n${'x'.repeat(150)}`;
       },
     } as unknown as CatalogSource;

--- a/sdk/__tests__/renderer.test.ts
+++ b/sdk/__tests__/renderer.test.ts
@@ -19,7 +19,12 @@ describe('renderTemplate', () => {
   it('replaces placeholders in file content', () => {
     const manifest = minimalManifest({
       variables: [
-        { name: 'ProjectName', type: 'string', placeholder: '__PROJECT_NAME__', description: 'Name' },
+        {
+          name: 'ProjectName',
+          type: 'string',
+          placeholder: '__PROJECT_NAME__',
+          description: 'Name',
+        },
       ],
     });
     const files: SkeletonFile[] = [
@@ -32,7 +37,12 @@ describe('renderTemplate', () => {
   it('replaces placeholders in file paths', () => {
     const manifest = minimalManifest({
       variables: [
-        { name: 'ProjectName', type: 'string', placeholder: '__PROJECT_NAME__', description: 'Name' },
+        {
+          name: 'ProjectName',
+          type: 'string',
+          placeholder: '__PROJECT_NAME__',
+          description: 'Name',
+        },
       ],
     });
     const files: SkeletonFile[] = [
@@ -45,7 +55,12 @@ describe('renderTemplate', () => {
   it('excludes files when conditional is false', () => {
     const manifest = minimalManifest({
       variables: [
-        { name: 'IncludeMemory', type: 'bool', placeholder: '__INCLUDE_MEMORY__', description: 'Memory' },
+        {
+          name: 'IncludeMemory',
+          type: 'bool',
+          placeholder: '__INCLUDE_MEMORY__',
+          description: 'Memory',
+        },
       ],
       conditionals: [{ path: 'src/memory', when: 'IncludeMemory' }],
     });
@@ -62,7 +77,12 @@ describe('renderTemplate', () => {
   it('includes files when conditional is true', () => {
     const manifest = minimalManifest({
       variables: [
-        { name: 'IncludeMemory', type: 'bool', placeholder: '__INCLUDE_MEMORY__', description: 'Memory' },
+        {
+          name: 'IncludeMemory',
+          type: 'bool',
+          placeholder: '__INCLUDE_MEMORY__',
+          description: 'Memory',
+        },
       ],
       conditionals: [{ path: 'src/memory', when: 'IncludeMemory' }],
     });
@@ -105,8 +125,18 @@ describe('renderTemplate', () => {
   it('replaces multiple placeholders in the same content', () => {
     const manifest = minimalManifest({
       variables: [
-        { name: 'ProjectName', type: 'string', placeholder: '__PROJECT_NAME__', description: 'Name' },
-        { name: 'Description', type: 'string', placeholder: '__DESCRIPTION__', description: 'Desc' },
+        {
+          name: 'ProjectName',
+          type: 'string',
+          placeholder: '__PROJECT_NAME__',
+          description: 'Name',
+        },
+        {
+          name: 'Description',
+          type: 'string',
+          placeholder: '__DESCRIPTION__',
+          description: 'Desc',
+        },
       ],
     });
     const files: SkeletonFile[] = [
@@ -121,13 +151,9 @@ describe('renderTemplate', () => {
 
   it('replaces all occurrences of the same placeholder', () => {
     const manifest = minimalManifest({
-      variables: [
-        { name: 'Name', type: 'string', placeholder: '__NAME__', description: 'Name' },
-      ],
+      variables: [{ name: 'Name', type: 'string', placeholder: '__NAME__', description: 'Name' }],
     });
-    const files: SkeletonFile[] = [
-      { path: 'test.txt', content: '__NAME__ uses __NAME__' },
-    ];
+    const files: SkeletonFile[] = [{ path: 'test.txt', content: '__NAME__ uses __NAME__' }];
     const result = renderTemplate(manifest, files, { Name: 'foo' });
     expect(result.files[0].content).toBe('foo uses foo');
   });
@@ -139,7 +165,12 @@ describe('renderTemplate', () => {
       ],
     });
     const files: SkeletonFile[] = [
-      { path: 'stack.ts', content: ['import a;', '// #if IncludeVpc', 'import vpc;', '// #endif', 'use();'].join('\n') },
+      {
+        path: 'stack.ts',
+        content: ['import a;', '// #if IncludeVpc', 'import vpc;', '// #endif', 'use();'].join(
+          '\n',
+        ),
+      },
     ];
     const off = renderTemplate(manifest, files, { IncludeVpc: false });
     expect(off.files[0].content).toBe(['import a;', 'use();'].join('\n'));

--- a/sdk/__tests__/resolver.test.ts
+++ b/sdk/__tests__/resolver.test.ts
@@ -13,18 +13,12 @@ function v(overrides: Partial<TemplateVariable> & { name: string }): TemplateVar
 
 describe('resolveVariables', () => {
   it('applies provided values', () => {
-    const result = resolveVariables(
-      [v({ name: 'ProjectName' })],
-      { ProjectName: 'my-app' },
-    );
+    const result = resolveVariables([v({ name: 'ProjectName' })], { ProjectName: 'my-app' });
     expect(result.ProjectName).toBe('my-app');
   });
 
   it('falls back to defaults', () => {
-    const result = resolveVariables(
-      [v({ name: 'ProjectName', default: 'default-app' })],
-      {},
-    );
+    const result = resolveVariables([v({ name: 'ProjectName', default: 'default-app' })], {});
     expect(result.ProjectName).toBe('default-app');
   });
 
@@ -43,59 +37,43 @@ describe('resolveVariables', () => {
   });
 
   it('throws on missing required variable', () => {
-    expect(() =>
-      resolveVariables([v({ name: 'Name', required: true })], {}),
-    ).toThrow("Required variable 'Name' has no value and no default");
+    expect(() => resolveVariables([v({ name: 'Name', required: true })], {})).toThrow(
+      "Required variable 'Name' has no value and no default",
+    );
   });
 
   it('expands ${VarName} cross-references', () => {
     const result = resolveVariables(
-      [
-        v({ name: 'ProjectName' }),
-        v({ name: 'ModulePath', default: 'packages/${ProjectName}' }),
-      ],
+      [v({ name: 'ProjectName' }), v({ name: 'ModulePath', default: 'packages/${ProjectName}' })],
       { ProjectName: 'my-app' },
     );
     expect(result.ModulePath).toBe('packages/my-app');
   });
 
   it('detects direct circular references (A→A)', () => {
-    expect(() =>
-      resolveVariables(
-        [v({ name: 'A', default: '${A}' })],
-        {},
-      ),
-    ).toThrow("Circular reference in variable 'A'");
+    expect(() => resolveVariables([v({ name: 'A', default: '${A}' })], {})).toThrow(
+      "Circular reference in variable 'A'",
+    );
   });
 
   it('detects indirect circular references (A→B→A)', () => {
     expect(() =>
-      resolveVariables(
-        [
-          v({ name: 'A', default: '${B}' }),
-          v({ name: 'B', default: '${A}' }),
-        ],
-        {},
-      ),
+      resolveVariables([v({ name: 'A', default: '${B}' }), v({ name: 'B', default: '${A}' })], {}),
     ).toThrow(/[Cc]ircular reference/);
   });
 
   it('throws on reference to unknown variable', () => {
-    expect(() =>
-      resolveVariables(
-        [v({ name: 'A', default: '${Nonexistent}' })],
-        {},
-      ),
-    ).toThrow("references unknown variable 'Nonexistent'");
+    expect(() => resolveVariables([v({ name: 'A', default: '${Nonexistent}' })], {})).toThrow(
+      "references unknown variable 'Nonexistent'",
+    );
   });
 
   it('validates enum membership', () => {
     expect(() =>
-      resolveVariables(
-        [v({ name: 'Provider', type: 'enum', options: ['a', 'b'] })],
-        { Provider: 'c' },
-      ),
-    ).toThrow("not in options: a, b");
+      resolveVariables([v({ name: 'Provider', type: 'enum', options: ['a', 'b'] })], {
+        Provider: 'c',
+      }),
+    ).toThrow('not in options: a, b');
   });
 
   it('validates regex patterns', () => {
@@ -113,19 +91,15 @@ describe('resolveVariables', () => {
   });
 
   it('passes valid regex patterns', () => {
-    const result = resolveVariables(
-      [v({ name: 'Name', validation: { pattern: '[a-z-]+' } })],
-      { Name: 'my-app' },
-    );
+    const result = resolveVariables([v({ name: 'Name', validation: { pattern: '[a-z-]+' } })], {
+      Name: 'my-app',
+    });
     expect(result.Name).toBe('my-app');
   });
 
   it('converts boolean and number values to strings', () => {
     const result = resolveVariables(
-      [
-        v({ name: 'Flag', type: 'bool' }),
-        v({ name: 'Count', type: 'int' }),
-      ],
+      [v({ name: 'Flag', type: 'bool' }), v({ name: 'Count', type: 'int' })],
       { Flag: true, Count: 42 },
     );
     expect(result.Flag).toBe('true');

--- a/sdk/__tests__/sources/github.test.ts
+++ b/sdk/__tests__/sources/github.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GitHubSource } from "../../src/sources/github.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitHubSource } from '../../src/sources/github.js';
 
 const mockFetch = vi.fn();
 
@@ -8,7 +8,7 @@ beforeEach(() => {
   // top-level `vi.fn()` instances — reset between tests explicitly so
   // `mock.calls` and `toHaveBeenCalledTimes` start clean.
   mockFetch.mockReset();
-  vi.stubGlobal("fetch", mockFetch);
+  vi.stubGlobal('fetch', mockFetch);
 });
 
 afterEach(() => {
@@ -18,7 +18,7 @@ afterEach(() => {
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { 'Content-Type': 'application/json' },
   });
 }
 
@@ -26,47 +26,45 @@ function textResponse(text: string, status = 200): Response {
   return new Response(text, { status });
 }
 
-describe("GitHubSource", () => {
-  describe("constructor defaults", () => {
-    it("uses nanohype/nanohype repo and main ref by default", async () => {
+describe('GitHubSource', () => {
+  describe('constructor defaults', () => {
+    it('uses nanohype/nanohype repo and main ref by default', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
       const source = new GitHubSource();
       await source.listTemplates();
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "repos/nanohype/nanohype/contents/templates?ref=main",
-        ),
+        expect.stringContaining('repos/nanohype/nanohype/contents/templates?ref=main'),
         expect.any(Object),
       );
     });
 
-    it("accepts custom repo and ref", async () => {
+    it('accepts custom repo and ref', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
-      const source = new GitHubSource({ repo: "org/repo", ref: "v1.0.0" });
+      const source = new GitHubSource({ repo: 'org/repo', ref: 'v1.0.0' });
       await source.listTemplates();
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("repos/org/repo/contents/templates?ref=v1.0.0"),
+        expect.stringContaining('repos/org/repo/contents/templates?ref=v1.0.0'),
         expect.any(Object),
       );
     });
   });
 
-  describe("authorization", () => {
-    it("includes Bearer token when provided", async () => {
+  describe('authorization', () => {
+    it('includes Bearer token when provided', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
-      const source = new GitHubSource({ token: "ghp_test123" });
+      const source = new GitHubSource({ token: 'ghp_test123' });
       await source.listTemplates();
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: "Bearer ghp_test123",
+            Authorization: 'Bearer ghp_test123',
           }),
         }),
       );
     });
 
-    it("omits Authorization header when no token", async () => {
+    it('omits Authorization header when no token', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
       const source = new GitHubSource();
       await source.listTemplates();
@@ -75,13 +73,13 @@ describe("GitHubSource", () => {
     });
   });
 
-  describe("listTemplates", () => {
-    it("parses directory listing and fetches manifests", async () => {
+  describe('listTemplates', () => {
+    it('parses directory listing and fetches manifests', async () => {
       mockFetch
         .mockResolvedValueOnce(
           jsonResponse([
-            { name: "go-cli", type: "dir" },
-            { name: "README.md", type: "file" },
+            { name: 'go-cli', type: 'dir' },
+            { name: 'README.md', type: 'file' },
           ]),
         )
         .mockResolvedValueOnce(
@@ -93,11 +91,11 @@ describe("GitHubSource", () => {
       const source = new GitHubSource();
       const entries = await source.listTemplates();
       expect(entries).toHaveLength(1);
-      expect(entries[0].name).toBe("go-cli");
-      expect(entries[0].displayName).toBe("Go CLI");
+      expect(entries[0].name).toBe('go-cli');
+      expect(entries[0].displayName).toBe('Go CLI');
     });
 
-    it("caches results within TTL", async () => {
+    it('caches results within TTL', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
       const source = new GitHubSource({ cacheTtl: 60_000 });
       await source.listTemplates();
@@ -105,43 +103,39 @@ describe("GitHubSource", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it("throws on non-OK response", async () => {
+    it('throws on non-OK response', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({}, 403));
       const source = new GitHubSource();
-      await expect(source.listTemplates()).rejects.toThrow(
-        "Failed to list catalog: 403",
-      );
+      await expect(source.listTemplates()).rejects.toThrow('Failed to list catalog: 403');
     });
 
-    it("skips directories without a manifest but throws on other manifest failures", async () => {
+    it('skips directories without a manifest but throws on other manifest failures', async () => {
       mockFetch
-        .mockResolvedValueOnce(
-          jsonResponse([{ name: "not-a-template", type: "dir" }]),
-        )
-        .mockResolvedValueOnce(textResponse("Not found", 404));
+        .mockResolvedValueOnce(jsonResponse([{ name: 'not-a-template', type: 'dir' }]))
+        .mockResolvedValueOnce(textResponse('Not found', 404));
       const source = new GitHubSource();
       await expect(source.listTemplates()).resolves.toEqual([]);
 
       mockFetch
-        .mockResolvedValueOnce(jsonResponse([{ name: "go-cli", type: "dir" }]))
-        .mockResolvedValueOnce(textResponse("rate limited", 429));
+        .mockResolvedValueOnce(jsonResponse([{ name: 'go-cli', type: 'dir' }]))
+        .mockResolvedValueOnce(textResponse('rate limited', 429));
       const rateLimited = new GitHubSource({ cacheTtl: 0 });
       await expect(rateLimited.listTemplates()).rejects.toThrow(
         "Failed to fetch manifest for template 'go-cli': 429",
       );
     });
 
-    it("throws on an unparseable manifest instead of dropping the entry", async () => {
+    it('throws on an unparseable manifest instead of dropping the entry', async () => {
       mockFetch
-        .mockResolvedValueOnce(jsonResponse([{ name: "go-cli", type: "dir" }]))
-        .mockResolvedValueOnce(textResponse("{{ not: yaml: at: all"));
+        .mockResolvedValueOnce(jsonResponse([{ name: 'go-cli', type: 'dir' }]))
+        .mockResolvedValueOnce(textResponse('{{ not: yaml: at: all'));
       const source = new GitHubSource();
       await expect(source.listTemplates()).rejects.toThrow(
         "Invalid manifest for template 'go-cli'",
       );
     });
 
-    it("bounds every request with an abort signal", async () => {
+    it('bounds every request with an abort signal', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse([]));
       const source = new GitHubSource();
       await source.listTemplates();
@@ -152,25 +146,23 @@ describe("GitHubSource", () => {
     });
   });
 
-  describe("fetchTemplate", () => {
-    it("throws on missing template", async () => {
-      mockFetch.mockResolvedValueOnce(textResponse("Not found", 404));
+  describe('fetchTemplate', () => {
+    it('throws on missing template', async () => {
+      mockFetch.mockResolvedValueOnce(textResponse('Not found', 404));
       const source = new GitHubSource();
-      await expect(source.fetchTemplate("missing")).rejects.toThrow(
-        "Template 'missing' not found",
-      );
+      await expect(source.fetchTemplate('missing')).rejects.toThrow("Template 'missing' not found");
     });
 
-    it("parses manifest, fetches skeleton tree, and returns files", async () => {
+    it('parses manifest, fetches skeleton tree, and returns files', async () => {
       const manifestYaml = [
-        "apiVersion: nanohype/v1",
-        "name: go-cli",
-        "displayName: Go CLI",
-        "description: A Go CLI starter",
+        'apiVersion: nanohype/v1',
+        'name: go-cli',
+        'displayName: Go CLI',
+        'description: A Go CLI starter',
         'version: "1.0.0"',
-        "tags: [go, cli]",
-        "variables: []",
-      ].join("\n");
+        'tags: [go, cli]',
+        'variables: []',
+      ].join('\n');
 
       mockFetch
         // 1. Manifest YAML fetch
@@ -180,75 +172,75 @@ describe("GitHubSource", () => {
           jsonResponse({
             tree: [
               {
-                path: "templates/go-cli/template.yaml",
-                type: "blob",
-                sha: "aaa",
+                path: 'templates/go-cli/template.yaml',
+                type: 'blob',
+                sha: 'aaa',
               },
               {
-                path: "templates/go-cli/skeleton/main.go",
-                type: "blob",
-                sha: "bbb",
+                path: 'templates/go-cli/skeleton/main.go',
+                type: 'blob',
+                sha: 'bbb',
               },
               {
-                path: "templates/go-cli/skeleton/pkg/util.go",
-                type: "blob",
-                sha: "ccc",
+                path: 'templates/go-cli/skeleton/pkg/util.go',
+                type: 'blob',
+                sha: 'ccc',
               },
               {
-                path: "templates/other/skeleton/index.ts",
-                type: "blob",
-                sha: "ddd",
+                path: 'templates/other/skeleton/index.ts',
+                type: 'blob',
+                sha: 'ddd',
               },
-              { path: "templates/go-cli/skeleton", type: "tree", sha: "eee" },
+              { path: 'templates/go-cli/skeleton', type: 'tree', sha: 'eee' },
             ],
           }),
         )
         // 3. File content fetches (only the two skeleton blobs matching the prefix)
-        .mockResolvedValueOnce(textResponse("package main\n\nfunc main() {}"))
-        .mockResolvedValueOnce(textResponse("package pkg\n\nfunc Util() {}"));
+        .mockResolvedValueOnce(textResponse('package main\n\nfunc main() {}'))
+        .mockResolvedValueOnce(textResponse('package pkg\n\nfunc Util() {}'));
 
       const source = new GitHubSource();
-      const { manifest, files } = await source.fetchTemplate("go-cli");
+      const { manifest, files } = await source.fetchTemplate('go-cli');
 
       // Manifest is parsed correctly
-      expect(manifest.apiVersion).toBe("nanohype/v1");
-      expect(manifest.name).toBe("go-cli");
-      expect(manifest.displayName).toBe("Go CLI");
-      expect(manifest.description).toBe("A Go CLI starter");
-      expect(manifest.version).toBe("1.0.0");
-      expect(manifest.tags).toEqual(["go", "cli"]);
+      expect(manifest.apiVersion).toBe('nanohype/v1');
+      expect(manifest.name).toBe('go-cli');
+      expect(manifest.displayName).toBe('Go CLI');
+      expect(manifest.description).toBe('A Go CLI starter');
+      expect(manifest.version).toBe('1.0.0');
+      expect(manifest.tags).toEqual(['go', 'cli']);
 
       // Skeleton files have paths relative to the skeleton/ directory
       expect(files).toHaveLength(2);
       expect(files[0]).toEqual({
-        path: "main.go",
-        content: "package main\n\nfunc main() {}",
+        path: 'main.go',
+        content: 'package main\n\nfunc main() {}',
       });
       expect(files[1]).toEqual({
-        path: "pkg/util.go",
-        content: "package pkg\n\nfunc Util() {}",
+        path: 'pkg/util.go',
+        content: 'package pkg\n\nfunc Util() {}',
       });
 
       // Verify the correct URLs were called
       expect(mockFetch).toHaveBeenCalledTimes(4);
       expect(mockFetch.mock.calls[0][0]).toContain(
-        "raw.githubusercontent.com/nanohype/nanohype/main/templates/go-cli/template.yaml",
+        'raw.githubusercontent.com/nanohype/nanohype/main/templates/go-cli/template.yaml',
       );
       expect(mockFetch.mock.calls[1][0]).toContain(
-        "api.github.com/repos/nanohype/nanohype/git/trees/main?recursive=1",
+        'api.github.com/repos/nanohype/nanohype/git/trees/main?recursive=1',
       );
     });
 
-    it("throws when a skeleton file fails to fetch — never renders a partial scaffold", async () => {
+    it('throws when a skeleton file fails to fetch — never renders a partial scaffold', async () => {
       const manifestYaml = [
-        "apiVersion: nanohype/v1",
-        "name: go-cli",
-        "displayName: Go CLI",
-        "description: A Go CLI starter",
+        'apiVersion: nanohype/v1',
+        'name: go-cli',
+        'displayName: Go CLI',
+        'description: A Go CLI starter',
         'version: "1.0.0"',
-        "tags: [go, cli]",
-        "variables: []",
-      ].join("\n");
+        'tags: [go, cli]',
+        'variables: []',
+      ].join('\n');
 
       mockFetch
         .mockResolvedValueOnce(textResponse(manifestYaml))
@@ -256,35 +248,35 @@ describe("GitHubSource", () => {
           jsonResponse({
             tree: [
               {
-                path: "templates/go-cli/skeleton/main.go",
-                type: "blob",
-                sha: "aaa",
+                path: 'templates/go-cli/skeleton/main.go',
+                type: 'blob',
+                sha: 'aaa',
               },
               {
-                path: "templates/go-cli/skeleton/pkg/util.go",
-                type: "blob",
-                sha: "bbb",
+                path: 'templates/go-cli/skeleton/pkg/util.go',
+                type: 'blob',
+                sha: 'bbb',
               },
             ],
           }),
         )
-        .mockResolvedValueOnce(textResponse("package main"))
-        .mockResolvedValueOnce(textResponse("Server error", 500));
+        .mockResolvedValueOnce(textResponse('package main'))
+        .mockResolvedValueOnce(textResponse('Server error', 500));
 
       const source = new GitHubSource();
-      await expect(source.fetchTemplate("go-cli")).rejects.toThrow(
+      await expect(source.fetchTemplate('go-cli')).rejects.toThrow(
         "Failed to fetch skeleton file 'templates/go-cli/skeleton/pkg/util.go' for template 'go-cli': 500",
       );
     });
   });
 
-  describe("listComposites", () => {
-    it("parses composite directory listing", async () => {
+  describe('listComposites', () => {
+    it('parses composite directory listing', async () => {
       mockFetch
         .mockResolvedValueOnce(
           jsonResponse([
-            { name: "ai-chatbot.yaml", type: "file" },
-            { name: "not-yaml.md", type: "file" },
+            { name: 'ai-chatbot.yaml', type: 'file' },
+            { name: 'not-yaml.md', type: 'file' },
           ]),
         )
         .mockResolvedValueOnce(
@@ -296,16 +288,16 @@ describe("GitHubSource", () => {
       const source = new GitHubSource();
       const entries = await source.listComposites();
       expect(entries).toHaveLength(1);
-      expect(entries[0].name).toBe("ai-chatbot");
+      expect(entries[0].name).toBe('ai-chatbot');
       expect(entries[0].templateCount).toBe(1);
     });
   });
 
-  describe("fetchComposite", () => {
-    it("throws on missing composite", async () => {
-      mockFetch.mockResolvedValueOnce(textResponse("Not found", 404));
+  describe('fetchComposite', () => {
+    it('throws on missing composite', async () => {
+      mockFetch.mockResolvedValueOnce(textResponse('Not found', 404));
       const source = new GitHubSource();
-      await expect(source.fetchComposite("missing")).rejects.toThrow(
+      await expect(source.fetchComposite('missing')).rejects.toThrow(
         "Composite 'missing' not found",
       );
     });
@@ -353,75 +345,63 @@ describe("GitHubSource", () => {
     it('rejects contract repos outside the known set without fetching', async () => {
       const source = new GitHubSource();
       await expect(
-        source.fetchContract(
-          'nanohype/main/evil' as Parameters<typeof source.fetchContract>[0],
-        ),
+        source.fetchContract('nanohype/main/evil' as Parameters<typeof source.fetchContract>[0]),
       ).rejects.toThrow('Unknown contract repo');
       expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 });
 
-describe("GitHubSource.fetchContract", () => {
-  it("resolves a public repo via raw.githubusercontent when no token is set", async () => {
+describe('GitHubSource.fetchContract', () => {
+  it('resolves a public repo via raw.githubusercontent when no token is set', async () => {
     // The constructor falls back to GITHUB_TOKEN, which CI sets — clear it so this
     // exercises the no-token path.
-    vi.stubEnv("GITHUB_TOKEN", "");
-    mockFetch.mockResolvedValueOnce(
-      textResponse("# eks-gitops — agent entry point"),
-    );
+    vi.stubEnv('GITHUB_TOKEN', '');
+    mockFetch.mockResolvedValueOnce(textResponse('# eks-gitops — agent entry point'));
     const source = new GitHubSource();
-    const md = await source.fetchContract("eks-gitops");
-    expect(md).toContain("# eks-gitops");
+    const md = await source.fetchContract('eks-gitops');
+    expect(md).toContain('# eks-gitops');
     const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain(
-      "raw.githubusercontent.com/nanohype/eks-gitops/main/AGENTS.md",
-    );
+    expect(url).toContain('raw.githubusercontent.com/nanohype/eks-gitops/main/AGENTS.md');
     vi.unstubAllEnvs();
   });
 
-  it("resolves via the authenticated contents API when a token is set", async () => {
-    const md = "# eks-fleet — agent entry point";
+  it('resolves via the authenticated contents API when a token is set', async () => {
+    const md = '# eks-fleet — agent entry point';
     mockFetch.mockResolvedValueOnce(
       jsonResponse({
-        content: Buffer.from(md).toString("base64"),
-        encoding: "base64",
+        content: Buffer.from(md).toString('base64'),
+        encoding: 'base64',
       }),
     );
-    const source = new GitHubSource({ token: "ghp_x" });
-    const out = await source.fetchContract("eks-fleet");
+    const source = new GitHubSource({ token: 'ghp_x' });
+    const out = await source.fetchContract('eks-fleet');
     expect(out).toBe(md);
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain(
-      "api.github.com/repos/nanohype/eks-fleet/contents/AGENTS.md?ref=main",
-    );
-    expect((opts.headers as Record<string, string>).Authorization).toBe(
-      "Bearer ghp_x",
-    );
+    expect(url).toContain('api.github.com/repos/nanohype/eks-fleet/contents/AGENTS.md?ref=main');
+    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer ghp_x');
   });
 
-  it("falls back to GITHUB_TOKEN from the environment for the contents API", async () => {
-    vi.stubEnv("GITHUB_TOKEN", "env_token");
+  it('falls back to GITHUB_TOKEN from the environment for the contents API', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'env_token');
     mockFetch.mockResolvedValueOnce(
       jsonResponse({
-        content: Buffer.from("# kx").toString("base64"),
-        encoding: "base64",
+        content: Buffer.from('# kx').toString('base64'),
+        encoding: 'base64',
       }),
     );
     const source = new GitHubSource();
-    await source.fetchContract("kx");
+    await source.fetchContract('kx');
     const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((opts.headers as Record<string, string>).Authorization).toBe(
-      "Bearer env_token",
-    );
+    expect((opts.headers as Record<string, string>).Authorization).toBe('Bearer env_token');
     vi.unstubAllEnvs();
   });
 
-  it("throws NanohypeError when the AGENTS.md is missing", async () => {
-    vi.stubEnv("GITHUB_TOKEN", "");
-    mockFetch.mockResolvedValueOnce(textResponse("Not Found", 404));
+  it('throws NanohypeError when the AGENTS.md is missing', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '');
+    mockFetch.mockResolvedValueOnce(textResponse('Not Found', 404));
     const source = new GitHubSource();
-    await expect(source.fetchContract("landing-zone")).rejects.toThrow(
+    await expect(source.fetchContract('landing-zone')).rejects.toThrow(
       "AGENTS.md for repo 'landing-zone' not found",
     );
     vi.unstubAllEnvs();

--- a/sdk/__tests__/validator.test.ts
+++ b/sdk/__tests__/validator.test.ts
@@ -150,7 +150,7 @@ describe('validateManifest', () => {
           ],
         }),
       ),
-    ).toThrow("is a substring of");
+    ).toThrow('is a substring of');
   });
 
   it('rejects bool variable with non-boolean default', () => {

--- a/sdk/schemas/template.schema.json
+++ b/sdk/schemas/template.schema.json
@@ -4,15 +4,7 @@
   "title": "nanohype Template",
   "description": "Schema for nanohype template catalog template.yaml files.",
   "type": "object",
-  "required": [
-    "apiVersion",
-    "name",
-    "displayName",
-    "description",
-    "version",
-    "tags",
-    "variables"
-  ],
+  "required": ["apiVersion", "name", "displayName", "description", "version", "tags", "variables"],
   "additionalProperties": false,
   "properties": {
     "apiVersion": {

--- a/sdk/src/composite.ts
+++ b/sdk/src/composite.ts
@@ -75,7 +75,7 @@ export async function renderComposite(
       const result = renderTemplate(tmplManifest, files, entryValues);
 
       // Prefix paths for non-root entries
-      const prefix = entry.root ? '' : (entry.path ? entry.path + '/' : '');
+      const prefix = entry.root ? '' : entry.path ? entry.path + '/' : '';
       for (const file of result.files) {
         const prefixedPath = prefix + file.path;
         // Last-writer-wins on path collisions

--- a/sdk/src/contracts.ts
+++ b/sdk/src/contracts.ts
@@ -22,10 +22,7 @@ const ALL_REPOS: ContractRepoInfo[] = [
  * and `GitHubSource.fetchContract` for the resolution rules. The repo's
  * visibility is stamped onto the result when it's a known descriptor.
  */
-export async function loadContract(
-  source: CatalogSource,
-  repo: ContractRepo,
-): Promise<Contract> {
+export async function loadContract(source: CatalogSource, repo: ContractRepo): Promise<Contract> {
   const content = await source.fetchContract(repo);
   const visibility = ALL_REPOS.find((r) => r.repo === repo)?.visibility;
   return visibility ? { repo, content, visibility } : { repo, content };

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -31,22 +31,14 @@ export type {
   VersionCurrencyStandard,
 } from './types.js';
 
-export type {
-  CatalogSource,
-  GitHubSourceOptions,
-  LocalSourceOptions,
-} from './source.js';
+export type { CatalogSource, GitHubSourceOptions, LocalSourceOptions } from './source.js';
 
 // Sources
 export { GitHubSource } from './sources/github.js';
 export { LocalSource } from './sources/local.js';
 
 // Errors
-export {
-  NanohypeError,
-  ManifestValidationError,
-  VariableResolutionError,
-} from './errors.js';
+export { NanohypeError, ManifestValidationError, VariableResolutionError } from './errors.js';
 
 // Functions
 export {

--- a/sdk/src/source.ts
+++ b/sdk/src/source.ts
@@ -8,13 +8,11 @@ import type {
   StandardName,
   SkeletonFile,
   TemplateManifest,
-} from "./types.js";
+} from './types.js';
 
 export interface CatalogSource {
   listTemplates(): Promise<CatalogEntry[]>;
-  fetchTemplate(
-    name: string,
-  ): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }>;
+  fetchTemplate(name: string): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }>;
   listComposites(): Promise<CompositeCatalogEntry[]>;
   fetchComposite(name: string): Promise<CompositeManifest>;
 

--- a/sdk/src/sources/github.ts
+++ b/sdk/src/sources/github.ts
@@ -1,4 +1,4 @@
-import yaml from "js-yaml";
+import yaml from 'js-yaml';
 import type {
   Catalog,
   CatalogEntry,
@@ -9,12 +9,12 @@ import type {
   Standard,
   StandardName,
   TemplateManifest,
-} from "../types.js";
-import type { CatalogSource, GitHubSourceOptions } from "../source.js";
-import { NanohypeError } from "../errors.js";
-import { isContractRepo } from "../contracts.js";
-import { isStandardName } from "../standards.js";
-import { isCatalogName } from "../validator.js";
+} from '../types.js';
+import type { CatalogSource, GitHubSourceOptions } from '../source.js';
+import { NanohypeError } from '../errors.js';
+import { isContractRepo } from '../contracts.js';
+import { isStandardName } from '../standards.js';
+import { isCatalogName } from '../validator.js';
 
 interface CacheEntry<T> {
   data: T;
@@ -36,15 +36,12 @@ async function mapConcurrent<T, R>(
 ): Promise<R[]> {
   const results = new Array<R>(items.length);
   let next = 0;
-  const workers = Array.from(
-    { length: Math.min(limit, items.length) },
-    async () => {
-      while (next < items.length) {
-        const i = next++;
-        results[i] = await fn(items[i]);
-      }
-    },
-  );
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i]);
+    }
+  });
   await Promise.all(workers);
   return results;
 }
@@ -63,12 +60,11 @@ export class GitHubSource implements CatalogSource {
   private readonly requestTimeout: number;
 
   private catalogCache: CacheEntry<CatalogEntry[]> | null = null;
-  private compositeCatalogCache: CacheEntry<CompositeCatalogEntry[]> | null =
-    null;
+  private compositeCatalogCache: CacheEntry<CompositeCatalogEntry[]> | null = null;
 
   constructor(options: GitHubSourceOptions = {}) {
-    this.repo = options.repo ?? "nanohype/nanohype";
-    this.ref = options.ref ?? "main";
+    this.repo = options.repo ?? 'nanohype/nanohype';
+    this.ref = options.ref ?? 'main';
     // Fall back to GITHUB_TOKEN so a private contract repo resolves with no caller
     // config when the env var is present.
     this.token = options.token ?? process.env.GITHUB_TOKEN;
@@ -78,7 +74,7 @@ export class GitHubSource implements CatalogSource {
 
   private headers(): Record<string, string> {
     const h: Record<string, string> = {
-      Accept: "application/vnd.github.v3+json",
+      Accept: 'application/vnd.github.v3+json',
     };
     if (this.token) h.Authorization = `Bearer ${this.token}`;
     return h;
@@ -91,10 +87,8 @@ export class GitHubSource implements CatalogSource {
         signal: AbortSignal.timeout(this.requestTimeout),
       });
     } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        throw new NanohypeError(
-          `GitHub request timed out after ${this.requestTimeout}ms: ${url}`,
-        );
+      if (err instanceof Error && err.name === 'TimeoutError') {
+        throw new NanohypeError(`GitHub request timed out after ${this.requestTimeout}ms: ${url}`);
       }
       throw err;
     }
@@ -114,19 +108,16 @@ export class GitHubSource implements CatalogSource {
     const res = await this.get(
       `https://api.github.com/repos/${this.repo}/contents/templates?ref=${this.ref}`,
     );
-    if (!res.ok)
-      throw new NanohypeError(`Failed to list catalog: ${res.status}`);
+    if (!res.ok) throw new NanohypeError(`Failed to list catalog: ${res.status}`);
 
     const dirs = (await res.json()) as { name: string; type: string }[];
-    const templateDirs = dirs.filter((d) => d.type === "dir");
+    const templateDirs = dirs.filter((d) => d.type === 'dir');
 
     const fetched = await mapConcurrent(
       templateDirs,
       FETCH_CONCURRENCY,
       async (dir): Promise<CatalogEntry | null> => {
-        const manifestRes = await this.get(
-          this.raw(`templates/${dir.name}/template.yaml`),
-        );
+        const manifestRes = await this.get(this.raw(`templates/${dir.name}/template.yaml`));
         // A directory without a template.yaml is not a template — skip it.
         // Anything else non-OK (rate limit, outage) must not silently shrink
         // the catalog.
@@ -172,17 +163,13 @@ export class GitHubSource implements CatalogSource {
     }
 
     // Fetch manifest
-    const manifestRes = await this.get(
-      this.raw(`templates/${name}/template.yaml`),
-    );
+    const manifestRes = await this.get(this.raw(`templates/${name}/template.yaml`));
     if (!manifestRes.ok) {
-      throw new NanohypeError(
-        `Template '${name}' not found: ${manifestRes.status}`,
-      );
+      throw new NanohypeError(`Template '${name}' not found: ${manifestRes.status}`);
     }
     const manifest = yaml.load(await manifestRes.text()) as TemplateManifest;
 
-    if (manifest.apiVersion !== "nanohype/v1") {
+    if (manifest.apiVersion !== 'nanohype/v1') {
       throw new NanohypeError(`Unsupported apiVersion: ${manifest.apiVersion}`);
     }
 
@@ -190,8 +177,7 @@ export class GitHubSource implements CatalogSource {
     const treeRes = await this.get(
       `https://api.github.com/repos/${this.repo}/git/trees/${this.ref}?recursive=1`,
     );
-    if (!treeRes.ok)
-      throw new NanohypeError(`Failed to fetch repo tree: ${treeRes.status}`);
+    if (!treeRes.ok) throw new NanohypeError(`Failed to fetch repo tree: ${treeRes.status}`);
 
     const tree = (await treeRes.json()) as {
       tree: { path: string; type: string; sha: string }[];
@@ -199,47 +185,37 @@ export class GitHubSource implements CatalogSource {
 
     const skeletonPrefix = `templates/${name}/skeleton/`;
     const skeletonBlobs = tree.tree.filter(
-      (entry) => entry.type === "blob" && entry.path.startsWith(skeletonPrefix),
+      (entry) => entry.type === 'blob' && entry.path.startsWith(skeletonPrefix),
     );
 
     // Fetch file contents. Any failure aborts the render — a skeleton with
     // holes is worse than no skeleton.
-    const files = await mapConcurrent(
-      skeletonBlobs,
-      FETCH_CONCURRENCY,
-      async (blob) => {
-        const fileRes = await this.get(this.raw(blob.path));
-        if (!fileRes.ok) {
-          throw new NanohypeError(
-            `Failed to fetch skeleton file '${blob.path}' for template '${name}': ${fileRes.status}`,
-          );
-        }
-        return {
-          path: blob.path.slice(skeletonPrefix.length),
-          content: await fileRes.text(),
-        } satisfies SkeletonFile;
-      },
-    );
+    const files = await mapConcurrent(skeletonBlobs, FETCH_CONCURRENCY, async (blob) => {
+      const fileRes = await this.get(this.raw(blob.path));
+      if (!fileRes.ok) {
+        throw new NanohypeError(
+          `Failed to fetch skeleton file '${blob.path}' for template '${name}': ${fileRes.status}`,
+        );
+      }
+      return {
+        path: blob.path.slice(skeletonPrefix.length),
+        content: await fileRes.text(),
+      } satisfies SkeletonFile;
+    });
 
     return { manifest, files };
   }
 
   async listComposites(): Promise<CompositeCatalogEntry[]> {
-    if (this.isFresh(this.compositeCatalogCache))
-      return this.compositeCatalogCache.data;
+    if (this.isFresh(this.compositeCatalogCache)) return this.compositeCatalogCache.data;
 
     const res = await this.get(
       `https://api.github.com/repos/${this.repo}/contents/composites?ref=${this.ref}`,
     );
-    if (!res.ok)
-      throw new NanohypeError(
-        `Failed to list composite catalog: ${res.status}`,
-      );
+    if (!res.ok) throw new NanohypeError(`Failed to list composite catalog: ${res.status}`);
 
     const items = (await res.json()) as { name: string; type: string }[];
-    const yamlFiles = items.filter(
-      (f) => f.type === "file" && f.name.endsWith(".yaml"),
-    );
+    const yamlFiles = items.filter((f) => f.type === 'file' && f.name.endsWith('.yaml'));
 
     const fetched = await mapConcurrent(
       yamlFiles,
@@ -260,7 +236,7 @@ export class GitHubSource implements CatalogSource {
             `Invalid composite manifest '${file.name}': ${err instanceof Error ? err.message : String(err)}`,
           );
         }
-        if (manifest.kind !== "composite") return null;
+        if (manifest.kind !== 'composite') return null;
         return {
           name: manifest.name,
           displayName: manifest.displayName,
@@ -271,9 +247,7 @@ export class GitHubSource implements CatalogSource {
         };
       },
     );
-    const entries = fetched.filter(
-      (e): e is CompositeCatalogEntry => e !== null,
-    );
+    const entries = fetched.filter((e): e is CompositeCatalogEntry => e !== null);
 
     this.compositeCatalogCache = { data: entries, fetchedAt: Date.now() };
     return entries;
@@ -281,31 +255,25 @@ export class GitHubSource implements CatalogSource {
 
   async fetchComposite(name: string): Promise<CompositeManifest> {
     if (!isCatalogName(name)) {
-      throw new NanohypeError(
-        `Invalid composite name: ${JSON.stringify(name)}`,
-      );
+      throw new NanohypeError(`Invalid composite name: ${JSON.stringify(name)}`);
     }
     const res = await this.get(this.raw(`composites/${name}.yaml`));
-    if (!res.ok)
-      throw new NanohypeError(`Composite '${name}' not found: ${res.status}`);
+    if (!res.ok) throw new NanohypeError(`Composite '${name}' not found: ${res.status}`);
     const manifest = yaml.load(await res.text()) as CompositeManifest;
 
-    if (manifest.apiVersion !== "nanohype/v1") {
+    if (manifest.apiVersion !== 'nanohype/v1') {
       throw new NanohypeError(`Unsupported apiVersion: ${manifest.apiVersion}`);
     }
-    if (manifest.kind !== "composite") {
-      throw new NanohypeError(
-        `Expected kind 'composite', got '${manifest.kind}'`,
-      );
+    if (manifest.kind !== 'composite') {
+      throw new NanohypeError(`Expected kind 'composite', got '${manifest.kind}'`);
     }
 
     return manifest;
   }
 
   async fetchCatalogManifest(): Promise<Catalog> {
-    const res = await this.get(this.raw("catalog.json"));
-    if (!res.ok)
-      throw new NanohypeError(`catalog.json not found: ${res.status}`);
+    const res = await this.get(this.raw('catalog.json'));
+    if (!res.ok) throw new NanohypeError(`catalog.json not found: ${res.status}`);
     return (await res.json()) as Catalog;
   }
 
@@ -315,8 +283,7 @@ export class GitHubSource implements CatalogSource {
       throw new NanohypeError(`Unknown standard: ${JSON.stringify(name)}`);
     }
     const res = await this.get(this.raw(`standards/${name}.json`));
-    if (!res.ok)
-      throw new NanohypeError(`Standard '${name}' not found: ${res.status}`);
+    if (!res.ok) throw new NanohypeError(`Standard '${name}' not found: ${res.status}`);
     return (await res.json()) as Standard;
   }
 
@@ -333,8 +300,8 @@ export class GitHubSource implements CatalogSource {
     // `<org>/<repo>`. Otherwise we still target the configured ref on the
     // explicit repo path (an MCP server pointed at a fork's `nanohype` will
     // pull contracts from the matching forked siblings, which is correct).
-    const [org] = this.repo.split("/");
-    const targetRepo = repo === "nanohype" ? this.repo : `${org}/${repo}`;
+    const [org] = this.repo.split('/');
+    const targetRepo = repo === 'nanohype' ? this.repo : `${org}/${repo}`;
 
     // With a token, resolve via the authenticated contents API — it works for
     // both public and private repos (raw.githubusercontent can't authenticate
@@ -345,29 +312,23 @@ export class GitHubSource implements CatalogSource {
         `https://api.github.com/repos/${targetRepo}/contents/AGENTS.md?ref=${this.ref}`,
       );
       if (!res.ok) {
-        throw new NanohypeError(
-          `AGENTS.md for repo '${repo}' not found: ${res.status}`,
-        );
+        throw new NanohypeError(`AGENTS.md for repo '${repo}' not found: ${res.status}`);
       }
       const body = (await res.json()) as {
         content?: string;
         encoding?: string;
       };
-      if (body.encoding === "base64" && body.content) {
-        return Buffer.from(body.content, "base64").toString("utf-8");
+      if (body.encoding === 'base64' && body.content) {
+        return Buffer.from(body.content, 'base64').toString('utf-8');
       }
-      throw new NanohypeError(
-        `AGENTS.md for repo '${repo}' returned an unexpected encoding`,
-      );
+      throw new NanohypeError(`AGENTS.md for repo '${repo}' returned an unexpected encoding`);
     }
 
     const res = await this.get(
       `https://raw.githubusercontent.com/${targetRepo}/${this.ref}/AGENTS.md`,
     );
     if (!res.ok) {
-      throw new NanohypeError(
-        `AGENTS.md for repo '${repo}' not found: ${res.status}`,
-      );
+      throw new NanohypeError(`AGENTS.md for repo '${repo}' not found: ${res.status}`);
     }
     return await res.text();
   }

--- a/sdk/src/standards.ts
+++ b/sdk/src/standards.ts
@@ -51,10 +51,7 @@ const EXPECTED_KIND: Record<StandardName, Standard['kind']> = {
  * so a misnamed or corrupted file fails fast rather than producing
  * confusing downstream errors.
  */
-export async function loadStandard(
-  source: CatalogSource,
-  name: StandardName,
-): Promise<Standard> {
+export async function loadStandard(source: CatalogSource, name: StandardName): Promise<Standard> {
   const standard = await source.fetchStandard(name);
   const expected = EXPECTED_KIND[name];
   if (standard.kind !== expected) {

--- a/standards/README.md
+++ b/standards/README.md
@@ -111,7 +111,7 @@ The canonical tag/label taxonomy every cloud resource and k8s object on the stac
 The taxonomy is three tiers:
 
 - **Required (10)** — the billing + ownership + security skeleton, auto-injected on every resource: `environment`, `managed-by`, `project`, `repository`, `cost-center`, `business-unit`, `data-classification`, `compliance`, `component`, `team`.
-- **Recommended (5)** — the *own / trace / expire* idiom: `owner` (escalation handle), `revision` (deployed source rev), `provisioner` (the factory job that created it), `lifecycle` (`ephemeral` | `persistent`), `expiry` (the date an ephemeral resource is reapable). All auto-derivable; `lifecycle`+`expiry` make orphan-reaping policy-driven, `provisioner`+`revision` carry provenance.
+- **Recommended (5)** — the _own / trace / expire_ idiom: `owner` (escalation handle), `revision` (deployed source rev), `provisioner` (the factory job that created it), `lifecycle` (`ephemeral` | `persistent`), `expiry` (the date an ephemeral resource is reapable). All auto-derivable; `lifecycle`+`expiry` make orphan-reaping policy-driven, `provisioner`+`revision` carry provenance.
 - **Contextual (4)** — applied only where meaningful: `tenant`, `platform` (per-tenant / per-app identity), `model-family`, `model-id` (AI-workload OTel only).
 
 Each dimension renders per surface by deterministic transform:
@@ -133,7 +133,7 @@ The bar for how every system is observed and what dashboard it ships to represen
 
 - **RED + USE + golden signals** — request-serving services expose Rate / Errors / Duration (latency as p50/p95/p99 from a histogram, never an average); saturable resources expose Utilization / Saturation / Errors. Panels and alerts query the **system's own nouns** (reconcile loop, vend pipeline, queue, model gateway, tofu run) — generic node/CPU dashboards and embedded community boards do not count as representing the system.
 - **At least one SLO per system** — an SLI (good/valid ratio) over a 30-day window against an objective. Default availability objective `0.999`; add a latency SLO for latency-sensitive paths. The remaining error budget is `(1 - objective)` minus what's been spent.
-- **Multi-window multi-burn-rate alerts** — alert on the *rate* the budget burns, not instantaneous error ratio. The canonical four windows: page at 14.4× (1h/5m) and 6× (6h/30m), ticket at 3× (1d/2h) and 1× (3d/6h). An alert fires only when both its long and short window exceed the burn-rate factor.
+- **Multi-window multi-burn-rate alerts** — alert on the _rate_ the budget burns, not instantaneous error ratio. The canonical four windows: page at 14.4× (1h/5m) and 6× (6h/30m), ticket at 3× (1d/2h) and 1× (3d/6h). An alert fires only when both its long and short window exceed the burn-rate factor.
 - **Recording-rule convention** — `<metric>:sli_error:ratio_rate<window>` over each window; burn-rate alerts reference these rather than recomputing inline.
 - **The required dashboard** — five rows: an SLO/error-budget row (30d SLI vs objective, budget remaining, fast/slow burn) plus traffic, errors, latency (p50/p95/p99), and saturation.
 

--- a/standards/observability-slo.json
+++ b/standards/observability-slo.json
@@ -34,10 +34,34 @@
       "method": "Multi-window, multi-burn-rate (Google SRE Workbook). An alert fires only when BOTH a long window and a short window exceed the burn-rate factor, which suppresses flapping and one-off spikes while still catching fast burns quickly.",
       "burn_rate_definition": "burn_rate = error_ratio_over_window / (1 - objective). A burn rate of 1 exhausts the whole budget exactly over the SLO window; a burn rate of 14.4 exhausts 2% of a 30d budget in 1h.",
       "windows": [
-        { "severity": "page", "long": "1h", "short": "5m", "factor": 14.4, "budget_consumed": "2% in 1h" },
-        { "severity": "page", "long": "6h", "short": "30m", "factor": 6, "budget_consumed": "5% in 6h" },
-        { "severity": "ticket", "long": "1d", "short": "2h", "factor": 3, "budget_consumed": "10% in 1d" },
-        { "severity": "ticket", "long": "3d", "short": "6h", "factor": 1, "budget_consumed": "10% in 3d" }
+        {
+          "severity": "page",
+          "long": "1h",
+          "short": "5m",
+          "factor": 14.4,
+          "budget_consumed": "2% in 1h"
+        },
+        {
+          "severity": "page",
+          "long": "6h",
+          "short": "30m",
+          "factor": 6,
+          "budget_consumed": "5% in 6h"
+        },
+        {
+          "severity": "ticket",
+          "long": "1d",
+          "short": "2h",
+          "factor": 3,
+          "budget_consumed": "10% in 1d"
+        },
+        {
+          "severity": "ticket",
+          "long": "3d",
+          "short": "6h",
+          "factor": 1,
+          "budget_consumed": "10% in 3d"
+        }
       ]
     },
     "recording_rules": {
@@ -46,11 +70,22 @@
     },
     "dashboard_requirements": {
       "required_rows": [
-        { "id": "slo", "panels": ["30d SLI vs objective (stat)", "error budget remaining (gauge)", "fast burn rate — 1h (stat/timeseries)", "slow burn rate — 6h (stat/timeseries)"] },
+        {
+          "id": "slo",
+          "panels": [
+            "30d SLI vs objective (stat)",
+            "error budget remaining (gauge)",
+            "fast burn rate — 1h (stat/timeseries)",
+            "slow burn rate — 6h (stat/timeseries)"
+          ]
+        },
         { "id": "traffic", "panels": ["request rate by status and/or route"] },
         { "id": "errors", "panels": ["error ratio (percentunit)", "errors by status/class"] },
         { "id": "latency", "panels": ["p50", "p95", "p99 from histogram_quantile"] },
-        { "id": "saturation", "panels": ["in-flight / queue depth / backlog", "resource utilization vs limit"] }
+        {
+          "id": "saturation",
+          "panels": ["in-flight / queue depth / backlog", "resource utilization vs limit"]
+        }
       ],
       "conventions": {
         "uid": "<system>-overview, or <system>-<facet> for additional boards",

--- a/standards/resource-tagging.json
+++ b/standards/resource-tagging.json
@@ -21,11 +21,7 @@
         "tenants.nanohype.dev/",
         "governance.nanohype.dev/"
       ],
-      "otel": [
-        "agents.",
-        "deployment.",
-        "service."
-      ],
+      "otel": ["agents.", "deployment.", "service."],
       "app_extension": {
         "k8s": "<app>.tenants.nanohype.dev/<key>",
         "aws": "app:<key>",
@@ -39,122 +35,274 @@
         "id": "environment",
         "tier": "required",
         "meaning": "Deploy stage: dev, staging, production, or org.",
-        "render": { "aws": "Environment", "azure": "Environment", "gcp": "environment", "k8s": "platform.nanohype.dev/environment", "otel": "deployment.environment" }
+        "render": {
+          "aws": "Environment",
+          "azure": "Environment",
+          "gcp": "environment",
+          "k8s": "platform.nanohype.dev/environment",
+          "otel": "deployment.environment"
+        }
       },
       {
         "id": "managed-by",
         "tier": "required",
         "meaning": "The tool that owns the resource lifecycle. Value: opentofu (substrate) or eks-agent-platform (operator-reconciled).",
-        "render": { "aws": "ManagedBy", "azure": "ManagedBy", "gcp": "managed_by", "k8s": "app.kubernetes.io/managed-by", "otel": null }
+        "render": {
+          "aws": "ManagedBy",
+          "azure": "ManagedBy",
+          "gcp": "managed_by",
+          "k8s": "app.kubernetes.io/managed-by",
+          "otel": null
+        }
       },
       {
         "id": "project",
         "tier": "required",
         "meaning": "The substrate project the resource belongs to. Value: landing-zone.",
-        "render": { "aws": "Project", "azure": "Project", "gcp": "project", "k8s": "platform.nanohype.dev/project", "otel": null }
+        "render": {
+          "aws": "Project",
+          "azure": "Project",
+          "gcp": "project",
+          "k8s": "platform.nanohype.dev/project",
+          "otel": null
+        }
       },
       {
         "id": "repository",
         "tier": "required",
         "meaning": "The source repository as org/name (e.g. nanohype/landing-zone).",
-        "render": { "aws": "Repository", "azure": "Repository", "gcp": "repository", "k8s": "platform.nanohype.dev/repository", "otel": null }
+        "render": {
+          "aws": "Repository",
+          "azure": "Repository",
+          "gcp": "repository",
+          "k8s": "platform.nanohype.dev/repository",
+          "otel": null
+        }
       },
       {
         "id": "cost-center",
         "tier": "required",
         "meaning": "Billing rollup unit (e.g. platform-engineering).",
-        "render": { "aws": "CostCenter", "azure": "CostCenter", "gcp": "cost_center", "k8s": "platform.nanohype.dev/cost-center", "otel": null }
+        "render": {
+          "aws": "CostCenter",
+          "azure": "CostCenter",
+          "gcp": "cost_center",
+          "k8s": "platform.nanohype.dev/cost-center",
+          "otel": null
+        }
       },
       {
         "id": "business-unit",
         "tier": "required",
         "meaning": "Organizational rollup above cost-center (e.g. engineering).",
-        "render": { "aws": "BusinessUnit", "azure": "BusinessUnit", "gcp": "business_unit", "k8s": "platform.nanohype.dev/business-unit", "otel": null }
+        "render": {
+          "aws": "BusinessUnit",
+          "azure": "BusinessUnit",
+          "gcp": "business_unit",
+          "k8s": "platform.nanohype.dev/business-unit",
+          "otel": null
+        }
       },
       {
         "id": "data-classification",
         "tier": "required",
         "meaning": "Data sensitivity: public, internal, confidential, or restricted.",
-        "render": { "aws": "DataClassification", "azure": "DataClassification", "gcp": "data_classification", "k8s": "platform.nanohype.dev/data-classification", "otel": null }
+        "render": {
+          "aws": "DataClassification",
+          "azure": "DataClassification",
+          "gcp": "data_classification",
+          "k8s": "platform.nanohype.dev/data-classification",
+          "otel": null
+        }
       },
       {
         "id": "compliance",
         "tier": "required",
         "meaning": "Compliance regime: soc2, hipaa, or none.",
-        "render": { "aws": "Compliance", "azure": "Compliance", "gcp": "compliance", "k8s": "platform.nanohype.dev/compliance", "otel": null }
+        "render": {
+          "aws": "Compliance",
+          "azure": "Compliance",
+          "gcp": "compliance",
+          "k8s": "platform.nanohype.dev/compliance",
+          "otel": null
+        }
       },
       {
         "id": "component",
         "tier": "required",
         "meaning": "The substrate component or workload role (network, cluster, llm, ...).",
-        "render": { "aws": "Component", "azure": "Component", "gcp": "component", "k8s": "app.kubernetes.io/component", "otel": null }
+        "render": {
+          "aws": "Component",
+          "azure": "Component",
+          "gcp": "component",
+          "k8s": "app.kubernetes.io/component",
+          "otel": null
+        }
       },
       {
         "id": "team",
         "tier": "required",
         "meaning": "The owning team that operates the resource (e.g. platform).",
-        "render": { "aws": "Team", "azure": "Team", "gcp": "team", "k8s": "platform.nanohype.dev/team", "otel": null }
+        "render": {
+          "aws": "Team",
+          "azure": "Team",
+          "gcp": "team",
+          "k8s": "platform.nanohype.dev/team",
+          "otel": null
+        }
       },
       {
         "id": "owner",
         "tier": "recommended",
         "meaning": "Accountable handle for escalation (a team or GitHub-team slug). Auto-filled from the env-level owner, defaulting to team when unset; never hand-entered per resource.",
-        "render": { "aws": "Owner", "azure": "Owner", "gcp": "owner", "k8s": "platform.nanohype.dev/owner", "otel": null }
+        "render": {
+          "aws": "Owner",
+          "azure": "Owner",
+          "gcp": "owner",
+          "k8s": "platform.nanohype.dev/owner",
+          "otel": null
+        }
       },
       {
         "id": "revision",
         "tier": "recommended",
         "meaning": "The deployed source revision (a short git SHA or chart appVersion) for provenance and rollback correlation.",
-        "render": { "aws": "Revision", "azure": "Revision", "gcp": "revision", "k8s": "app.kubernetes.io/version", "otel": "service.version" }
+        "render": {
+          "aws": "Revision",
+          "azure": "Revision",
+          "gcp": "revision",
+          "k8s": "app.kubernetes.io/version",
+          "otel": "service.version"
+        }
       },
       {
         "id": "provisioner",
         "tier": "recommended",
         "meaning": "The factory job or CI run that created the resource (a pipeline run id). Feeds provenance and attribution.",
-        "render": { "aws": "Provisioner", "azure": "Provisioner", "gcp": "provisioner", "k8s": "platform.nanohype.dev/provisioner", "otel": null }
+        "render": {
+          "aws": "Provisioner",
+          "azure": "Provisioner",
+          "gcp": "provisioner",
+          "k8s": "platform.nanohype.dev/provisioner",
+          "otel": null
+        }
       },
       {
         "id": "lifecycle",
         "tier": "recommended",
         "meaning": "Whether the resource is reapable: ephemeral or persistent. Ephemeral resources past their expiry are cleanup candidates.",
-        "render": { "aws": "Lifecycle", "azure": "Lifecycle", "gcp": "lifecycle", "k8s": "platform.nanohype.dev/lifecycle", "otel": null }
+        "render": {
+          "aws": "Lifecycle",
+          "azure": "Lifecycle",
+          "gcp": "lifecycle",
+          "k8s": "platform.nanohype.dev/lifecycle",
+          "otel": null
+        }
       },
       {
         "id": "expiry",
         "tier": "recommended",
         "meaning": "An ISO-8601 date (YYYY-MM-DD) after which an ephemeral resource is safe to reap. Set by the vend layer as now + ttl; omit on persistent resources.",
-        "render": { "aws": "Expiry", "azure": "Expiry", "gcp": "expiry", "k8s": "platform.nanohype.dev/expiry", "otel": null }
+        "render": {
+          "aws": "Expiry",
+          "azure": "Expiry",
+          "gcp": "expiry",
+          "k8s": "platform.nanohype.dev/expiry",
+          "otel": null
+        }
       },
       {
         "id": "tenant",
         "tier": "contextual",
         "meaning": "The Platform tenant a per-tenant resource belongs to. Applies only to multi-tenant components and per-tenant cloud resources.",
-        "render": { "aws": "Tenant", "azure": "Tenant", "gcp": "tenant", "k8s": "agents.nanohype.dev/tenant", "otel": "agents.tenant" }
+        "render": {
+          "aws": "Tenant",
+          "azure": "Tenant",
+          "gcp": "tenant",
+          "k8s": "agents.nanohype.dev/tenant",
+          "otel": "agents.tenant"
+        }
       },
       {
         "id": "platform",
         "tier": "contextual",
         "meaning": "The Platform CR name (the app). k8s and OTel only — never a cloud tag.",
-        "render": { "aws": null, "azure": null, "gcp": null, "k8s": "agents.nanohype.dev/platform", "otel": "agents.platform" }
+        "render": {
+          "aws": null,
+          "azure": null,
+          "gcp": null,
+          "k8s": "agents.nanohype.dev/platform",
+          "otel": "agents.platform"
+        }
       },
       {
         "id": "model-family",
         "tier": "contextual",
         "meaning": "The LLM family for AI workloads. OTel only — runtime cost attribution.",
-        "render": { "aws": null, "azure": null, "gcp": null, "k8s": null, "otel": "agents.model_family" }
+        "render": {
+          "aws": null,
+          "azure": null,
+          "gcp": null,
+          "k8s": null,
+          "otel": "agents.model_family"
+        }
       },
       {
         "id": "model-id",
         "tier": "contextual",
         "meaning": "The full Bedrock model id for AI workloads. OTel only — runtime cost attribution.",
-        "render": { "aws": null, "azure": null, "gcp": null, "k8s": null, "otel": "agents.model_id" }
+        "render": {
+          "aws": null,
+          "azure": null,
+          "gcp": null,
+          "k8s": null,
+          "otel": "agents.model_id"
+        }
       }
     ],
     "required_by_surface": {
-      "aws": ["Environment", "ManagedBy", "Project", "Repository", "CostCenter", "BusinessUnit", "DataClassification", "Compliance", "Component", "Team"],
-      "azure": ["Environment", "ManagedBy", "Project", "Repository", "CostCenter", "BusinessUnit", "DataClassification", "Compliance", "Component", "Team"],
-      "gcp": ["environment", "managed_by", "project", "repository", "cost_center", "business_unit", "data_classification", "compliance", "component", "team"],
-      "k8s": ["app.kubernetes.io/managed-by", "app.kubernetes.io/component", "platform.nanohype.dev/environment", "platform.nanohype.dev/team"],
+      "aws": [
+        "Environment",
+        "ManagedBy",
+        "Project",
+        "Repository",
+        "CostCenter",
+        "BusinessUnit",
+        "DataClassification",
+        "Compliance",
+        "Component",
+        "Team"
+      ],
+      "azure": [
+        "Environment",
+        "ManagedBy",
+        "Project",
+        "Repository",
+        "CostCenter",
+        "BusinessUnit",
+        "DataClassification",
+        "Compliance",
+        "Component",
+        "Team"
+      ],
+      "gcp": [
+        "environment",
+        "managed_by",
+        "project",
+        "repository",
+        "cost_center",
+        "business_unit",
+        "data_classification",
+        "compliance",
+        "component",
+        "team"
+      ],
+      "k8s": [
+        "app.kubernetes.io/managed-by",
+        "app.kubernetes.io/component",
+        "platform.nanohype.dev/environment",
+        "platform.nanohype.dev/team"
+      ],
       "otel": ["agents.tenant", "agents.platform"]
     }
   }

--- a/standards/version-currency.json
+++ b/standards/version-currency.json
@@ -36,10 +36,6 @@
       "kotlin": "Maven Central (search.maven.org)",
       "csharp": "NuGet (nuget.org)"
     },
-    "accepted_pin_reasons": [
-      "security hold",
-      "upstream bug",
-      "compatibility with pinned peer"
-    ]
+    "accepted_pin_reasons": ["security hold", "upstream bug", "compatibility with pinned peer"]
   }
 }

--- a/templates/a2a-agent/README.md
+++ b/templates/a2a-agent/README.md
@@ -13,14 +13,14 @@ Scaffolds an Agent-to-Agent (A2A) protocol peer in TypeScript.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `"An A2A protocol agent"` | Short project description |
-| `LlmProvider` | string | `"anthropic"` | LLM provider for agent reasoning |
-| `Transport` | string | `"http"` | A2A transport (`http` or `websocket`) |
-| `IncludeDiscovery` | bool | `true` | Include agent discovery and Agent Card |
-| `IncludeTests` | bool | `true` | Include test suite |
+| Variable           | Type   | Default                   | Description                            |
+| ------------------ | ------ | ------------------------- | -------------------------------------- |
+| `ProjectName`      | string | _(required)_              | Kebab-case project name                |
+| `Description`      | string | `"An A2A protocol agent"` | Short project description              |
+| `LlmProvider`      | string | `"anthropic"`             | LLM provider for agent reasoning       |
+| `Transport`        | string | `"http"`                  | A2A transport (`http` or `websocket`)  |
+| `IncludeDiscovery` | bool   | `true`                    | Include agent discovery and Agent Card |
+| `IncludeTests`     | bool   | `true`                    | Include test suite                     |
 
 ## Project layout
 

--- a/templates/a2a-agent/template.yaml
+++ b/templates/a2a-agent/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: a2a-agent
-displayName: "A2A Agent"
+displayName: 'A2A Agent'
 description: >
   Scaffolds an Agent-to-Agent (A2A) protocol peer in TypeScript. A2A is
   the open protocol for multi-agent interoperability — the agent-level
@@ -12,7 +12,7 @@ description: >
   and WebSocket transports, optional agent discovery with an Agent Card
   served at /.well-known/agent.json, and a pluggable provider registry
   for LLM backends.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -21,65 +21,65 @@ tags: [typescript, agent, a2a, multi-agent, protocol, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "An A2A protocol agent"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'An A2A protocol agent'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for agent reasoning"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for agent reasoning'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: Transport
     type: string
-    placeholder: "__TRANSPORT__"
-    description: "A2A transport protocol (http or websocket)"
-    prompt: "Transport"
-    default: "http"
+    placeholder: '__TRANSPORT__'
+    description: 'A2A transport protocol (http or websocket)'
+    prompt: 'Transport'
+    default: 'http'
 
   - name: IncludeDiscovery
     type: bool
-    placeholder: "__INCLUDE_DISCOVERY__"
-    description: "Include agent discovery registry and Agent Card at /.well-known/agent.json"
-    prompt: "Include agent discovery?"
+    placeholder: '__INCLUDE_DISCOVERY__'
+    description: 'Include agent discovery registry and Agent Card at /.well-known/agent.json'
+    prompt: 'Include agent discovery?'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test suite with Vitest"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test suite with Vitest'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/discovery/registry.ts"
+  - path: 'src/discovery/registry.ts'
     when: IncludeDiscovery
-  - path: "src/discovery/card.ts"
+  - path: 'src/discovery/card.ts'
     when: IncludeDiscovery
-  - path: "src/__tests__/skills.test.ts"
+  - path: 'src/__tests__/skills.test.ts'
     when: IncludeTests
-  - path: "src/__tests__/protocol.test.ts"
+  - path: 'src/__tests__/protocol.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [mcp-server-ts, agentic-loop, eval-harness]
@@ -87,6 +87,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/acceptance-criteria/README.md
+++ b/templates/acceptance-criteria/README.md
@@ -11,11 +11,11 @@ Scaffolds an acceptance criteria framework using Given/When/Then BDD structure w
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Format` | string | `gherkin` | Criteria format style |
-| `IncludeDoD` | bool | `true` | Include definition of done checklist |
+| Variable      | Type   | Default    | Description                          |
+| ------------- | ------ | ---------- | ------------------------------------ |
+| `ProjectName` | string | (required) | Kebab-case project name              |
+| `Format`      | string | `gherkin`  | Criteria format style                |
+| `IncludeDoD`  | bool   | `true`     | Include definition of done checklist |
 
 ## Project layout
 

--- a/templates/acceptance-criteria/template.yaml
+++ b/templates/acceptance-criteria/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: acceptance-criteria
-displayName: "Acceptance Criteria"
+displayName: 'Acceptance Criteria'
 description: >
   Scaffolds an acceptance criteria framework using Given/When/Then BDD
   structure. Includes a reusable template for writing criteria, example
   Gherkin feature files, and an optional definition of done checklist.
   Provides a consistent format for capturing expected behavior across
   features and user stories.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [qa]
 category: qa
@@ -17,30 +17,30 @@ tags: [testing, qa, bdd, gherkin, acceptance-criteria]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in document titles and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in document titles and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Format
     type: string
-    placeholder: "__FORMAT__"
-    description: "Criteria format style (e.g., gherkin, tabular, narrative)"
-    prompt: "Criteria format"
-    default: "gherkin"
+    placeholder: '__FORMAT__'
+    description: 'Criteria format style (e.g., gherkin, tabular, narrative)'
+    prompt: 'Criteria format'
+    default: 'gherkin'
 
   - name: IncludeDoD
     type: bool
-    placeholder: "__INCLUDE_DOD__"
-    description: "Include a definition of done checklist document"
-    prompt: "Include definition of done?"
+    placeholder: '__INCLUDE_DOD__'
+    description: 'Include a definition of done checklist document'
+    prompt: 'Include definition of done?'
     default: true
 
 conditionals:
-  - path: "criteria/definition-of-done.md"
+  - path: 'criteria/definition-of-done.md'
     when: IncludeDoD
 
 composition:

--- a/templates/agent-fleet/README.md
+++ b/templates/agent-fleet/README.md
@@ -12,15 +12,15 @@ Both CRs derive their namespace, ownership, and IRSA from the Platform via `spec
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `FleetName` | string | (required) | AgentFleet CR name + label selector |
-| `Tenant` | string | (required) | Owning team — sets the `tenants-<team>` namespace, matching the Platform |
-| `AppName` | string | (required) | Companion Platform tenant name (matches `k8s-app-tenant`'s `AppName`); used as `spec.platformRef.name` |
-| `ModelFamily` | string | `anthropic` | Bedrock model family for the gateway route — `anthropic`, `meta`, `mistral`, `cohere`, `amazon-titan`, `amazon-nova`, `stability` |
-| `ModelId` | string | `anthropic.claude-sonnet-4-6` | Bedrock model ID (or inference-profile ID) for the gateway route |
-| `RouteName` | string | (required) | ModelGateway route name referenced by each `AgentFleet.spec.agents[].modelRoute` |
-| `Compute` | string | `none` | Accelerator — `none` (CPU), `nvidia-l40s`, `nvidia-h100`, `neuron`. Non-`none` references an `AcceleratorClaim` CR by name |
+| Variable      | Type   | Default                       | Description                                                                                                                       |
+| ------------- | ------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `FleetName`   | string | (required)                    | AgentFleet CR name + label selector                                                                                               |
+| `Tenant`      | string | (required)                    | Owning team — sets the `tenants-<team>` namespace, matching the Platform                                                          |
+| `AppName`     | string | (required)                    | Companion Platform tenant name (matches `k8s-app-tenant`'s `AppName`); used as `spec.platformRef.name`                            |
+| `ModelFamily` | string | `anthropic`                   | Bedrock model family for the gateway route — `anthropic`, `meta`, `mistral`, `cohere`, `amazon-titan`, `amazon-nova`, `stability` |
+| `ModelId`     | string | `anthropic.claude-sonnet-4-6` | Bedrock model ID (or inference-profile ID) for the gateway route                                                                  |
+| `RouteName`   | string | (required)                    | ModelGateway route name referenced by each `AgentFleet.spec.agents[].modelRoute`                                                  |
+| `Compute`     | string | `none`                        | Accelerator — `none` (CPU), `nvidia-l40s`, `nvidia-h100`, `neuron`. Non-`none` references an `AcceleratorClaim` CR by name        |
 
 ## Project layout
 

--- a/templates/agent-fleet/template.yaml
+++ b/templates/agent-fleet/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: agent-fleet
-displayName: "Agent Fleet (kagent + AgentFleet CR)"
+displayName: 'Agent Fleet (kagent + AgentFleet CR)'
 description: >
   Scaffolds the AI-workload composite on top of a Platform tenant.
   Produces an AgentFleet CR (agents.nanohype.dev/v1alpha1) composing
@@ -10,7 +10,7 @@ description: >
   model resolution and Guardrails. Pairs with k8s-app-tenant — the
   Platform CR there owns the tenant boundary; this composes the AI
   pieces inside that boundary.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -19,67 +19,67 @@ tags: [kubernetes, kagent, bedrock, agents, agentgateway, keda, nanohype]
 variables:
   - name: FleetName
     type: string
-    placeholder: "__FLEET_NAME__"
-    description: "Kebab-case fleet name — used as AgentFleet CR name and label selector."
-    prompt: "Fleet name"
+    placeholder: '__FLEET_NAME__'
+    description: 'Kebab-case fleet name — used as AgentFleet CR name and label selector.'
+    prompt: 'Fleet name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Tenant
     type: string
-    placeholder: "__TENANT__"
+    placeholder: '__TENANT__'
     description: "Owning team — must match the Platform CR's spec.tenant."
-    prompt: "Owning team"
+    prompt: 'Owning team'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: AppName
     type: string
-    placeholder: "__APP_NAME__"
+    placeholder: '__APP_NAME__'
     description: "Companion Platform tenant name (matches k8s-app-tenant's AppName)."
-    prompt: "Platform tenant app name"
+    prompt: 'Platform tenant app name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: ModelFamily
     type: string
-    placeholder: "__MODEL_FAMILY__"
-    description: "Bedrock model family for the ModelGateway route. One of: anthropic, meta, mistral, cohere, amazon-titan, amazon-nova, stability."
-    prompt: "Model family"
-    default: "anthropic"
+    placeholder: '__MODEL_FAMILY__'
+    description: 'Bedrock model family for the ModelGateway route. One of: anthropic, meta, mistral, cohere, amazon-titan, amazon-nova, stability.'
+    prompt: 'Model family'
+    default: 'anthropic'
     validation:
-      pattern: "^(anthropic|meta|mistral|cohere|amazon-titan|amazon-nova|stability)$"
-      message: "Must be a Bedrock model family the operator accepts"
+      pattern: '^(anthropic|meta|mistral|cohere|amazon-titan|amazon-nova|stability)$'
+      message: 'Must be a Bedrock model family the operator accepts'
 
   - name: ModelId
     type: string
-    placeholder: "__MODEL_ID__"
-    description: "Bedrock model ID (full path including version)."
-    prompt: "Bedrock model ID"
-    default: "anthropic.claude-sonnet-4-6"
+    placeholder: '__MODEL_ID__'
+    description: 'Bedrock model ID (full path including version).'
+    prompt: 'Bedrock model ID'
+    default: 'anthropic.claude-sonnet-4-6'
 
   - name: RouteName
     type: string
-    placeholder: "__ROUTE_NAME__"
-    description: "ModelGateway route name. Referenced by each AgentFleet.spec.agents[].modelRoute."
-    prompt: "Model route name"
+    placeholder: '__ROUTE_NAME__'
+    description: 'ModelGateway route name. Referenced by each AgentFleet.spec.agents[].modelRoute.'
+    prompt: 'Model route name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: Compute
     type: string
-    placeholder: "__COMPUTE__"
-    description: "Accelerator class. Options: none (CPU-only), nvidia-l40s, nvidia-h100, neuron (Trn/Inf instances)."
-    prompt: "Accelerator class"
-    default: "none"
+    placeholder: '__COMPUTE__'
+    description: 'Accelerator class. Options: none (CPU-only), nvidia-l40s, nvidia-h100, neuron (Trn/Inf instances).'
+    prompt: 'Accelerator class'
+    default: 'none'
 
 conditionals: []
 
@@ -89,8 +89,8 @@ composition:
 
 prerequisites:
   - name: kubectl
-    version: ">=1.28"
-    purpose: "Apply the AgentFleet and ModelGateway CRs during initial setup"
+    version: '>=1.28'
+    purpose: 'Apply the AgentFleet and ModelGateway CRs during initial setup'
     optional: false
 
 hooks: {}

--- a/templates/agent-orchestrator/README.md
+++ b/templates/agent-orchestrator/README.md
@@ -14,12 +14,12 @@ Multi-agent orchestrator with task decomposition, capability-based routing, and 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `Multi-agent orchestrator` | Short project description |
-| `LlmProvider` | string | `anthropic` | `anthropic` or `openai` |
-| `IncludeTests` | bool | `true` | Include test suite |
+| Variable       | Type   | Default                    | Description               |
+| -------------- | ------ | -------------------------- | ------------------------- |
+| `ProjectName`  | string | _(required)_               | Kebab-case project name   |
+| `Description`  | string | `Multi-agent orchestrator` | Short project description |
+| `LlmProvider`  | string | `anthropic`                | `anthropic` or `openai`   |
+| `IncludeTests` | bool   | `true`                     | Include test suite        |
 
 ## Project layout
 

--- a/templates/agent-orchestrator/template.yaml
+++ b/templates/agent-orchestrator/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: agent-orchestrator
-displayName: "Agent Orchestrator"
+displayName: 'Agent Orchestrator'
 description: >
   Multi-agent orchestrator that decomposes tasks via an LLM-powered
   planner agent, routes subtasks to specialized agents based on
@@ -9,7 +9,7 @@ description: >
   through a shared context with namespacing and a handoff protocol
   that creates an audit trail of agent-to-agent transitions. Supports
   Anthropic and OpenAI as LLM providers for orchestration reasoning.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -18,51 +18,51 @@ tags: [typescript, agent, orchestrator, multi-agent, llm, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Multi-agent orchestrator"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Multi-agent orchestrator'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for orchestration reasoning"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for orchestration reasoning'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include the test suite"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include the test suite'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/orchestrator/__tests__/orchestrator.test.ts"
+  - path: 'src/orchestrator/__tests__/orchestrator.test.ts'
     when: IncludeTests
-  - path: "src/orchestrator/__tests__/routing.test.ts"
+  - path: 'src/orchestrator/__tests__/routing.test.ts'
     when: IncludeTests
-  - path: "src/orchestrator/__tests__/context.test.ts"
+  - path: 'src/orchestrator/__tests__/context.test.ts'
     when: IncludeTests
-  - path: "src/orchestrator/resilience/__tests__/circuit-breaker.test.ts"
+  - path: 'src/orchestrator/resilience/__tests__/circuit-breaker.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, mcp-server-ts, rag-pipeline]
@@ -70,6 +70,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/agentic-loop/README.md
+++ b/templates/agentic-loop/README.md
@@ -12,14 +12,14 @@ Scaffolds a TypeScript agentic loop — the core pattern behind tool-calling AI 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `"An agentic loop powered by LLM tool-calling"` | Short project description |
-| `LlmProvider` | string | `"anthropic"` | `anthropic` or `openai` |
-| `IncludeMemory` | bool | `true` | Include memory subsystem |
-| `IncludeEval` | bool | `true` | Include eval harness |
-| `MaxIterations` | int | `10` | Max tool-calling loop iterations |
+| Variable        | Type   | Default                                         | Description                      |
+| --------------- | ------ | ----------------------------------------------- | -------------------------------- |
+| `ProjectName`   | string | _(required)_                                    | Kebab-case project name          |
+| `Description`   | string | `"An agentic loop powered by LLM tool-calling"` | Short project description        |
+| `LlmProvider`   | string | `"anthropic"`                                   | `anthropic` or `openai`          |
+| `IncludeMemory` | bool   | `true`                                          | Include memory subsystem         |
+| `IncludeEval`   | bool   | `true`                                          | Include eval harness             |
+| `MaxIterations` | int    | `10`                                            | Max tool-calling loop iterations |
 
 ## Project layout
 

--- a/templates/agentic-loop/template.yaml
+++ b/templates/agentic-loop/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: agentic-loop
-displayName: "Agentic Loop"
+displayName: 'Agentic Loop'
 description: >
   Scaffolds a TypeScript agentic loop that sends messages to an LLM,
   detects tool-call requests in the response, executes them via a typed
@@ -10,7 +10,7 @@ description: >
   OpenAI as LLM providers, an optional conversation memory subsystem
   with token-aware truncation, and an optional eval harness for
   assertion-based testing against fixture files.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -19,69 +19,69 @@ tags: [typescript, agent, llm, tools, agentic, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "An agentic loop powered by LLM tool-calling"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'An agentic loop powered by LLM tool-calling'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider to use for the agent"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider to use for the agent'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeMemory
     type: bool
-    placeholder: "__INCLUDE_MEMORY__"
-    description: "Include the conversation memory subsystem with token-aware truncation"
-    prompt: "Include memory subsystem?"
+    placeholder: '__INCLUDE_MEMORY__'
+    description: 'Include the conversation memory subsystem with token-aware truncation'
+    prompt: 'Include memory subsystem?'
     default: true
 
   - name: IncludeEval
     type: bool
-    placeholder: "__INCLUDE_EVAL__"
-    description: "Include the eval harness for assertion-based agent testing"
-    prompt: "Include eval harness?"
+    placeholder: '__INCLUDE_EVAL__'
+    description: 'Include the eval harness for assertion-based agent testing'
+    prompt: 'Include eval harness?'
     default: true
 
   - name: MaxIterations
     type: int
-    placeholder: "__MAX_ITERATIONS__"
-    description: "Maximum number of tool-calling loop iterations before the agent stops"
-    prompt: "Max loop iterations"
+    placeholder: '__MAX_ITERATIONS__'
+    description: 'Maximum number of tool-calling loop iterations before the agent stops'
+    prompt: 'Max loop iterations'
     default: 10
 
 conditionals:
-  - path: "src/memory/store.ts"
+  - path: 'src/memory/store.ts'
     when: IncludeMemory
-  - path: "src/memory/context.ts"
+  - path: 'src/memory/context.ts'
     when: IncludeMemory
-  - path: "src/memory/conversation.ts"
+  - path: 'src/memory/conversation.ts'
     when: IncludeMemory
-  - path: "src/eval/runner.ts"
+  - path: 'src/eval/runner.ts'
     when: IncludeEval
-  - path: "src/eval/assertions.ts"
+  - path: 'src/eval/assertions.ts'
     when: IncludeEval
-  - path: "src/eval/fixtures/.gitkeep"
+  - path: 'src/eval/fixtures/.gitkeep'
     when: IncludeEval
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [mcp-server-ts, eval-harness, rag-pipeline]
@@ -89,6 +89,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/api-gateway/README.md
+++ b/templates/api-gateway/README.md
@@ -16,12 +16,12 @@ API gateway with edge routing, per-route authentication, rate limiting, traffic 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `API gateway with routing, auth, and rate limiting` | Project description |
-| `Framework` | string | `hono` | HTTP framework |
-| `IncludeTests` | bool | `true` | Include test suite |
+| Variable       | Type   | Default                                             | Description             |
+| -------------- | ------ | --------------------------------------------------- | ----------------------- |
+| `ProjectName`  | string | --                                                  | Kebab-case project name |
+| `Description`  | string | `API gateway with routing, auth, and rate limiting` | Project description     |
+| `Framework`    | string | `hono`                                              | HTTP framework          |
+| `IncludeTests` | bool   | `true`                                              | Include test suite      |
 
 ## Project layout
 

--- a/templates/api-gateway/template.yaml
+++ b/templates/api-gateway/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: api-gateway
-displayName: "API Gateway"
+displayName: 'API Gateway'
 description: >
   Scaffolds an API gateway with edge routing, per-route auth and rate
   limiting, traffic management (canary splits, health checking), and
   per-upstream circuit breakers. Built on Hono with native fetch proxying,
   JWT/API key validation via jose, and OpenTelemetry instrumentation.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -16,53 +16,53 @@ tags: [typescript, hono, api-gateway, proxy, rate-limit, auth]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "API gateway with routing, auth, and rate limiting"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'API gateway with routing, auth, and rate limiting'
 
   - name: Framework
     type: string
-    placeholder: "__FRAMEWORK__"
-    description: "HTTP framework (hono is default; extensible to express, fastify)"
-    prompt: "HTTP framework"
-    default: "hono"
+    placeholder: '__FRAMEWORK__'
+    description: 'HTTP framework (hono is default; extensible to express, fastify)'
+    prompt: 'HTTP framework'
+    default: 'hono'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test suite for gateway components"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test suite for gateway components'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/gateway/__tests__/proxy.test.ts"
+  - path: 'src/gateway/__tests__/proxy.test.ts'
     when: IncludeTests
-  - path: "src/gateway/__tests__/matcher.test.ts"
+  - path: 'src/gateway/__tests__/matcher.test.ts'
     when: IncludeTests
-  - path: "src/gateway/__tests__/rate-limit.test.ts"
+  - path: 'src/gateway/__tests__/rate-limit.test.ts'
     when: IncludeTests
-  - path: "src/gateway/__tests__/canary.test.ts"
+  - path: 'src/gateway/__tests__/canary.test.ts'
     when: IncludeTests
-  - path: "src/gateway/__tests__/registry.test.ts"
+  - path: 'src/gateway/__tests__/registry.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [infra-aws, infra-fly, module-auth-ts, module-rate-limit-ts, module-cache-ts]
@@ -70,6 +70,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the API gateway"
+    version: '>=22'
+    purpose: 'Node.js runtime for the API gateway'
     optional: false

--- a/templates/battle-cards/README.md
+++ b/templates/battle-cards/README.md
@@ -11,11 +11,11 @@ Scaffolds a competitive intelligence package with feature comparison matrices, p
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `CompetitorCount` | int | `3` | Number of competitor slots |
-| `IncludeObjections` | bool | `true` | Include objection handling |
+| Variable            | Type   | Default    | Description                |
+| ------------------- | ------ | ---------- | -------------------------- |
+| `ProjectName`       | string | (required) | Kebab-case project name    |
+| `CompetitorCount`   | int    | `3`        | Number of competitor slots |
+| `IncludeObjections` | bool   | `true`     | Include objection handling |
 
 ## Project layout
 

--- a/templates/battle-cards/template.yaml
+++ b/templates/battle-cards/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: battle-cards
-displayName: "Competitive Battle Cards"
+displayName: 'Competitive Battle Cards'
 description: >
   Scaffolds a competitive intelligence package with feature comparison
   matrices, positioning statements, win/loss analysis templates, and
   objection handling guides. Gives sales and marketing teams structured
   ammunition for competitive deals.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [sales]
 category: sales
@@ -16,30 +16,30 @@ tags: [competitive, battle-cards, sales, positioning, objections]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: CompetitorCount
     type: int
-    placeholder: "__COMPETITOR_COUNT__"
-    description: "Number of competitor slots in the comparison matrix"
-    prompt: "Number of competitors"
+    placeholder: '__COMPETITOR_COUNT__'
+    description: 'Number of competitor slots in the comparison matrix'
+    prompt: 'Number of competitors'
     default: 3
 
   - name: IncludeObjections
     type: bool
-    placeholder: "__INCLUDE_OBJECTIONS__"
-    description: "Include an objection handling guide"
-    prompt: "Include objection handling?"
+    placeholder: '__INCLUDE_OBJECTIONS__'
+    description: 'Include an objection handling guide'
+    prompt: 'Include objection handling?'
     default: true
 
 conditionals:
-  - path: "cards/objection-handling.md"
+  - path: 'cards/objection-handling.md'
     when: IncludeObjections
 
 composition:

--- a/templates/brand-guidelines/README.md
+++ b/templates/brand-guidelines/README.md
@@ -11,11 +11,11 @@ Brand guideline documentation covering color palette definitions, typography sca
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `BrandName` | string | (required) | Display name of the brand |
-| `IncludeVoiceTone` | bool | `true` | Include voice and tone guidelines |
+| Variable           | Type   | Default    | Description                       |
+| ------------------ | ------ | ---------- | --------------------------------- |
+| `ProjectName`      | string | (required) | Kebab-case project name           |
+| `BrandName`        | string | (required) | Display name of the brand         |
+| `IncludeVoiceTone` | bool   | `true`     | Include voice and tone guidelines |
 
 ## Project layout
 

--- a/templates/brand-guidelines/template.yaml
+++ b/templates/brand-guidelines/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: brand-guidelines
-displayName: "Brand Guidelines"
+displayName: 'Brand Guidelines'
 description: >
   Scaffolds brand guideline documentation covering color palette definitions,
   typography scale, logo usage rules, and optional voice and tone guidelines.
   Provides a structured reference for maintaining brand consistency across
   all touchpoints and teams.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [design]
 category: design
@@ -16,30 +16,30 @@ tags: [brand, guidelines, typography, color, voice-tone]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as directory and reference identifier"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as directory and reference identifier'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: BrandName
     type: string
-    placeholder: "__BRAND_NAME__"
-    description: "Display name of the brand, used in guidelines and documentation"
-    prompt: "Brand name"
+    placeholder: '__BRAND_NAME__'
+    description: 'Display name of the brand, used in guidelines and documentation'
+    prompt: 'Brand name'
     required: true
 
   - name: IncludeVoiceTone
     type: bool
-    placeholder: "__INCLUDE_VOICE_TONE__"
-    description: "Include voice and tone guidelines for written content"
-    prompt: "Include voice and tone guidelines?"
+    placeholder: '__INCLUDE_VOICE_TONE__'
+    description: 'Include voice and tone guidelines for written content'
+    prompt: 'Include voice and tone guidelines?'
     default: true
 
 conditionals:
-  - path: "brand/voice-tone.md"
+  - path: 'brand/voice-tone.md'
     when: IncludeVoiceTone
 
 composition:

--- a/templates/brief-campaign-plan/README.md
+++ b/templates/brief-campaign-plan/README.md
@@ -13,13 +13,13 @@ Scaffolds an agent brief for producing a marketing campaign plan. The rendered b
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Internal project name |
-| `CampaignGoal` | string | (required) | Primary campaign objective |
-| `TargetAudience` | string | (required) | Target audience segments |
-| `Budget` | string | `""` | Total campaign budget or range |
-| `Timeline` | string | `""` | Campaign duration or key dates |
+| Variable         | Type   | Default    | Description                    |
+| ---------------- | ------ | ---------- | ------------------------------ |
+| `ProjectName`    | string | (required) | Internal project name          |
+| `CampaignGoal`   | string | (required) | Primary campaign objective     |
+| `TargetAudience` | string | (required) | Target audience segments       |
+| `Budget`         | string | `""`       | Total campaign budget or range |
+| `Timeline`       | string | `""`       | Campaign duration or key dates |
 
 ## Project layout
 

--- a/templates/brief-campaign-plan/template.yaml
+++ b/templates/brief-campaign-plan/template.yaml
@@ -2,14 +2,14 @@ apiVersion: nanohype/v1
 kind: brief
 
 name: brief-campaign-plan
-displayName: "Campaign Plan Brief"
+displayName: 'Campaign Plan Brief'
 description: >
   Scaffolds an agent brief for producing a marketing campaign plan.
   The rendered brief instructs an agent to define campaign strategy,
   identify distribution channels, craft messaging pillars, set KPIs
   and measurement criteria, and produce a structured campaign plan
   with timeline and budget allocation.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [marketing]
 category: marketing
@@ -18,38 +18,38 @@ tags: [brief, campaign, marketing, strategy, kpi]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Internal project name for the campaign"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Internal project name for the campaign'
+    prompt: 'Project name'
     required: true
 
   - name: CampaignGoal
     type: string
-    placeholder: "__CAMPAIGN_GOAL__"
-    description: "Primary objective of the campaign (awareness, acquisition, retention, launch)"
-    prompt: "Campaign goal"
+    placeholder: '__CAMPAIGN_GOAL__'
+    description: 'Primary objective of the campaign (awareness, acquisition, retention, launch)'
+    prompt: 'Campaign goal'
     required: true
 
   - name: TargetAudience
     type: string
-    placeholder: "__TARGET_AUDIENCE__"
-    description: "Target audience segments for the campaign"
-    prompt: "Target audience"
+    placeholder: '__TARGET_AUDIENCE__'
+    description: 'Target audience segments for the campaign'
+    prompt: 'Target audience'
     required: true
 
   - name: Budget
     type: string
-    placeholder: "__BUDGET__"
-    description: "Total campaign budget or budget range"
-    prompt: "Budget"
-    default: ""
+    placeholder: '__BUDGET__'
+    description: 'Total campaign budget or budget range'
+    prompt: 'Budget'
+    default: ''
 
   - name: Timeline
     type: string
-    placeholder: "__TIMELINE__"
-    description: "Campaign duration or key dates"
-    prompt: "Timeline"
-    default: ""
+    placeholder: '__TIMELINE__'
+    description: 'Campaign duration or key dates'
+    prompt: 'Timeline'
+    default: ''
 
 composition:
   pairsWith: [campaign-brief, content-calendar]

--- a/templates/brief-design-review/README.md
+++ b/templates/brief-design-review/README.md
@@ -12,12 +12,12 @@ Scaffolds an agent brief for conducting a comprehensive design review. The rende
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Name of the project under review |
-| `DesignSystemUrl` | string | `""` | URL to the design system documentation or Figma library |
-| `TargetPlatform` | string | `web` | Primary platform being reviewed |
-| `AuditScope` | string | `full` | Scope of the review |
+| Variable          | Type   | Default    | Description                                             |
+| ----------------- | ------ | ---------- | ------------------------------------------------------- |
+| `ProjectName`     | string | (required) | Name of the project under review                        |
+| `DesignSystemUrl` | string | `""`       | URL to the design system documentation or Figma library |
+| `TargetPlatform`  | string | `web`      | Primary platform being reviewed                         |
+| `AuditScope`      | string | `full`     | Scope of the review                                     |
 
 ## Project layout
 

--- a/templates/brief-design-review/template.yaml
+++ b/templates/brief-design-review/template.yaml
@@ -2,14 +2,14 @@ apiVersion: nanohype/v1
 kind: brief
 
 name: brief-design-review
-displayName: "Design Review Brief"
+displayName: 'Design Review Brief'
 description: >
   Scaffolds an agent brief for conducting a comprehensive design review.
   The rendered brief instructs an agent to audit visual consistency, design
   token coverage, accessibility compliance, and component-level coherence
   against a design system. Produces a structured findings report with
   prioritized recommendations.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [design]
 category: design
@@ -18,31 +18,31 @@ tags: [brief, design-review, accessibility, design-system, audit]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Name of the project under review"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Name of the project under review'
+    prompt: 'Project name'
     required: true
 
   - name: DesignSystemUrl
     type: string
-    placeholder: "__DESIGN_SYSTEM_URL__"
-    description: "URL to the design system documentation or Figma library"
-    prompt: "Design system URL"
-    default: ""
+    placeholder: '__DESIGN_SYSTEM_URL__'
+    description: 'URL to the design system documentation or Figma library'
+    prompt: 'Design system URL'
+    default: ''
 
   - name: TargetPlatform
     type: string
-    placeholder: "__TARGET_PLATFORM__"
-    description: "Primary platform being reviewed (web, ios, android, cross-platform)"
-    prompt: "Target platform"
-    default: "web"
+    placeholder: '__TARGET_PLATFORM__'
+    description: 'Primary platform being reviewed (web, ios, android, cross-platform)'
+    prompt: 'Target platform'
+    default: 'web'
 
   - name: AuditScope
     type: string
-    placeholder: "__AUDIT_SCOPE__"
-    description: "Scope of the review (full, component-only, page-level, token-audit)"
-    prompt: "Audit scope"
-    default: "full"
+    placeholder: '__AUDIT_SCOPE__'
+    description: 'Scope of the review (full, component-only, page-level, token-audit)'
+    prompt: 'Audit scope'
+    default: 'full'
 
 composition:
   pairsWith: [design-system, design-tokens, component-inventory]

--- a/templates/brief-onboarding-playbook/README.md
+++ b/templates/brief-onboarding-playbook/README.md
@@ -14,13 +14,13 @@ Scaffolds an agent brief for producing a customer onboarding playbook. The rende
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Internal project name |
-| `ProductName` | string | (required) | Customer-facing product name |
-| `OnboardingModel` | string | `guided` | Onboarding approach |
-| `TimeToValue` | string | `30 days` | Target time to first value realization |
-| `KeyMilestones` | string | `""` | Comma-separated key milestones |
+| Variable          | Type   | Default    | Description                            |
+| ----------------- | ------ | ---------- | -------------------------------------- |
+| `ProjectName`     | string | (required) | Internal project name                  |
+| `ProductName`     | string | (required) | Customer-facing product name           |
+| `OnboardingModel` | string | `guided`   | Onboarding approach                    |
+| `TimeToValue`     | string | `30 days`  | Target time to first value realization |
+| `KeyMilestones`   | string | `""`       | Comma-separated key milestones         |
 
 ## Project layout
 

--- a/templates/brief-onboarding-playbook/template.yaml
+++ b/templates/brief-onboarding-playbook/template.yaml
@@ -2,14 +2,14 @@ apiVersion: nanohype/v1
 kind: brief
 
 name: brief-onboarding-playbook
-displayName: "Onboarding Playbook Brief"
+displayName: 'Onboarding Playbook Brief'
 description: >
   Scaffolds an agent brief for producing a customer onboarding playbook.
   The rendered brief instructs an agent to define onboarding stages,
   set milestone criteria, create health scoring rubrics, design
   intervention triggers, and produce a playbook that guides
   customer success teams from signup through time-to-value.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [customer-success]
 category: customer-success
@@ -18,38 +18,38 @@ tags: [brief, onboarding, customer-success, playbook, milestones]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Internal project name"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Internal project name'
+    prompt: 'Project name'
     required: true
 
   - name: ProductName
     type: string
-    placeholder: "__PRODUCT_NAME__"
-    description: "Customer-facing product name"
-    prompt: "Product name"
+    placeholder: '__PRODUCT_NAME__'
+    description: 'Customer-facing product name'
+    prompt: 'Product name'
     required: true
 
   - name: OnboardingModel
     type: string
-    placeholder: "__ONBOARDING_MODEL__"
-    description: "Onboarding approach (guided, self-serve, hybrid, white-glove)"
-    prompt: "Onboarding model"
-    default: "guided"
+    placeholder: '__ONBOARDING_MODEL__'
+    description: 'Onboarding approach (guided, self-serve, hybrid, white-glove)'
+    prompt: 'Onboarding model'
+    default: 'guided'
 
   - name: TimeToValue
     type: string
-    placeholder: "__TIME_TO_VALUE__"
-    description: "Target duration from signup to first value realization"
-    prompt: "Time to value"
-    default: "30 days"
+    placeholder: '__TIME_TO_VALUE__'
+    description: 'Target duration from signup to first value realization'
+    prompt: 'Time to value'
+    default: '30 days'
 
   - name: KeyMilestones
     type: string
-    placeholder: "__KEY_MILESTONES__"
-    description: "Comma-separated key milestones customers should hit"
-    prompt: "Key milestones"
-    default: ""
+    placeholder: '__KEY_MILESTONES__'
+    description: 'Comma-separated key milestones customers should hit'
+    prompt: 'Key milestones'
+    default: ''
 
 composition:
   pairsWith: [onboarding-playbook, qbr-template]

--- a/templates/brief-prd/README.md
+++ b/templates/brief-prd/README.md
@@ -13,13 +13,13 @@ Scaffolds an agent brief for drafting a product requirements document. The rende
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Internal project codename |
-| `ProductName` | string | (required) | Customer-facing product name |
-| `ProblemStatement` | string | (required) | Core problem this product addresses |
-| `TargetAudience` | string | `""` | Primary user segments or personas |
-| `ExistingResearch` | string | `""` | Links or references to existing research |
+| Variable           | Type   | Default    | Description                              |
+| ------------------ | ------ | ---------- | ---------------------------------------- |
+| `ProjectName`      | string | (required) | Internal project codename                |
+| `ProductName`      | string | (required) | Customer-facing product name             |
+| `ProblemStatement` | string | (required) | Core problem this product addresses      |
+| `TargetAudience`   | string | `""`       | Primary user segments or personas        |
+| `ExistingResearch` | string | `""`       | Links or references to existing research |
 
 ## Project layout
 

--- a/templates/brief-prd/template.yaml
+++ b/templates/brief-prd/template.yaml
@@ -2,13 +2,13 @@ apiVersion: nanohype/v1
 kind: brief
 
 name: brief-prd
-displayName: "Product Requirements Document Brief"
+displayName: 'Product Requirements Document Brief'
 description: >
   Scaffolds an agent brief for drafting a product requirements document.
   The rendered brief instructs an agent to analyze a problem space, define
   functional and non-functional requirements, write user stories, establish
   success metrics, and produce a complete PRD ready for engineering handoff.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [product]
 category: product
@@ -17,38 +17,38 @@ tags: [brief, prd, product, requirements, user-stories]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Internal project codename or identifier"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Internal project codename or identifier'
+    prompt: 'Project name'
     required: true
 
   - name: ProductName
     type: string
-    placeholder: "__PRODUCT_NAME__"
-    description: "Customer-facing product or feature name"
-    prompt: "Product name"
+    placeholder: '__PRODUCT_NAME__'
+    description: 'Customer-facing product or feature name'
+    prompt: 'Product name'
     required: true
 
   - name: ProblemStatement
     type: string
-    placeholder: "__PROBLEM_STATEMENT__"
-    description: "Core problem this product addresses"
-    prompt: "Problem statement"
+    placeholder: '__PROBLEM_STATEMENT__'
+    description: 'Core problem this product addresses'
+    prompt: 'Problem statement'
     required: true
 
   - name: TargetAudience
     type: string
-    placeholder: "__TARGET_AUDIENCE__"
-    description: "Primary user segments or personas"
-    prompt: "Target audience"
-    default: ""
+    placeholder: '__TARGET_AUDIENCE__'
+    description: 'Primary user segments or personas'
+    prompt: 'Target audience'
+    default: ''
 
   - name: ExistingResearch
     type: string
-    placeholder: "__EXISTING_RESEARCH__"
-    description: "Links or references to existing research, interviews, or data"
-    prompt: "Existing research"
-    default: ""
+    placeholder: '__EXISTING_RESEARCH__'
+    description: 'Links or references to existing research, interviews, or data'
+    prompt: 'Existing research'
+    default: ''
 
 composition:
   pairsWith: [prd-template, research-framework]

--- a/templates/brief-proposal/README.md
+++ b/templates/brief-proposal/README.md
@@ -13,13 +13,13 @@ Scaffolds an agent brief for drafting a client-facing proposal. The rendered bri
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Internal project name |
-| `CompanyName` | string | (required) | Your company name |
-| `ClientName` | string | (required) | Client organization name |
-| `EngagementType` | string | `services` | Type of engagement |
-| `ClientContext` | string | `""` | Background on the client's situation |
+| Variable         | Type   | Default    | Description                          |
+| ---------------- | ------ | ---------- | ------------------------------------ |
+| `ProjectName`    | string | (required) | Internal project name                |
+| `CompanyName`    | string | (required) | Your company name                    |
+| `ClientName`     | string | (required) | Client organization name             |
+| `EngagementType` | string | `services` | Type of engagement                   |
+| `ClientContext`  | string | `""`       | Background on the client's situation |
 
 ## Project layout
 

--- a/templates/brief-proposal/template.yaml
+++ b/templates/brief-proposal/template.yaml
@@ -2,14 +2,14 @@ apiVersion: nanohype/v1
 kind: brief
 
 name: brief-proposal
-displayName: "Proposal Brief"
+displayName: 'Proposal Brief'
 description: >
   Scaffolds an agent brief for drafting a client-facing proposal.
   The rendered brief instructs an agent to analyze client needs,
   define a solution approach, structure pricing and timeline,
   articulate differentiators, and produce a polished proposal
   document ready for client delivery.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [sales]
 category: sales
@@ -18,38 +18,38 @@ tags: [brief, proposal, sales, client, engagement]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Internal project name for this engagement"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Internal project name for this engagement'
+    prompt: 'Project name'
     required: true
 
   - name: CompanyName
     type: string
-    placeholder: "__COMPANY_NAME__"
-    description: "Your company name as it should appear in the proposal"
-    prompt: "Company name"
+    placeholder: '__COMPANY_NAME__'
+    description: 'Your company name as it should appear in the proposal'
+    prompt: 'Company name'
     required: true
 
   - name: ClientName
     type: string
-    placeholder: "__CLIENT_NAME__"
-    description: "Client organization name"
-    prompt: "Client name"
+    placeholder: '__CLIENT_NAME__'
+    description: 'Client organization name'
+    prompt: 'Client name'
     required: true
 
   - name: EngagementType
     type: string
-    placeholder: "__ENGAGEMENT_TYPE__"
-    description: "Type of engagement (services, product, advisory, hybrid)"
-    prompt: "Engagement type"
-    default: "services"
+    placeholder: '__ENGAGEMENT_TYPE__'
+    description: 'Type of engagement (services, product, advisory, hybrid)'
+    prompt: 'Engagement type'
+    default: 'services'
 
   - name: ClientContext
     type: string
-    placeholder: "__CLIENT_CONTEXT__"
+    placeholder: '__CLIENT_CONTEXT__'
     description: "Background on the client's situation, goals, or pain points"
-    prompt: "Client context"
-    default: ""
+    prompt: 'Client context'
+    default: ''
 
 composition:
   pairsWith: [proposal-template, battle-cards]

--- a/templates/brief-runbook/README.md
+++ b/templates/brief-runbook/README.md
@@ -14,12 +14,12 @@ Scaffolds an agent brief for producing an operational runbook. The rendered brie
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Project or team that owns the service |
-| `ServiceName` | string | (required) | Name of the service |
-| `InfraProvider` | string | `aws` | Primary infrastructure provider |
-| `IncidentSeverityLevels` | string | `P1,P2,P3,P4` | Comma-separated severity levels |
+| Variable                 | Type   | Default       | Description                           |
+| ------------------------ | ------ | ------------- | ------------------------------------- |
+| `ProjectName`            | string | (required)    | Project or team that owns the service |
+| `ServiceName`            | string | (required)    | Name of the service                   |
+| `InfraProvider`          | string | `aws`         | Primary infrastructure provider       |
+| `IncidentSeverityLevels` | string | `P1,P2,P3,P4` | Comma-separated severity levels       |
 
 ## Project layout
 

--- a/templates/brief-runbook/template.yaml
+++ b/templates/brief-runbook/template.yaml
@@ -2,14 +2,14 @@ apiVersion: nanohype/v1
 kind: brief
 
 name: brief-runbook
-displayName: "Runbook Brief"
+displayName: 'Runbook Brief'
 description: >
   Scaffolds an agent brief for producing an operational runbook.
   The rendered brief instructs an agent to analyze a service's
   architecture, document dependencies and failure modes, create
   step-by-step operational procedures, define escalation paths,
   and produce a runbook suitable for on-call engineers.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [operations]
 category: operations
@@ -18,31 +18,31 @@ tags: [brief, runbook, operations, incident, on-call]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Project or team that owns this service"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Project or team that owns this service'
+    prompt: 'Project name'
     required: true
 
   - name: ServiceName
     type: string
-    placeholder: "__SERVICE_NAME__"
-    description: "Name of the service this runbook covers"
-    prompt: "Service name"
+    placeholder: '__SERVICE_NAME__'
+    description: 'Name of the service this runbook covers'
+    prompt: 'Service name'
     required: true
 
   - name: InfraProvider
     type: string
-    placeholder: "__INFRA_PROVIDER__"
-    description: "Primary infrastructure provider (aws, gcp, azure, fly, vercel)"
-    prompt: "Infrastructure provider"
-    default: "aws"
+    placeholder: '__INFRA_PROVIDER__'
+    description: 'Primary infrastructure provider (aws, gcp, azure, fly, vercel)'
+    prompt: 'Infrastructure provider'
+    default: 'aws'
 
   - name: IncidentSeverityLevels
     type: string
-    placeholder: "__INCIDENT_SEVERITY_LEVELS__"
-    description: "Comma-separated severity levels used by the organization"
-    prompt: "Incident severity levels"
-    default: "P1,P2,P3,P4"
+    placeholder: '__INCIDENT_SEVERITY_LEVELS__'
+    description: 'Comma-separated severity levels used by the organization'
+    prompt: 'Incident severity levels'
+    default: 'P1,P2,P3,P4'
 
 composition:
   pairsWith: [runbook, monitoring-stack]

--- a/templates/brief-test-strategy/README.md
+++ b/templates/brief-test-strategy/README.md
@@ -13,12 +13,12 @@ Scaffolds an agent brief for producing a comprehensive test strategy. The render
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Name of the project |
-| `Language` | string | `typescript` | Primary programming language |
-| `TestingGoal` | string | `comprehensive coverage` | High-level testing objective |
-| `CriticalPaths` | string | `""` | Comma-separated critical paths to prioritize |
+| Variable        | Type   | Default                  | Description                                  |
+| --------------- | ------ | ------------------------ | -------------------------------------------- |
+| `ProjectName`   | string | (required)               | Name of the project                          |
+| `Language`      | string | `typescript`             | Primary programming language                 |
+| `TestingGoal`   | string | `comprehensive coverage` | High-level testing objective                 |
+| `CriticalPaths` | string | `""`                     | Comma-separated critical paths to prioritize |
 
 ## Project layout
 

--- a/templates/brief-test-strategy/template.yaml
+++ b/templates/brief-test-strategy/template.yaml
@@ -2,13 +2,13 @@ apiVersion: nanohype/v1
 kind: brief
 
 name: brief-test-strategy
-displayName: "Test Strategy Brief"
+displayName: 'Test Strategy Brief'
 description: >
   Scaffolds an agent brief for producing a comprehensive test strategy.
   The rendered brief instructs an agent to analyze a codebase, identify
   critical paths, recommend tooling, define coverage targets, and produce
   a layered test strategy document organized by test type and priority.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [qa]
 category: qa
@@ -17,31 +17,31 @@ tags: [brief, testing, strategy, qa, coverage]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Name of the project to define a test strategy for"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Name of the project to define a test strategy for'
+    prompt: 'Project name'
     required: true
 
   - name: Language
     type: string
-    placeholder: "__LANGUAGE__"
-    description: "Primary programming language of the codebase"
-    prompt: "Primary language"
-    default: "typescript"
+    placeholder: '__LANGUAGE__'
+    description: 'Primary programming language of the codebase'
+    prompt: 'Primary language'
+    default: 'typescript'
 
   - name: TestingGoal
     type: string
-    placeholder: "__TESTING_GOAL__"
-    description: "High-level objective for the test strategy"
-    prompt: "Testing goal"
-    default: "comprehensive coverage"
+    placeholder: '__TESTING_GOAL__'
+    description: 'High-level objective for the test strategy'
+    prompt: 'Testing goal'
+    default: 'comprehensive coverage'
 
   - name: CriticalPaths
     type: string
-    placeholder: "__CRITICAL_PATHS__"
-    description: "Comma-separated list of critical user or system paths to prioritize"
-    prompt: "Critical paths"
-    default: ""
+    placeholder: '__CRITICAL_PATHS__'
+    description: 'Comma-separated list of critical user or system paths to prioritize'
+    prompt: 'Critical paths'
+    default: ''
 
 composition:
   pairsWith: [test-plan, test-automation, eval-harness]

--- a/templates/campaign-brief/README.md
+++ b/templates/campaign-brief/README.md
@@ -11,11 +11,11 @@ Scaffolds a marketing campaign brief with objectives, audience segments, messagi
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
+| Variable       | Type   | Default    | Description                  |
+| -------------- | ------ | ---------- | ---------------------------- |
+| `ProjectName`  | string | (required) | Kebab-case project name      |
 | `CampaignName` | string | (required) | Human-readable campaign name |
-| `Channel` | string | `multi` | Primary distribution channel |
+| `Channel`      | string | `multi`    | Primary distribution channel |
 
 ## Project layout
 

--- a/templates/campaign-brief/template.yaml
+++ b/templates/campaign-brief/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: campaign-brief
-displayName: "Campaign Brief"
+displayName: 'Campaign Brief'
 description: >
   Scaffolds a marketing campaign brief with objectives, audience
   segments, messaging matrix, channel plan, and timeline. Provides
   a structured package that aligns creative, media, and stakeholders
   around campaign strategy and execution.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [marketing]
 category: marketing
@@ -16,27 +16,27 @@ tags: [campaign, marketing, messaging, channels, timeline]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: CampaignName
     type: string
-    placeholder: "__CAMPAIGN_NAME__"
-    description: "Human-readable campaign name for document titles"
-    prompt: "Campaign name"
+    placeholder: '__CAMPAIGN_NAME__'
+    description: 'Human-readable campaign name for document titles'
+    prompt: 'Campaign name'
     required: true
 
   - name: Channel
     type: string
-    placeholder: "__CHANNEL__"
-    description: "Primary distribution channel (multi, email, social, paid, organic)"
-    prompt: "Primary channel"
-    default: "multi"
+    placeholder: '__CHANNEL__'
+    description: 'Primary distribution channel (multi, email, social, paid, organic)'
+    prompt: 'Primary channel'
+    default: 'multi'
 
 composition:
   pairsWith: [content-calendar, prd-template, brand-guidelines]

--- a/templates/change-management/README.md
+++ b/templates/change-management/README.md
@@ -11,11 +11,11 @@ Scaffolds a change management package with a change request template, impact ass
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ChangeType` | enum | `normal` | Default change type: standard, normal, or emergency |
-| `IncludeRollback` | bool | `true` | Include rollback plan |
+| Variable          | Type   | Default    | Description                                         |
+| ----------------- | ------ | ---------- | --------------------------------------------------- |
+| `ProjectName`     | string | (required) | Kebab-case project name                             |
+| `ChangeType`      | enum   | `normal`   | Default change type: standard, normal, or emergency |
+| `IncludeRollback` | bool   | `true`     | Include rollback plan                               |
 
 ## Project layout
 

--- a/templates/change-management/template.yaml
+++ b/templates/change-management/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: change-management
-displayName: "Change Management"
+displayName: 'Change Management'
 description: >
   Scaffolds a change management package with a change request template,
   impact assessment matrix, and approval workflow configuration.
   Optionally includes a rollback plan with triggers and verification
   steps. Designed for operations and engineering teams managing
   controlled changes to production systems.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [operations]
 category: operations
@@ -17,31 +17,31 @@ tags: [change-management, change-request, impact-assessment, approval, rollback]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ChangeType
     type: enum
-    placeholder: "__CHANGE_TYPE__"
-    description: "Default change type determining approval workflow and SLAs"
-    prompt: "Change type"
-    default: "normal"
+    placeholder: '__CHANGE_TYPE__'
+    description: 'Default change type determining approval workflow and SLAs'
+    prompt: 'Change type'
+    default: 'normal'
     options: [standard, normal, emergency]
 
   - name: IncludeRollback
     type: bool
-    placeholder: "__INCLUDE_ROLLBACK__"
-    description: "Include a rollback plan document"
-    prompt: "Include rollback plan?"
+    placeholder: '__INCLUDE_ROLLBACK__'
+    description: 'Include a rollback plan document'
+    prompt: 'Include rollback plan?'
     default: true
 
 conditionals:
-  - path: "change/rollback-plan.md"
+  - path: 'change/rollback-plan.md'
     when: IncludeRollback
 
 composition:

--- a/templates/chrome-ext/README.md
+++ b/templates/chrome-ext/README.md
@@ -15,14 +15,14 @@ Chrome extension (Manifest V3) with a React sidepanel for AI-powered interaction
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | `my-extension` | Kebab-case project name |
-| `ExtensionName` | string | `My Extension` | Display name in Chrome |
-| `Description` | string | `An AI-powered Chrome extension` | Extension description |
-| `IncludeContentScript` | bool | `true` | Include content script |
-| `IncludeOptions` | bool | `true` | Include options page |
-| `LlmProvider` | string | `anthropic` | Default provider: anthropic or openai |
+| Variable               | Type   | Default                          | Description                           |
+| ---------------------- | ------ | -------------------------------- | ------------------------------------- |
+| `ProjectName`          | string | `my-extension`                   | Kebab-case project name               |
+| `ExtensionName`        | string | `My Extension`                   | Display name in Chrome                |
+| `Description`          | string | `An AI-powered Chrome extension` | Extension description                 |
+| `IncludeContentScript` | bool   | `true`                           | Include content script                |
+| `IncludeOptions`       | bool   | `true`                           | Include options page                  |
+| `LlmProvider`          | string | `anthropic`                      | Default provider: anthropic or openai |
 
 ## Project layout
 

--- a/templates/chrome-ext/template.yaml
+++ b/templates/chrome-ext/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: chrome-ext
-displayName: "Chrome Extension (React + Vite)"
+displayName: 'Chrome Extension (React + Vite)'
 description: >
   Scaffolds a Chrome extension using Manifest V3 with a React sidepanel
   for AI-powered interactions. Includes a Vite-based build system with
   multi-entry compilation for sidepanel, background service worker,
   content script, and options page. Supports Anthropic and OpenAI as
   LLM providers with streaming chat in the sidepanel.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -17,69 +17,69 @@ tags: [chrome-extension, react, vite, typescript, ai, browser]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
-    default: "my-extension"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
+    default: 'my-extension'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ExtensionName
     type: string
-    placeholder: "__EXTENSION_NAME__"
-    description: "Human-readable extension name displayed in Chrome"
-    prompt: "Extension display name"
-    default: "My Extension"
+    placeholder: '__EXTENSION_NAME__'
+    description: 'Human-readable extension name displayed in Chrome'
+    prompt: 'Extension display name'
+    default: 'My Extension'
     required: true
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short extension description for manifest and README"
-    prompt: "Extension description"
-    default: "An AI-powered Chrome extension"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short extension description for manifest and README'
+    prompt: 'Extension description'
+    default: 'An AI-powered Chrome extension'
 
   - name: IncludeContentScript
     type: bool
-    placeholder: "__INCLUDE_CONTENT_SCRIPT__"
-    description: "Include content script for page interaction and text selection"
-    prompt: "Include content script?"
+    placeholder: '__INCLUDE_CONTENT_SCRIPT__'
+    description: 'Include content script for page interaction and text selection'
+    prompt: 'Include content script?'
     default: true
 
   - name: IncludeOptions
     type: bool
-    placeholder: "__INCLUDE_OPTIONS__"
-    description: "Include options page for API key and settings management"
-    prompt: "Include options page?"
+    placeholder: '__INCLUDE_OPTIONS__'
+    description: 'Include options page for API key and settings management'
+    prompt: 'Include options page?'
     default: true
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider for AI interactions"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider for AI interactions'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
 conditionals:
-  - path: "src/content/index.ts"
+  - path: 'src/content/index.ts'
     when: IncludeContentScript
-  - path: "src/content/styles.css"
+  - path: 'src/content/styles.css'
     when: IncludeContentScript
-  - path: "src/options/App.tsx"
+  - path: 'src/options/App.tsx'
     when: IncludeOptions
-  - path: "src/options/index.tsx"
+  - path: 'src/options/index.tsx'
     when: IncludeOptions
-  - path: "src/options/index.html"
+  - path: 'src/options/index.html'
     when: IncludeOptions
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [mcp-server-ts, ts-service]
@@ -87,9 +87,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for Vite build tooling"
+    version: '>=22'
+    purpose: 'Node.js runtime for Vite build tooling'
     optional: false
   - name: chrome
-    purpose: "Extension testing via chrome://extensions"
+    purpose: 'Extension testing via chrome://extensions'
     optional: true

--- a/templates/ci-eval/README.md
+++ b/templates/ci-eval/README.md
@@ -12,14 +12,14 @@ CI pipeline for eval-gated deployments. Runs LLM evaluation suites on every pull
 
 ## Variables
 
-| Name | Type | Default | Description |
-|------|------|---------|-------------|
-| `ProjectName` | string | *(required)* | Kebab-case project name |
-| `Description` | string | `CI pipeline for eval-gated deployments` | Short project description |
-| `EvalPath` | string | `evals` | Directory containing YAML eval suite files |
-| `RegressionThreshold` | string | `0.05` | Max allowed score regression (0.0–1.0) |
-| `LlmProvider` | string | `anthropic` | Default LLM provider |
-| `IncludeTests` | bool | `true` | Include unit tests |
+| Name                  | Type   | Default                                  | Description                                |
+| --------------------- | ------ | ---------------------------------------- | ------------------------------------------ |
+| `ProjectName`         | string | _(required)_                             | Kebab-case project name                    |
+| `Description`         | string | `CI pipeline for eval-gated deployments` | Short project description                  |
+| `EvalPath`            | string | `evals`                                  | Directory containing YAML eval suite files |
+| `RegressionThreshold` | string | `0.05`                                   | Max allowed score regression (0.0–1.0)     |
+| `LlmProvider`         | string | `anthropic`                              | Default LLM provider                       |
+| `IncludeTests`        | bool   | `true`                                   | Include unit tests                         |
 
 ## Project layout
 

--- a/templates/ci-eval/template.yaml
+++ b/templates/ci-eval/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: ci-eval
-displayName: "CI Eval Pipeline"
+displayName: 'CI Eval Pipeline'
 description: >
   GitHub Actions workflow for eval-gated deployments. Runs LLM evaluation
   suites on every pull request, compares scores against a stored baseline,
   posts a markdown report as a PR comment, and fails the check if any
   suite regresses beyond a configurable threshold. Ships with a CLI for
   local runs, baseline management, and score comparison.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -17,63 +17,63 @@ tags: [typescript, ci, eval, github-actions, llm, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "CI pipeline for eval-gated deployments"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'CI pipeline for eval-gated deployments'
 
   - name: EvalPath
     type: string
-    placeholder: "__EVAL_PATH__"
-    description: "Directory containing YAML eval suite files"
-    prompt: "Eval suites directory"
-    default: "evals"
+    placeholder: '__EVAL_PATH__'
+    description: 'Directory containing YAML eval suite files'
+    prompt: 'Eval suites directory'
+    default: 'evals'
 
   - name: RegressionThreshold
     type: string
-    placeholder: "__REGRESSION_THRESHOLD__"
-    description: "Maximum allowed score regression before failing the check (0.0–1.0)"
-    prompt: "Regression threshold"
-    default: "0.05"
+    placeholder: '__REGRESSION_THRESHOLD__'
+    description: 'Maximum allowed score regression before failing the check (0.0–1.0)'
+    prompt: 'Regression threshold'
+    default: '0.05'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider name (built-in: anthropic, openai — or any custom registered provider)"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider name (built-in: anthropic, openai — or any custom registered provider)'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include unit tests for baseline, reporter, and runner"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include unit tests for baseline, reporter, and runner'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/__tests__/baseline.test.ts"
+  - path: 'src/__tests__/baseline.test.ts'
     when: IncludeTests
-  - path: "src/__tests__/reporter.test.ts"
+  - path: 'src/__tests__/reporter.test.ts'
     when: IncludeTests
-  - path: "src/__tests__/runner.test.ts"
+  - path: 'src/__tests__/runner.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [eval-harness, ts-service, agentic-loop]
@@ -81,9 +81,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false
   - name: gh
-    purpose: "GitHub CLI for posting PR comments"
+    purpose: 'GitHub CLI for posting PR comments'
     optional: true

--- a/templates/compliance-checklist/README.md
+++ b/templates/compliance-checklist/README.md
@@ -11,11 +11,11 @@ Scaffolds a compliance management package with control inventory, audit trail tr
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Framework` | string | `soc2` | Compliance framework |
-| `IncludeEvidenceTemplates` | bool | `true` | Include evidence templates |
+| Variable                   | Type   | Default    | Description                |
+| -------------------------- | ------ | ---------- | -------------------------- |
+| `ProjectName`              | string | (required) | Kebab-case project name    |
+| `Framework`                | string | `soc2`     | Compliance framework       |
+| `IncludeEvidenceTemplates` | bool   | `true`     | Include evidence templates |
 
 ## Project layout
 

--- a/templates/compliance-checklist/template.yaml
+++ b/templates/compliance-checklist/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: compliance-checklist
-displayName: "Compliance Checklist"
+displayName: 'Compliance Checklist'
 description: >
   Scaffolds a compliance management package with control inventory,
   audit trail tracking, and remediation workflows. Optionally includes
   evidence collection templates. Supports SOC 2, ISO 27001, HIPAA,
   and other frameworks through configurable control definitions.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [operations]
 category: operations
@@ -16,30 +16,30 @@ tags: [compliance, audit, soc2, controls, remediation]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Framework
     type: string
-    placeholder: "__FRAMEWORK__"
-    description: "Compliance framework (soc2, iso27001, hipaa, pci-dss)"
-    prompt: "Compliance framework"
-    default: "soc2"
+    placeholder: '__FRAMEWORK__'
+    description: 'Compliance framework (soc2, iso27001, hipaa, pci-dss)'
+    prompt: 'Compliance framework'
+    default: 'soc2'
 
   - name: IncludeEvidenceTemplates
     type: bool
-    placeholder: "__INCLUDE_EVIDENCE_TEMPLATES__"
-    description: "Include evidence collection templates"
-    prompt: "Include evidence templates?"
+    placeholder: '__INCLUDE_EVIDENCE_TEMPLATES__'
+    description: 'Include evidence collection templates'
+    prompt: 'Include evidence templates?'
     default: true
 
 conditionals:
-  - path: "compliance/evidence/collection-template.md"
+  - path: 'compliance/evidence/collection-template.md'
     when: IncludeEvidenceTemplates
 
 composition:

--- a/templates/component-inventory/README.md
+++ b/templates/component-inventory/README.md
@@ -11,11 +11,11 @@ Component inventory with structured status tracking, ownership metadata, and an 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Framework` | string | `react` | Frontend framework |
-| `IncludeA11yChecklist` | bool | `true` | Include accessibility checklist |
+| Variable               | Type   | Default    | Description                     |
+| ---------------------- | ------ | ---------- | ------------------------------- |
+| `ProjectName`          | string | (required) | Kebab-case project name         |
+| `Framework`            | string | `react`    | Frontend framework              |
+| `IncludeA11yChecklist` | bool   | `true`     | Include accessibility checklist |
 
 ## Project layout
 

--- a/templates/component-inventory/template.yaml
+++ b/templates/component-inventory/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: component-inventory
-displayName: "Component Inventory"
+displayName: 'Component Inventory'
 description: >
   Scaffolds a component inventory with structured status tracking, ownership
   metadata, and an optional accessibility checklist. Provides a single registry
   for tracking every UI component from proposal through deprecation, with
   framework-specific implementation notes and audit history.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [design]
 category: design
@@ -16,30 +16,30 @@ tags: [components, inventory, accessibility, design, audit]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as directory and reference identifier"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as directory and reference identifier'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Framework
     type: string
-    placeholder: "__FRAMEWORK__"
-    description: "Frontend framework used for component implementation"
-    prompt: "Frontend framework"
-    default: "react"
+    placeholder: '__FRAMEWORK__'
+    description: 'Frontend framework used for component implementation'
+    prompt: 'Frontend framework'
+    default: 'react'
 
   - name: IncludeA11yChecklist
     type: bool
-    placeholder: "__INCLUDE_A11Y_CHECKLIST__"
-    description: "Include accessibility audit checklist for component reviews"
-    prompt: "Include accessibility checklist?"
+    placeholder: '__INCLUDE_A11Y_CHECKLIST__'
+    description: 'Include accessibility audit checklist for component reviews'
+    prompt: 'Include accessibility checklist?'
     default: true
 
 conditionals:
-  - path: "a11y/checklist.md"
+  - path: 'a11y/checklist.md'
     when: IncludeA11yChecklist
 
 composition:

--- a/templates/content-calendar/README.md
+++ b/templates/content-calendar/README.md
@@ -11,11 +11,11 @@ Scaffolds an editorial content calendar with content pillars, distribution matri
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Cadence` | enum | `weekly` | Publishing cadence: weekly, biweekly, or monthly |
-| `IncludeSocial` | bool | `true` | Include social media playbook |
+| Variable        | Type   | Default    | Description                                      |
+| --------------- | ------ | ---------- | ------------------------------------------------ |
+| `ProjectName`   | string | (required) | Kebab-case project name                          |
+| `Cadence`       | enum   | `weekly`   | Publishing cadence: weekly, biweekly, or monthly |
+| `IncludeSocial` | bool   | `true`     | Include social media playbook                    |
 
 ## Project layout
 

--- a/templates/content-calendar/template.yaml
+++ b/templates/content-calendar/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: content-calendar
-displayName: "Content Calendar"
+displayName: 'Content Calendar'
 description: >
   Scaffolds an editorial content calendar with content pillars,
   distribution matrix, and publishing cadence. Supports weekly,
   biweekly, and monthly rhythms. Optionally includes a social media
   playbook with platform-specific guidance.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [marketing]
 category: marketing
@@ -16,31 +16,31 @@ tags: [content, editorial, calendar, distribution, social]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Cadence
     type: enum
-    placeholder: "__CADENCE__"
-    description: "Publishing cadence for the editorial calendar"
-    prompt: "Publishing cadence"
-    default: "weekly"
-    options: ["weekly", "biweekly", "monthly"]
+    placeholder: '__CADENCE__'
+    description: 'Publishing cadence for the editorial calendar'
+    prompt: 'Publishing cadence'
+    default: 'weekly'
+    options: ['weekly', 'biweekly', 'monthly']
 
   - name: IncludeSocial
     type: bool
-    placeholder: "__INCLUDE_SOCIAL__"
-    description: "Include a social media playbook"
-    prompt: "Include social playbook?"
+    placeholder: '__INCLUDE_SOCIAL__'
+    description: 'Include a social media playbook'
+    prompt: 'Include social playbook?'
     default: true
 
 conditionals:
-  - path: "content/social-playbook.md"
+  - path: 'content/social-playbook.md'
     when: IncludeSocial
 
 composition:

--- a/templates/data-pipeline/README.md
+++ b/templates/data-pipeline/README.md
@@ -13,13 +13,13 @@ Scaffolds an ETL pipeline for AI workloads in TypeScript. Implements document in
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | "Data pipeline for AI workloads" | Project description |
-| `EmbeddingProvider` | string | `openai` | Embedding provider name |
-| `ChunkStrategy` | string | `recursive` | Chunking strategy name |
-| `IncludeTests` | bool | `true` | Include vitest test suite |
+| Variable            | Type   | Default                          | Description               |
+| ------------------- | ------ | -------------------------------- | ------------------------- |
+| `ProjectName`       | string | _(required)_                     | Kebab-case project name   |
+| `Description`       | string | "Data pipeline for AI workloads" | Project description       |
+| `EmbeddingProvider` | string | `openai`                         | Embedding provider name   |
+| `ChunkStrategy`     | string | `recursive`                      | Chunking strategy name    |
+| `IncludeTests`      | bool   | `true`                           | Include vitest test suite |
 
 ## Project layout
 

--- a/templates/data-pipeline/template.yaml
+++ b/templates/data-pipeline/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: data-pipeline
-displayName: "Data Pipeline"
+displayName: 'Data Pipeline'
 description: >
   Scaffolds an ETL pipeline for AI workloads in TypeScript. Implements
   document ingestion from files and web pages, configurable chunking
@@ -12,7 +12,7 @@ description: >
   alternate. Supports multiple ingest sources (PDF, Markdown, plain text,
   JSON, CSV, web — SSRF-guarded) and output formats (JSONL, console).
   Output is compatible with module-vector-store's VectorDocument shape.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -21,58 +21,58 @@ tags: [typescript, etl, embeddings, pipeline, data, chunking, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory names"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory names'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Data pipeline for AI workloads"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Data pipeline for AI workloads'
 
   - name: EmbeddingProvider
     type: string
-    placeholder: "__EMBEDDING_PROVIDER__"
-    description: "Provider for text embeddings — bedrock (Titan v2, default) or openai"
-    prompt: "Embedding provider"
-    default: "bedrock"
+    placeholder: '__EMBEDDING_PROVIDER__'
+    description: 'Provider for text embeddings — bedrock (Titan v2, default) or openai'
+    prompt: 'Embedding provider'
+    default: 'bedrock'
 
   - name: ChunkStrategy
     type: string
-    placeholder: "__CHUNK_STRATEGY__"
-    description: "Text chunking strategy for splitting documents (e.g. recursive, fixed, semantic)"
-    prompt: "Chunking strategy"
-    default: "recursive"
+    placeholder: '__CHUNK_STRATEGY__'
+    description: 'Text chunking strategy for splitting documents (e.g. recursive, fixed, semantic)'
+    prompt: 'Chunking strategy'
+    default: 'recursive'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include vitest test suite with orchestrator, chunking, and registry tests"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include vitest test suite with orchestrator, chunking, and registry tests'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/pipeline/__tests__/orchestrator.test.ts"
+  - path: 'src/pipeline/__tests__/orchestrator.test.ts'
     when: IncludeTests
-  - path: "src/pipeline/__tests__/recursive.test.ts"
+  - path: 'src/pipeline/__tests__/recursive.test.ts'
     when: IncludeTests
-  - path: "src/pipeline/__tests__/fixed-size.test.ts"
+  - path: 'src/pipeline/__tests__/fixed-size.test.ts'
     when: IncludeTests
-  - path: "src/pipeline/__tests__/registry.test.ts"
+  - path: 'src/pipeline/__tests__/registry.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [module-vector-store, rag-pipeline, eval-harness]
@@ -80,6 +80,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=24"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=24'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/design-system/README.md
+++ b/templates/design-system/README.md
@@ -11,12 +11,12 @@ Design system specification with foundational principles, a component catalog st
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `DesignToolkit` | string | `figma` | Primary design tool |
-| `IncludeTokenSync` | bool | `true` | Include token sync config |
-| `ColorScheme` | enum | `both` | Color scheme: light, dark, or both |
+| Variable           | Type   | Default    | Description                        |
+| ------------------ | ------ | ---------- | ---------------------------------- |
+| `ProjectName`      | string | (required) | Kebab-case project name            |
+| `DesignToolkit`    | string | `figma`    | Primary design tool                |
+| `IncludeTokenSync` | bool   | `true`     | Include token sync config          |
+| `ColorScheme`      | enum   | `both`     | Color scheme: light, dark, or both |
 
 ## Project layout
 

--- a/templates/design-system/template.yaml
+++ b/templates/design-system/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: design-system
-displayName: "Design System"
+displayName: 'Design System'
 description: >
   Scaffolds a design system specification with foundational principles,
   a component catalog structure, usage guidelines, and optional token
   sync configuration. Provides the structural backbone for maintaining
   a consistent visual language across products and teams.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [design]
 category: design
@@ -16,38 +16,38 @@ tags: [design-system, components, tokens, figma, design]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as directory and reference identifier"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as directory and reference identifier'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: DesignToolkit
     type: string
-    placeholder: "__DESIGN_TOOLKIT__"
-    description: "Primary design tool used for source-of-truth assets"
-    prompt: "Design toolkit"
-    default: "figma"
+    placeholder: '__DESIGN_TOOLKIT__'
+    description: 'Primary design tool used for source-of-truth assets'
+    prompt: 'Design toolkit'
+    default: 'figma'
 
   - name: IncludeTokenSync
     type: bool
-    placeholder: "__INCLUDE_TOKEN_SYNC__"
-    description: "Include token sync configuration for automated design-to-code token export"
-    prompt: "Include token sync config?"
+    placeholder: '__INCLUDE_TOKEN_SYNC__'
+    description: 'Include token sync configuration for automated design-to-code token export'
+    prompt: 'Include token sync config?'
     default: true
 
   - name: ColorScheme
     type: enum
-    placeholder: "__COLOR_SCHEME__"
-    description: "Color scheme support mode"
-    prompt: "Color scheme"
-    default: "both"
-    options: ["light", "dark", "both"]
+    placeholder: '__COLOR_SCHEME__'
+    description: 'Color scheme support mode'
+    prompt: 'Color scheme'
+    default: 'both'
+    options: ['light', 'dark', 'both']
 
 conditionals:
-  - path: "sync/token-sync-config.yaml"
+  - path: 'sync/token-sync-config.yaml'
     when: IncludeTokenSync
 
 composition:

--- a/templates/design-tokens/README.md
+++ b/templates/design-tokens/README.md
@@ -11,11 +11,11 @@ Design token system with base primitives, semantic aliases, theme configuration,
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `TokenFormat` | string | `json` | Primary output format |
-| `IncludeDarkMode` | bool | `true` | Include dark mode tokens |
+| Variable          | Type   | Default    | Description              |
+| ----------------- | ------ | ---------- | ------------------------ |
+| `ProjectName`     | string | (required) | Kebab-case project name  |
+| `TokenFormat`     | string | `json`     | Primary output format    |
+| `IncludeDarkMode` | bool   | `true`     | Include dark mode tokens |
 
 ## Project layout
 

--- a/templates/design-tokens/template.yaml
+++ b/templates/design-tokens/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: design-tokens
-displayName: "Design Tokens"
+displayName: 'Design Tokens'
 description: >
   Scaffolds a design token system with base primitives, semantic aliases,
   theme configuration, and optional dark mode definitions. Tokens follow
   a three-tier architecture: base values define raw primitives, semantic
   tokens map intent to base values, and themes override semantic tokens
   for different contexts.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [design]
 category: design
@@ -17,30 +17,30 @@ tags: [tokens, design, theming, dark-mode, css-variables]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as directory and token prefix"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as directory and token prefix'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: TokenFormat
     type: string
-    placeholder: "__TOKEN_FORMAT__"
-    description: "Primary output format for token files"
-    prompt: "Token format"
-    default: "json"
+    placeholder: '__TOKEN_FORMAT__'
+    description: 'Primary output format for token files'
+    prompt: 'Token format'
+    default: 'json'
 
   - name: IncludeDarkMode
     type: bool
-    placeholder: "__INCLUDE_DARK_MODE__"
-    description: "Include dark mode token overrides"
-    prompt: "Include dark mode tokens?"
+    placeholder: '__INCLUDE_DARK_MODE__'
+    description: 'Include dark mode token overrides'
+    prompt: 'Include dark mode tokens?'
     default: true
 
 conditionals:
-  - path: "tokens/dark.json"
+  - path: 'tokens/dark.json'
     when: IncludeDarkMode
 
 composition:

--- a/templates/discord-bot/README.md
+++ b/templates/discord-bot/README.md
@@ -13,12 +13,12 @@ TypeScript Discord bot with discord.js v14, AI-powered responses, and a pluggabl
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `"A Discord bot with AI"` | Short project description |
-| `LlmProvider` | string | `"anthropic"` | `anthropic` or `openai` |
-| `IncludeTests` | bool | `true` | Include test files |
+| Variable       | Type   | Default                   | Description               |
+| -------------- | ------ | ------------------------- | ------------------------- |
+| `ProjectName`  | string | _(required)_              | Kebab-case project name   |
+| `Description`  | string | `"A Discord bot with AI"` | Short project description |
+| `LlmProvider`  | string | `"anthropic"`             | `anthropic` or `openai`   |
+| `IncludeTests` | bool   | `true`                    | Include test files        |
 
 ## Project layout
 

--- a/templates/discord-bot/template.yaml
+++ b/templates/discord-bot/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: discord-bot
-displayName: "Discord Bot"
+displayName: 'Discord Bot'
 description: >
   Scaffolds a TypeScript Discord bot using discord.js v14 with
   GatewayIntentBits for guilds, messages, and message content. Includes
   slash command registration and handling, a messageCreate handler with
   AI-powered responses, a pluggable LLM provider registry (Anthropic and
   OpenAI), and embed-based rich formatting for structured AI output.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -17,45 +17,45 @@ tags: [typescript, discord, bot, ai, chatbot]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "A Discord bot with AI"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'A Discord bot with AI'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider to use for AI responses"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider to use for AI responses'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test files with vitest"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test files with vitest'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/__tests__/commands.test.ts"
+  - path: 'src/__tests__/commands.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [module-queue-ts, module-database-ts, agentic-loop]
@@ -63,6 +63,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the Discord bot"
+    version: '>=22'
+    purpose: 'Node.js runtime for the Discord bot'
     optional: false

--- a/templates/eks-addon/README.md
+++ b/templates/eks-addon/README.md
@@ -13,27 +13,27 @@ The Kustomize-based addon variant (used by `storage-classes`, `priority-classes`
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `AddonName` | string | (required) | Kebab-case addon name |
-| `Category` | string | `operations` | `bootstrap`, `networking`, `security`, `observability`, `operations`, `argo-platform` |
-| `ChartRepo` | string | (required) | Upstream Helm repo URL |
-| `ChartName` | string | (required) | Upstream chart name |
-| `ChartVersion` | string | (required) | Pinned chart version (never floating — look up via `helm search repo`) |
-| `SyncWave` | string | `40` | ArgoCD sync wave |
+| Variable       | Type   | Default      | Description                                                                           |
+| -------------- | ------ | ------------ | ------------------------------------------------------------------------------------- |
+| `AddonName`    | string | (required)   | Kebab-case addon name                                                                 |
+| `Category`     | string | `operations` | `bootstrap`, `networking`, `security`, `observability`, `operations`, `argo-platform` |
+| `ChartRepo`    | string | (required)   | Upstream Helm repo URL                                                                |
+| `ChartName`    | string | (required)   | Upstream chart name                                                                   |
+| `ChartVersion` | string | (required)   | Pinned chart version (never floating — look up via `helm search repo`)                |
+| `SyncWave`     | string | `40`         | ArgoCD sync wave                                                                      |
 
 ## Sync waves (eks-gitops convention)
 
-| Category | Wave range |
-|---|---|
-| `bootstrap` | 0, 2 |
-| `networking` | 1 |
-| `karpenter` (under operations) | 5 |
-| `security` | 10–12 |
-| `policies` (under security) | 20–21 |
-| `observability` | 30–33 |
-| `operations` | 40–44 |
-| `argo-platform` | 50–52 |
+| Category                       | Wave range |
+| ------------------------------ | ---------- |
+| `bootstrap`                    | 0, 2       |
+| `networking`                   | 1          |
+| `karpenter` (under operations) | 5          |
+| `security`                     | 10–12      |
+| `policies` (under security)    | 20–21      |
+| `observability`                | 30–33      |
+| `operations`                   | 40–44      |
+| `argo-platform`                | 50–52      |
 
 Apps land at wave ≥100 (handled by `k8s-app-tenant`).
 

--- a/templates/eks-addon/template.yaml
+++ b/templates/eks-addon/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: eks-addon
-displayName: "EKS GitOps Addon (Helm)"
+displayName: 'EKS GitOps Addon (Helm)'
 description: >
   Scaffolds a new Helm-based addon into nanohype/eks-gitops. Produces the
   addons/<category>/<name>/values.yaml + per-env delta files
@@ -9,7 +9,7 @@ description: >
   Helm values pattern (base + delta-only). The Kustomize variant
   (used by storage-classes, priority-classes, karpenter-resources)
   needs a different layout and is not covered here.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -18,48 +18,48 @@ tags: [kubernetes, helm, argocd, gitops, eks, nanohype]
 variables:
   - name: AddonName
     type: string
-    placeholder: "__ADDON_NAME__"
-    description: "Kebab-case addon name. Becomes the directory name under addons/<category>/."
-    prompt: "Addon name"
+    placeholder: '__ADDON_NAME__'
+    description: 'Kebab-case addon name. Becomes the directory name under addons/<category>/.'
+    prompt: 'Addon name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Category
     type: string
-    placeholder: "__CATEGORY__"
-    description: "Sync-wave category. One of: bootstrap, networking, security, observability, operations, argo-platform."
-    prompt: "Category"
-    default: "operations"
+    placeholder: '__CATEGORY__'
+    description: 'Sync-wave category. One of: bootstrap, networking, security, observability, operations, argo-platform.'
+    prompt: 'Category'
+    default: 'operations'
 
   - name: ChartRepo
     type: string
-    placeholder: "__CHART_REPO__"
-    description: "Upstream Helm chart repository URL (artifacthub link or OCI registry)."
-    prompt: "Chart repo URL"
+    placeholder: '__CHART_REPO__'
+    description: 'Upstream Helm chart repository URL (artifacthub link or OCI registry).'
+    prompt: 'Chart repo URL'
     required: true
 
   - name: ChartName
     type: string
-    placeholder: "__CHART_NAME__"
-    description: "Upstream chart name (as it appears in helm search results)."
-    prompt: "Chart name"
+    placeholder: '__CHART_NAME__'
+    description: 'Upstream chart name (as it appears in helm search results).'
+    prompt: 'Chart name'
     required: true
 
   - name: ChartVersion
     type: string
-    placeholder: "__CHART_VERSION__"
-    description: "Current stable chart version (pin to specific — never floating). Look up with: helm search repo <chart>."
-    prompt: "Chart version"
+    placeholder: '__CHART_VERSION__'
+    description: 'Current stable chart version (pin to specific — never floating). Look up with: helm search repo <chart>.'
+    prompt: 'Chart version'
     required: true
 
   - name: SyncWave
     type: string
-    placeholder: "__SYNC_WAVE__"
-    description: "ArgoCD sync wave. Categories: bootstrap (0,2), networking (1), karpenter (5), security (10-12), policies (20-21), observability (30-33), operations (40-44), argo-platform (50-52)."
-    prompt: "Sync wave"
-    default: "40"
+    placeholder: '__SYNC_WAVE__'
+    description: 'ArgoCD sync wave. Categories: bootstrap (0,2), networking (1), karpenter (5), security (10-12), policies (20-21), observability (30-33), operations (40-44), argo-platform (50-52).'
+    prompt: 'Sync wave'
+    default: '40'
 
 conditionals: []
 
@@ -69,12 +69,12 @@ composition:
 
 prerequisites:
   - name: helm
-    version: ">=3.0"
-    purpose: "Render and lint values locally against the upstream chart"
+    version: '>=3.0'
+    purpose: 'Render and lint values locally against the upstream chart'
     optional: false
   - name: kustomize
-    version: ">=5.0"
-    purpose: "Build per-env overlays via task validate"
+    version: '>=5.0'
+    purpose: 'Build per-env overlays via task validate'
     optional: false
   - name: yamllint
     purpose: "Required by eks-gitops CI's lint:yaml job"

--- a/templates/electron-app/README.md
+++ b/templates/electron-app/README.md
@@ -14,13 +14,13 @@ Electron desktop application with a React 19 renderer for AI-powered chat. Main 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | `my-electron-app` | Kebab-case project name |
-| `Description` | string | `Desktop app with AI` | App description |
-| `LlmProvider` | string | `anthropic` | Default provider: anthropic or openai |
-| `IncludeAutoUpdate` | bool | `false` | Include auto-update support |
-| `IncludeTests` | bool | `true` | Include test setup |
+| Variable            | Type   | Default               | Description                           |
+| ------------------- | ------ | --------------------- | ------------------------------------- |
+| `ProjectName`       | string | `my-electron-app`     | Kebab-case project name               |
+| `Description`       | string | `Desktop app with AI` | App description                       |
+| `LlmProvider`       | string | `anthropic`           | Default provider: anthropic or openai |
+| `IncludeAutoUpdate` | bool   | `false`               | Include auto-update support           |
+| `IncludeTests`      | bool   | `true`                | Include test setup                    |
 
 ## Project layout
 

--- a/templates/electron-app/template.yaml
+++ b/templates/electron-app/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: electron-app
-displayName: "Electron Desktop App (React + esbuild)"
+displayName: 'Electron Desktop App (React + esbuild)'
 description: >
   Scaffolds an Electron desktop application with a React 19 renderer for
   AI-powered chat. The main process holds API keys and routes AI calls
   through IPC, keeping secrets out of the renderer. Uses esbuild for
   main process bundling and Vite for the renderer. Supports Anthropic
   and OpenAI as LLM providers with a pluggable registry.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -17,53 +17,53 @@ tags: [electron, desktop, react, typescript, ai, esbuild, vite]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
-    default: "my-electron-app"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
+    default: 'my-electron-app'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short app description for package.json and README"
-    prompt: "App description"
-    default: "Desktop app with AI"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short app description for package.json and README'
+    prompt: 'App description'
+    default: 'Desktop app with AI'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider for AI interactions"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider for AI interactions'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeAutoUpdate
     type: bool
-    placeholder: "__INCLUDE_AUTO_UPDATE__"
-    description: "Include electron-updater for auto-update support"
-    prompt: "Include auto-update?"
+    placeholder: '__INCLUDE_AUTO_UPDATE__'
+    description: 'Include electron-updater for auto-update support'
+    prompt: 'Include auto-update?'
     default: false
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test setup with Vitest"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test setup with Vitest'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/__tests__/ipc.test.ts"
+  - path: 'src/__tests__/ipc.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [mcp-server-ts, module-database-ts, module-storage-ts]
@@ -71,9 +71,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for Electron, esbuild, and Vite"
+    version: '>=22'
+    purpose: 'Node.js runtime for Electron, esbuild, and Vite'
     optional: false
   - name: electron
-    purpose: "Desktop runtime (installed as npm dependency)"
+    purpose: 'Desktop runtime (installed as npm dependency)'
     optional: true

--- a/templates/eval-harness/README.md
+++ b/templates/eval-harness/README.md
@@ -13,12 +13,12 @@ Standalone TypeScript evaluation framework for testing LLM outputs. Define eval 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | `my-evals` | Kebab-case project name |
-| `Description` | string | `LLM evaluation harness` | Project description |
-| `LlmProvider` | string | `anthropic` | Default provider: anthropic or openai |
-| `IncludeCi` | bool | `true` | Include GitHub Actions eval workflow |
+| Variable      | Type   | Default                  | Description                           |
+| ------------- | ------ | ------------------------ | ------------------------------------- |
+| `ProjectName` | string | `my-evals`               | Kebab-case project name               |
+| `Description` | string | `LLM evaluation harness` | Project description                   |
+| `LlmProvider` | string | `anthropic`              | Default provider: anthropic or openai |
+| `IncludeCi`   | bool   | `true`                   | Include GitHub Actions eval workflow  |
 
 ## Project layout
 

--- a/templates/eval-harness/template.yaml
+++ b/templates/eval-harness/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: eval-harness
-displayName: "Eval Harness"
+displayName: 'Eval Harness'
 description: >
   Scaffolds a standalone TypeScript evaluation framework for testing LLM
   outputs. Loads eval suites from YAML files, runs each case against an
@@ -9,7 +9,7 @@ description: >
   JSON schema, token limits, custom predicates), and reports results to
   the console or as structured JSON. Works with any LLM system —
   Anthropic and OpenAI providers included out of the box.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -18,46 +18,46 @@ tags: [typescript, eval, testing, llm, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory"
-    prompt: "Project name"
-    default: "my-evals"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory'
+    prompt: 'Project name'
+    default: 'my-evals'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "LLM evaluation harness"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'LLM evaluation harness'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider name (built-in: anthropic, openai — or any custom registered provider)"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider name (built-in: anthropic, openai — or any custom registered provider)'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeCi
     type: bool
-    placeholder: "__INCLUDE_CI__"
-    description: "Include GitHub Actions CI workflow for automated eval runs"
-    prompt: "Include CI workflow?"
+    placeholder: '__INCLUDE_CI__'
+    description: 'Include GitHub Actions CI workflow for automated eval runs'
+    prompt: 'Include CI workflow?'
     default: true
 
 conditionals:
-  - path: ".github/workflows/evals.yml"
+  - path: '.github/workflows/evals.yml'
     when: IncludeCi
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, rag-pipeline, mcp-server-ts]
@@ -65,6 +65,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/fine-tune-pipeline/README.md
+++ b/templates/fine-tune-pipeline/README.md
@@ -12,13 +12,13 @@ TypeScript CLI for end-to-end LLM fine-tuning. Prepare datasets, submit training
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | `my-fine-tune` | Kebab-case project name |
-| `Description` | string | `LLM fine-tuning pipeline` | Project description |
-| `Provider` | string | `openai` | Default training provider: openai or custom |
-| `IncludeEval` | bool | `true` | Include post-training eval module |
-| `IncludeTests` | bool | `true` | Include vitest test suite |
+| Variable       | Type   | Default                    | Description                                 |
+| -------------- | ------ | -------------------------- | ------------------------------------------- |
+| `ProjectName`  | string | `my-fine-tune`             | Kebab-case project name                     |
+| `Description`  | string | `LLM fine-tuning pipeline` | Project description                         |
+| `Provider`     | string | `openai`                   | Default training provider: openai or custom |
+| `IncludeEval`  | bool   | `true`                     | Include post-training eval module           |
+| `IncludeTests` | bool   | `true`                     | Include vitest test suite                   |
 
 ## Project layout
 

--- a/templates/fine-tune-pipeline/template.yaml
+++ b/templates/fine-tune-pipeline/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: fine-tune-pipeline
-displayName: "Fine-Tune Pipeline"
+displayName: 'Fine-Tune Pipeline'
 description: >
   Scaffolds a TypeScript CLI for fine-tuning LLMs. Handles end-to-end
   dataset preparation (JSONL formatting, schema validation, train/val/test
@@ -10,7 +10,7 @@ description: >
   that compares base model vs fine-tuned model outputs side by side.
   The provider registry is pluggable — add new training backends by
   creating a single file that self-registers at import time.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -19,59 +19,59 @@ tags: [typescript, fine-tuning, llm, training, dataset, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory"
-    prompt: "Project name"
-    default: "my-fine-tune"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory'
+    prompt: 'Project name'
+    default: 'my-fine-tune'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "LLM fine-tuning pipeline"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'LLM fine-tuning pipeline'
 
   - name: Provider
     type: string
-    placeholder: "__PROVIDER__"
-    description: "Default training provider name (built-in: openai — or any custom registered provider)"
-    prompt: "Training provider"
-    default: "openai"
+    placeholder: '__PROVIDER__'
+    description: 'Default training provider name (built-in: openai — or any custom registered provider)'
+    prompt: 'Training provider'
+    default: 'openai'
 
   - name: IncludeEval
     type: bool
-    placeholder: "__INCLUDE_EVAL__"
-    description: "Include post-training evaluation module for comparing base vs fine-tuned models"
-    prompt: "Include eval module?"
+    placeholder: '__INCLUDE_EVAL__'
+    description: 'Include post-training evaluation module for comparing base vs fine-tuned models'
+    prompt: 'Include eval module?'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include vitest test suite with dataset and validation tests"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include vitest test suite with dataset and validation tests'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/eval/compare.ts"
+  - path: 'src/eval/compare.ts'
     when: IncludeEval
-  - path: "src/eval/metrics.ts"
+  - path: 'src/eval/metrics.ts'
     when: IncludeEval
-  - path: "src/__tests__/dataset.test.ts"
+  - path: 'src/__tests__/dataset.test.ts'
     when: IncludeTests
-  - path: "src/__tests__/validate.test.ts"
+  - path: 'src/__tests__/validate.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [eval-harness, agentic-loop, rag-pipeline]
@@ -79,6 +79,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/go-cli/README.md
+++ b/templates/go-cli/README.md
@@ -13,14 +13,14 @@ Scaffolds a Go CLI application using [Cobra](https://github.com/spf13/cobra) for
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Org` | string | (required) | GitHub org or username |
-| `GoModule` | string | `github.com/<Org>/<ProjectName>` | Full Go module path |
-| `Description` | string | `A CLI application` | Short project description |
-| `IncludeRelease` | bool | `true` | Include GoReleaser + release workflow |
-| `LogFormat` | enum | `json` | Log format: json, text, or pretty |
+| Variable         | Type   | Default                          | Description                           |
+| ---------------- | ------ | -------------------------------- | ------------------------------------- |
+| `ProjectName`    | string | (required)                       | Kebab-case project name               |
+| `Org`            | string | (required)                       | GitHub org or username                |
+| `GoModule`       | string | `github.com/<Org>/<ProjectName>` | Full Go module path                   |
+| `Description`    | string | `A CLI application`              | Short project description             |
+| `IncludeRelease` | bool   | `true`                           | Include GoReleaser + release workflow |
+| `LogFormat`      | enum   | `json`                           | Log format: json, text, or pretty     |
 
 ## Project layout
 

--- a/templates/go-cli/template.yaml
+++ b/templates/go-cli/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: go-cli
-displayName: "Go CLI Application"
+displayName: 'Go CLI Application'
 description: >
   Scaffolds a Go CLI application using Cobra for command structure,
   Viper for configuration management, and log/slog for structured logging.
   Produces a buildable binary with a root command, version subcommand,
   config file support, and a Makefile. Optionally includes GoReleaser
   configuration and a GitHub Actions release workflow.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -17,69 +17,69 @@ tags: [go, cli, cobra, viper, slog]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as binary name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as binary name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Org
     type: string
-    placeholder: "__ORG__"
-    description: "GitHub organization or username"
-    prompt: "GitHub org/username"
+    placeholder: '__ORG__'
+    description: 'GitHub organization or username'
+    prompt: 'GitHub org/username'
     required: true
     validation:
-      pattern: "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
-      message: "Must be a valid GitHub org or username"
+      pattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*$'
+      message: 'Must be a valid GitHub org or username'
 
   - name: GoModule
     type: string
-    placeholder: "__GO_MODULE__"
-    description: "Full Go module path"
-    prompt: "Go module path"
-    default: "github.com/${Org}/${ProjectName}"
+    placeholder: '__GO_MODULE__'
+    description: 'Full Go module path'
+    prompt: 'Go module path'
+    default: 'github.com/${Org}/${ProjectName}'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9./-]*$"
-      message: "Must be a valid Go module path"
+      pattern: '^[a-z][a-z0-9./-]*$'
+      message: 'Must be a valid Go module path'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for help text and README"
-    prompt: "Project description"
-    default: "A CLI application"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for help text and README'
+    prompt: 'Project description'
+    default: 'A CLI application'
 
   - name: IncludeRelease
     type: bool
-    placeholder: "__INCLUDE_RELEASE__"
-    description: "Include GoReleaser configuration and GitHub Actions release workflow"
-    prompt: "Include release automation?"
+    placeholder: '__INCLUDE_RELEASE__'
+    description: 'Include GoReleaser configuration and GitHub Actions release workflow'
+    prompt: 'Include release automation?'
     default: true
 
   - name: LogFormat
     type: enum
-    placeholder: "__LOG_FORMAT__"
-    description: "Default structured log output format"
-    prompt: "Log format"
-    default: "json"
-    options: ["json", "text", "pretty"]
+    placeholder: '__LOG_FORMAT__'
+    description: 'Default structured log output format'
+    prompt: 'Log format'
+    default: 'json'
+    options: ['json', 'text', 'pretty']
 
 conditionals:
-  - path: ".goreleaser.yaml"
+  - path: '.goreleaser.yaml'
     when: IncludeRelease
-  - path: ".github/workflows/release.yml"
+  - path: '.github/workflows/release.yml'
     when: IncludeRelease
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Initialize Go module and tidy dependencies"
-      run: "go mod tidy"
-      workdir: "."
+      description: 'Initialize Go module and tidy dependencies'
+      run: 'go mod tidy'
+      workdir: '.'
 
 composition:
   pairsWith: [eval-harness, infra-fly]
@@ -87,10 +87,10 @@ composition:
 
 prerequisites:
   - name: go
-    version: ">=1.24"
-    purpose: "Go compilation and module management"
+    version: '>=1.24'
+    purpose: 'Go compilation and module management'
     optional: false
   - name: goreleaser
-    version: ">=2.0"
-    purpose: "Automated release builds (only needed if release config is included)"
+    version: '>=2.0'
+    purpose: 'Automated release builds (only needed if release config is included)'
     optional: true

--- a/templates/go-service/README.md
+++ b/templates/go-service/README.md
@@ -16,14 +16,14 @@ Scaffolds a Go HTTP service using [chi v5](https://github.com/go-chi/chi) for ro
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `GoModule` | string | `github.com/<Org>/<ProjectName>` | Full Go module path |
-| `Org` | string | (required) | GitHub org or username |
-| `Description` | string | `A Go HTTP service` | Short project description |
-| `Database` | string | `postgres` | Default database backend |
-| `IncludeDocker` | bool | `true` | Include Docker support |
+| Variable        | Type   | Default                          | Description               |
+| --------------- | ------ | -------------------------------- | ------------------------- |
+| `ProjectName`   | string | (required)                       | Kebab-case project name   |
+| `GoModule`      | string | `github.com/<Org>/<ProjectName>` | Full Go module path       |
+| `Org`           | string | (required)                       | GitHub org or username    |
+| `Description`   | string | `A Go HTTP service`              | Short project description |
+| `Database`      | string | `postgres`                       | Default database backend  |
+| `IncludeDocker` | bool   | `true`                           | Include Docker support    |
 
 ## Project layout
 

--- a/templates/go-service/template.yaml
+++ b/templates/go-service/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: go-service
-displayName: "Go HTTP Service"
+displayName: 'Go HTTP Service'
 description: >
   Scaffolds a Go HTTP service using chi v5 for routing, structured middleware
   (logging, panic recovery), a repository-pattern database layer with PostgreSQL
@@ -9,7 +9,7 @@ description: >
   instrumentation. Includes graceful shutdown with signal handling, a Makefile,
   GitHub Actions CI, and optional Docker support. Auth-neutral — stack
   `module-auth-go` alongside when you need authentication.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -18,68 +18,68 @@ tags: [go, chi, api, service, rest]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as binary name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as binary name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: GoModule
     type: string
-    placeholder: "__GO_MODULE__"
-    description: "Full Go module path"
-    prompt: "Go module path"
-    default: "github.com/${Org}/${ProjectName}"
+    placeholder: '__GO_MODULE__'
+    description: 'Full Go module path'
+    prompt: 'Go module path'
+    default: 'github.com/${Org}/${ProjectName}'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9./-]*$"
-      message: "Must be a valid Go module path"
+      pattern: '^[a-z][a-z0-9./-]*$'
+      message: 'Must be a valid Go module path'
 
   - name: Org
     type: string
-    placeholder: "__ORG__"
-    description: "GitHub organization or username"
-    prompt: "GitHub org/username"
+    placeholder: '__ORG__'
+    description: 'GitHub organization or username'
+    prompt: 'GitHub org/username'
     required: true
     validation:
-      pattern: "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
-      message: "Must be a valid GitHub org or username"
+      pattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*$'
+      message: 'Must be a valid GitHub org or username'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for help text and README"
-    prompt: "Project description"
-    default: "A Go HTTP service"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for help text and README'
+    prompt: 'Project description'
+    default: 'A Go HTTP service'
 
   - name: Database
     type: string
-    placeholder: "__DATABASE__"
-    description: "Default database backend"
-    prompt: "Database backend"
-    default: "postgres"
+    placeholder: '__DATABASE__'
+    description: 'Default database backend'
+    prompt: 'Database backend'
+    default: 'postgres'
 
   - name: IncludeDocker
     type: bool
-    placeholder: "__INCLUDE_DOCKER__"
-    description: "Include Dockerfile and docker-compose.yml"
-    prompt: "Include Docker support?"
+    placeholder: '__INCLUDE_DOCKER__'
+    description: 'Include Dockerfile and docker-compose.yml'
+    prompt: 'Include Docker support?'
     default: true
 
 conditionals:
-  - path: "Dockerfile"
+  - path: 'Dockerfile'
     when: IncludeDocker
-  - path: "docker-compose.yml"
+  - path: 'docker-compose.yml'
     when: IncludeDocker
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Tidy Go module dependencies"
-      run: "go mod tidy"
-      workdir: "."
+      description: 'Tidy Go module dependencies'
+      run: 'go mod tidy'
+      workdir: '.'
 
 composition:
   pairsWith: [infra-aws, infra-fly, eval-harness, module-auth-go]
@@ -87,6 +87,6 @@ composition:
 
 prerequisites:
   - name: go
-    version: ">=1.26"
-    purpose: "Go compilation and module management"
+    version: '>=1.26'
+    purpose: 'Go compilation and module management'
     optional: false

--- a/templates/guardrails/README.md
+++ b/templates/guardrails/README.md
@@ -11,13 +11,13 @@ Input/output safety filters for AI systems.
 
 ## Variables
 
-| Variable | Placeholder | Default | Description |
-|----------|-------------|---------|-------------|
-| `ProjectName` | `__PROJECT_NAME__` | *(required)* | Kebab-case package name |
-| `Description` | `__DESCRIPTION__` | AI safety guardrails | Package description |
-| `IncludePii` | `__INCLUDE_PII__` | `true` | Include PII detection filter |
-| `IncludeContentPolicy` | `__INCLUDE_CONTENT_POLICY__` | `true` | Include content policy filter |
-| `IncludeTests` | `__INCLUDE_TESTS__` | `true` | Include test suite |
+| Variable               | Placeholder                  | Default              | Description                   |
+| ---------------------- | ---------------------------- | -------------------- | ----------------------------- |
+| `ProjectName`          | `__PROJECT_NAME__`           | _(required)_         | Kebab-case package name       |
+| `Description`          | `__DESCRIPTION__`            | AI safety guardrails | Package description           |
+| `IncludePii`           | `__INCLUDE_PII__`            | `true`               | Include PII detection filter  |
+| `IncludeContentPolicy` | `__INCLUDE_CONTENT_POLICY__` | `true`               | Include content policy filter |
+| `IncludeTests`         | `__INCLUDE_TESTS__`          | `true`               | Include test suite            |
 
 ## Project layout
 

--- a/templates/guardrails/template.yaml
+++ b/templates/guardrails/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: guardrails
-displayName: "AI Safety Guardrails"
+displayName: 'AI Safety Guardrails'
 description: >
   Input/output safety filters for AI systems. Pluggable filter pipeline
   that sits between user and LLM boundaries, inspecting and filtering
   both directions. Ships with prompt-injection detection, PII redaction,
   content-policy enforcement, and token-limit guards. The filter registry
   pattern makes it trivial to add custom safety filters.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -17,57 +17,57 @@ tags: [ai, safety, guardrails, filters, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "AI safety guardrails"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'AI safety guardrails'
 
   - name: IncludePii
     type: bool
-    placeholder: "__INCLUDE_PII__"
-    description: "Include PII detection filter"
+    placeholder: '__INCLUDE_PII__'
+    description: 'Include PII detection filter'
     default: true
 
   - name: IncludeContentPolicy
     type: bool
-    placeholder: "__INCLUDE_CONTENT_POLICY__"
-    description: "Include content policy filter"
+    placeholder: '__INCLUDE_CONTENT_POLICY__'
+    description: 'Include content policy filter'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test suite"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test suite'
     default: true
 
 conditionals:
-  - path: "src/guardrails/filters/pii.ts"
+  - path: 'src/guardrails/filters/pii.ts'
     when: IncludePii
-  - path: "src/guardrails/filters/__tests__/pii.test.ts"
+  - path: 'src/guardrails/filters/__tests__/pii.test.ts'
     when: IncludePii
-  - path: "src/guardrails/filters/content-policy.ts"
+  - path: 'src/guardrails/filters/content-policy.ts'
     when: IncludeContentPolicy
-  - path: "src/guardrails/filters/__tests__/pipeline.test.ts"
+  - path: 'src/guardrails/filters/__tests__/pipeline.test.ts'
     when: IncludeTests
-  - path: "src/guardrails/filters/__tests__/prompt-injection.test.ts"
+  - path: 'src/guardrails/filters/__tests__/prompt-injection.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, mcp-server-ts, ts-service, rag-pipeline]
@@ -75,6 +75,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the guardrails module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the guardrails module'
     optional: false

--- a/templates/incident-postmortem/README.md
+++ b/templates/incident-postmortem/README.md
@@ -10,11 +10,11 @@ Scaffolds a structured postmortem with incident summary, timeline reconstruction
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ServiceName` | string | (required) | Human-readable service name |
-| `IncludeFollowUp` | bool | `true` | Include follow-up action tracker |
+| Variable          | Type   | Default    | Description                      |
+| ----------------- | ------ | ---------- | -------------------------------- |
+| `ProjectName`     | string | (required) | Kebab-case project name          |
+| `ServiceName`     | string | (required) | Human-readable service name      |
+| `IncludeFollowUp` | bool   | `true`     | Include follow-up action tracker |
 
 ## Project layout
 

--- a/templates/incident-postmortem/template.yaml
+++ b/templates/incident-postmortem/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: incident-postmortem
-displayName: "Incident Postmortem"
+displayName: 'Incident Postmortem'
 description: >
   Scaffolds a structured postmortem with incident summary, timeline
   reconstruction, root cause analysis using the 5 Whys method, impact
   assessment, and lessons learned. Optionally includes a follow-up
   action tracker. Designed for SRE and engineering teams conducting
   blameless postmortems after production incidents.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [operations]
 category: operations
@@ -17,30 +17,30 @@ tags: [postmortem, incident, root-cause, timeline, action-items, sre]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ServiceName
     type: string
-    placeholder: "__SERVICE_NAME__"
-    description: "Human-readable service name for document titles"
-    prompt: "Service name"
+    placeholder: '__SERVICE_NAME__'
+    description: 'Human-readable service name for document titles'
+    prompt: 'Service name'
     required: true
 
   - name: IncludeFollowUp
     type: bool
-    placeholder: "__INCLUDE_FOLLOW_UP__"
-    description: "Include a follow-up action tracker"
-    prompt: "Include follow-up tracker?"
+    placeholder: '__INCLUDE_FOLLOW_UP__'
+    description: 'Include a follow-up action tracker'
+    prompt: 'Include follow-up tracker?'
     default: true
 
 conditionals:
-  - path: "postmortem/follow-up-tracker.yaml"
+  - path: 'postmortem/follow-up-tracker.yaml'
     when: IncludeFollowUp
 
 composition:

--- a/templates/infra-aws/README.md
+++ b/templates/infra-aws/README.md
@@ -32,15 +32,15 @@ The ECS Fargate path in this template is a historical fallback. Prefer EKS via `
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | `infra` | Kebab-case project name |
-| `Description` | string | `AWS CDK infrastructure for AI services` | Project description |
-| `AwsRegion` | string | `us-east-1` | AWS deployment region |
-| `ComputeTarget` | enum | `lambda` | Compute platform: `lambda` (preferred) or `ecs` (fallback) |
-| `IncludeVpc` | bool | `false` | Include VPC networking |
-| `IncludeRds` | bool | `false` | Include RDS PostgreSQL |
-| `IncludeMonitoring` | bool | `true` | Include CloudWatch monitoring |
+| Variable            | Type   | Default                                  | Description                                                |
+| ------------------- | ------ | ---------------------------------------- | ---------------------------------------------------------- |
+| `ProjectName`       | string | `infra`                                  | Kebab-case project name                                    |
+| `Description`       | string | `AWS CDK infrastructure for AI services` | Project description                                        |
+| `AwsRegion`         | string | `us-east-1`                              | AWS deployment region                                      |
+| `ComputeTarget`     | enum   | `lambda`                                 | Compute platform: `lambda` (preferred) or `ecs` (fallback) |
+| `IncludeVpc`        | bool   | `false`                                  | Include VPC networking                                     |
+| `IncludeRds`        | bool   | `false`                                  | Include RDS PostgreSQL                                     |
+| `IncludeMonitoring` | bool   | `true`                                   | Include CloudWatch monitoring                              |
 
 ## Project layout
 

--- a/templates/infra-aws/template.yaml
+++ b/templates/infra-aws/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: infra-aws
-displayName: "AWS CDK Infrastructure"
+displayName: 'AWS CDK Infrastructure'
 description: >
   Scaffolds an AWS CDK (TypeScript) infrastructure project for deploying
   AI services. Supports Lambda or ECS Fargate compute targets with API
@@ -9,7 +9,7 @@ description: >
   PostgreSQL database, and CloudWatch monitoring with alarms. Produces
   a deployable CDK app with modular constructs, snapshot tests, and
   standard CDK toolchain scripts.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -18,75 +18,75 @@ tags: [aws, cdk, infrastructure, typescript, iac]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as stack name and package name"
-    prompt: "Project name"
-    default: "infra"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as stack name and package name'
+    prompt: 'Project name'
+    default: 'infra'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README and package.json"
-    prompt: "Project description"
-    default: "AWS CDK infrastructure for AI services"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README and package.json'
+    prompt: 'Project description'
+    default: 'AWS CDK infrastructure for AI services'
 
   - name: AwsRegion
     type: string
-    placeholder: "__AWS_REGION__"
-    description: "AWS region for deployment"
-    prompt: "AWS region"
-    default: "us-east-1"
+    placeholder: '__AWS_REGION__'
+    description: 'AWS region for deployment'
+    prompt: 'AWS region'
+    default: 'us-east-1'
     validation:
-      pattern: "^[a-z]{2}-[a-z]+-[0-9]+$"
-      message: "Must be a valid AWS region (e.g. us-east-1, eu-west-2)"
+      pattern: '^[a-z]{2}-[a-z]+-[0-9]+$'
+      message: 'Must be a valid AWS region (e.g. us-east-1, eu-west-2)'
 
   - name: ComputeTarget
     type: enum
-    placeholder: "__COMPUTE_TARGET__"
-    description: "Compute platform for the service"
-    prompt: "Compute target"
-    default: "lambda"
-    options: ["lambda", "ecs"]
+    placeholder: '__COMPUTE_TARGET__'
+    description: 'Compute platform for the service'
+    prompt: 'Compute target'
+    default: 'lambda'
+    options: ['lambda', 'ecs']
 
   - name: IncludeVpc
     type: bool
-    placeholder: "__INCLUDE_VPC__"
-    description: "Include VPC with public and private subnets"
-    prompt: "Include VPC?"
+    placeholder: '__INCLUDE_VPC__'
+    description: 'Include VPC with public and private subnets'
+    prompt: 'Include VPC?'
     default: false
 
   - name: IncludeRds
     type: bool
-    placeholder: "__INCLUDE_RDS__"
-    description: "Include RDS PostgreSQL database with Secrets Manager credentials"
-    prompt: "Include RDS database?"
+    placeholder: '__INCLUDE_RDS__'
+    description: 'Include RDS PostgreSQL database with Secrets Manager credentials'
+    prompt: 'Include RDS database?'
     default: false
 
   - name: IncludeMonitoring
     type: bool
-    placeholder: "__INCLUDE_MONITORING__"
-    description: "Include CloudWatch dashboard, alarms, and SNS notifications"
-    prompt: "Include monitoring?"
+    placeholder: '__INCLUDE_MONITORING__'
+    description: 'Include CloudWatch dashboard, alarms, and SNS notifications'
+    prompt: 'Include monitoring?'
     default: true
 
 conditionals:
-  - path: "lib/constructs/vpc.ts"
+  - path: 'lib/constructs/vpc.ts'
     when: IncludeVpc || IncludeRds
-  - path: "lib/constructs/database.ts"
+  - path: 'lib/constructs/database.ts'
     when: IncludeRds
-  - path: "lib/constructs/monitoring.ts"
+  - path: 'lib/constructs/monitoring.ts'
     when: IncludeMonitoring
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [go-service, ts-service, go-cli]
@@ -94,10 +94,10 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for CDK and TypeScript"
+    version: '>=22'
+    purpose: 'Node.js runtime for CDK and TypeScript'
     optional: false
   - name: aws-cdk
-    version: ">=2.170"
-    purpose: "AWS CDK CLI for synthesizing and deploying stacks"
+    version: '>=2.170'
+    purpose: 'AWS CDK CLI for synthesizing and deploying stacks'
     optional: true

--- a/templates/infra-cloudflare/README.md
+++ b/templates/infra-cloudflare/README.md
@@ -12,13 +12,13 @@ Cloudflare Workers deployment configuration with wrangler.toml, TypeScript entry
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `Cloudflare Workers deployment` | Project description |
-| `IncludeR2` | bool | `false` | Include R2 storage bindings |
-| `IncludeD1` | bool | `false` | Include D1 database bindings |
-| `IncludeCi` | bool | `true` | Include GitHub Actions workflow |
+| Variable      | Type   | Default                         | Description                     |
+| ------------- | ------ | ------------------------------- | ------------------------------- |
+| `ProjectName` | string | (required)                      | Kebab-case project name         |
+| `Description` | string | `Cloudflare Workers deployment` | Project description             |
+| `IncludeR2`   | bool   | `false`                         | Include R2 storage bindings     |
+| `IncludeD1`   | bool   | `false`                         | Include D1 database bindings    |
+| `IncludeCi`   | bool   | `true`                          | Include GitHub Actions workflow |
 
 ## Project layout
 

--- a/templates/infra-cloudflare/template.yaml
+++ b/templates/infra-cloudflare/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: infra-cloudflare
-displayName: "Cloudflare Workers Deployment"
+displayName: 'Cloudflare Workers Deployment'
 description: >
   Scaffolds a Cloudflare Workers project with wrangler.toml configuration,
   a TypeScript fetch handler entry point, deploy scripts with environment
   selection, and an optional GitHub Actions CI/CD workflow for preview
   deploys on pull requests and production deploys on push to main. Includes
   commented R2 and D1 binding sections ready to uncomment.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -17,44 +17,44 @@ tags: [cloudflare, workers, edge, serverless, infrastructure]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as Worker name and resource identifiers"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as Worker name and resource identifiers'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README"
-    prompt: "Project description"
-    default: "Cloudflare Workers deployment"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README'
+    prompt: 'Project description'
+    default: 'Cloudflare Workers deployment'
 
   - name: IncludeR2
     type: bool
-    placeholder: "__INCLUDE_R2__"
-    description: "Include R2 object storage binding configuration and examples"
-    prompt: "Include R2 storage?"
+    placeholder: '__INCLUDE_R2__'
+    description: 'Include R2 object storage binding configuration and examples'
+    prompt: 'Include R2 storage?'
     default: false
 
   - name: IncludeD1
     type: bool
-    placeholder: "__INCLUDE_D1__"
-    description: "Include D1 database binding configuration and examples"
-    prompt: "Include D1 database?"
+    placeholder: '__INCLUDE_D1__'
+    description: 'Include D1 database binding configuration and examples'
+    prompt: 'Include D1 database?'
     default: false
 
   - name: IncludeCi
     type: bool
-    placeholder: "__INCLUDE_CI__"
-    description: "Include GitHub Actions workflow for preview and production deploys"
-    prompt: "Include CI/CD?"
+    placeholder: '__INCLUDE_CI__'
+    description: 'Include GitHub Actions workflow for preview and production deploys'
+    prompt: 'Include CI/CD?'
     default: true
 
 conditionals:
-  - path: ".github/workflows/deploy.yml"
+  - path: '.github/workflows/deploy.yml'
     when: IncludeCi
 
 composition:
@@ -63,9 +63,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for Wrangler CLI"
+    version: '>=22'
+    purpose: 'Node.js runtime for Wrangler CLI'
     optional: false
   - name: wrangler
-    purpose: "Cloudflare CLI for deploying and managing Workers"
+    purpose: 'Cloudflare CLI for deploying and managing Workers'
     optional: true

--- a/templates/infra-druid/README.md
+++ b/templates/infra-druid/README.md
@@ -15,15 +15,15 @@ Helm chart for deploying an Apache Druid OLAP cluster on Kubernetes. Six service
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `Apache Druid OLAP cluster` | Project description |
-| `DruidVersion` | string | `36.0.0` | Druid container image version |
-| `MetadataDriver` | string | `postgresql` | Metadata storage driver |
-| `DeepStorageType` | string | `s3` | Deep storage backend |
-| `IncludeMonitoring` | bool | `true` | Include Prometheus metrics emitter |
-| `IncludeTls` | bool | `true` | Include cert-manager TLS certificates |
+| Variable            | Type   | Default                     | Description                           |
+| ------------------- | ------ | --------------------------- | ------------------------------------- |
+| `ProjectName`       | string | (required)                  | Kebab-case project name               |
+| `Description`       | string | `Apache Druid OLAP cluster` | Project description                   |
+| `DruidVersion`      | string | `36.0.0`                    | Druid container image version         |
+| `MetadataDriver`    | string | `postgresql`                | Metadata storage driver               |
+| `DeepStorageType`   | string | `s3`                        | Deep storage backend                  |
+| `IncludeMonitoring` | bool   | `true`                      | Include Prometheus metrics emitter    |
+| `IncludeTls`        | bool   | `true`                      | Include cert-manager TLS certificates |
 
 ## Project layout
 

--- a/templates/infra-druid/template.yaml
+++ b/templates/infra-druid/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: infra-druid
-displayName: "Apache Druid OLAP Cluster"
+displayName: 'Apache Druid OLAP Cluster'
 description: >
   Scaffolds an Apache Druid OLAP cluster as a Helm chart for Kubernetes.
   Includes all six Druid services (router, broker, coordinator, overlord,
@@ -10,7 +10,7 @@ description: >
   (no ZooKeeper), configurable metadata storage and deep storage backends,
   optional cert-manager TLS certificates, and optional Prometheus metrics
   emitter.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -19,61 +19,61 @@ tags: [druid, olap, analytics, kubernetes, helm, infrastructure]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as Helm release name and resource prefix"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as Helm release name and resource prefix'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README and chart metadata"
-    prompt: "Project description"
-    default: "Apache Druid OLAP cluster"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README and chart metadata'
+    prompt: 'Project description'
+    default: 'Apache Druid OLAP cluster'
 
   - name: DruidVersion
     type: string
-    placeholder: "__DRUID_VERSION__"
-    description: "Apache Druid version for the container image"
-    prompt: "Druid version"
-    default: "37.0.0"
+    placeholder: '__DRUID_VERSION__'
+    description: 'Apache Druid version for the container image'
+    prompt: 'Druid version'
+    default: '37.0.0'
     validation:
       pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
-      message: "Must be a valid semver (e.g. 37.0.0)"
+      message: 'Must be a valid semver (e.g. 37.0.0)'
 
   - name: MetadataDriver
     type: string
-    placeholder: "__METADATA_DRIVER__"
-    description: "Metadata storage driver (postgresql, mysql, derby)"
-    prompt: "Metadata storage driver"
-    default: "postgresql"
+    placeholder: '__METADATA_DRIVER__'
+    description: 'Metadata storage driver (postgresql, mysql, derby)'
+    prompt: 'Metadata storage driver'
+    default: 'postgresql'
 
   - name: DeepStorageType
     type: string
-    placeholder: "__DEEP_STORAGE_TYPE__"
-    description: "Deep storage backend (s3, google, azure, hdfs, local)"
-    prompt: "Deep storage type"
-    default: "s3"
+    placeholder: '__DEEP_STORAGE_TYPE__'
+    description: 'Deep storage backend (s3, google, azure, hdfs, local)'
+    prompt: 'Deep storage type'
+    default: 's3'
 
   - name: IncludeMonitoring
     type: bool
-    placeholder: "__INCLUDE_MONITORING__"
-    description: "Include Prometheus metrics emitter configuration and annotations"
-    prompt: "Include monitoring?"
+    placeholder: '__INCLUDE_MONITORING__'
+    description: 'Include Prometheus metrics emitter configuration and annotations'
+    prompt: 'Include monitoring?'
     default: true
 
   - name: IncludeTls
     type: bool
-    placeholder: "__INCLUDE_TLS__"
-    description: "Include cert-manager Certificate for internal mTLS"
-    prompt: "Include TLS?"
+    placeholder: '__INCLUDE_TLS__'
+    description: 'Include cert-manager Certificate for internal mTLS'
+    prompt: 'Include TLS?'
     default: true
 
 conditionals:
-  - path: "chart/templates/certificate.yaml"
+  - path: 'chart/templates/certificate.yaml'
     when: IncludeTls
 
 composition:
@@ -82,12 +82,12 @@ composition:
 
 prerequisites:
   - name: kubectl
-    purpose: "Kubernetes CLI for cluster access and manifest debugging"
+    purpose: 'Kubernetes CLI for cluster access and manifest debugging'
     optional: false
   - name: helm
-    version: ">=3.0"
-    purpose: "Helm CLI for installing and upgrading the Druid chart"
+    version: '>=3.0'
+    purpose: 'Helm CLI for installing and upgrading the Druid chart'
     optional: false
   - name: cert-manager
-    purpose: "Kubernetes certificate management (only needed if TLS is enabled)"
+    purpose: 'Kubernetes certificate management (only needed if TLS is enabled)'
     optional: true

--- a/templates/infra-fly/README.md
+++ b/templates/infra-fly/README.md
@@ -13,16 +13,16 @@ Fly.io deployment configuration with fly.toml, multi-stage Dockerfile, deploy sc
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `Fly.io deployment configuration` | Project description |
-| `AppName` | string | (required) | Fly app name (globally unique) |
-| `Region` | string | `iad` | Fly.io region code |
-| `MachineSize` | string | `shared-cpu-1x` | VM size |
-| `IncludePostgres` | bool | `false` | Include Postgres setup |
-| `IncludeRedis` | bool | `false` | Include Redis setup |
-| `IncludeCi` | bool | `true` | Include GitHub Actions workflow |
+| Variable          | Type   | Default                           | Description                     |
+| ----------------- | ------ | --------------------------------- | ------------------------------- |
+| `ProjectName`     | string | (required)                        | Kebab-case project name         |
+| `Description`     | string | `Fly.io deployment configuration` | Project description             |
+| `AppName`         | string | (required)                        | Fly app name (globally unique)  |
+| `Region`          | string | `iad`                             | Fly.io region code              |
+| `MachineSize`     | string | `shared-cpu-1x`                   | VM size                         |
+| `IncludePostgres` | bool   | `false`                           | Include Postgres setup          |
+| `IncludeRedis`    | bool   | `false`                           | Include Redis setup             |
+| `IncludeCi`       | bool   | `true`                            | Include GitHub Actions workflow |
 
 ## Project layout
 

--- a/templates/infra-fly/template.yaml
+++ b/templates/infra-fly/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: infra-fly
-displayName: "Fly.io Deployment"
+displayName: 'Fly.io Deployment'
 description: >
   Scaffolds a Fly.io deployment configuration with fly.toml, multi-stage
   Dockerfile, deploy scripts, and optional Postgres and Redis provisioning.
   Includes a GitHub Actions CI/CD workflow for automatic deploys on push
   to main. Designed to pair with service templates for a complete deploy
   pipeline.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -17,75 +17,75 @@ tags: [fly, deployment, infrastructure, docker]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as directory name and identifiers"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as directory name and identifiers'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README"
-    prompt: "Project description"
-    default: "Fly.io deployment configuration"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README'
+    prompt: 'Project description'
+    default: 'Fly.io deployment configuration'
 
   - name: AppName
     type: string
-    placeholder: "__APP_NAME__"
-    description: "Fly app name (must be globally unique on Fly.io)"
-    prompt: "Fly app name"
+    placeholder: '__APP_NAME__'
+    description: 'Fly app name (must be globally unique on Fly.io)'
+    prompt: 'Fly app name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Region
     type: string
-    placeholder: "__REGION__"
-    description: "Fly.io deployment region"
-    prompt: "Primary region"
-    default: "iad"
+    placeholder: '__REGION__'
+    description: 'Fly.io deployment region'
+    prompt: 'Primary region'
+    default: 'iad'
     validation:
-      pattern: "^[a-z]{3}$"
-      message: "Must be a three-letter Fly.io region code (e.g. iad, ord, lhr)"
+      pattern: '^[a-z]{3}$'
+      message: 'Must be a three-letter Fly.io region code (e.g. iad, ord, lhr)'
 
   - name: MachineSize
     type: string
-    placeholder: "__MACHINE_SIZE__"
-    description: "Fly machine VM size"
-    prompt: "Machine size"
-    default: "shared-cpu-1x"
+    placeholder: '__MACHINE_SIZE__'
+    description: 'Fly machine VM size'
+    prompt: 'Machine size'
+    default: 'shared-cpu-1x'
 
   - name: IncludePostgres
     type: bool
-    placeholder: "__INCLUDE_POSTGRES__"
-    description: "Include Fly Postgres database setup script"
-    prompt: "Include Postgres?"
+    placeholder: '__INCLUDE_POSTGRES__'
+    description: 'Include Fly Postgres database setup script'
+    prompt: 'Include Postgres?'
     default: false
 
   - name: IncludeRedis
     type: bool
-    placeholder: "__INCLUDE_REDIS__"
-    description: "Include Fly Redis (Upstash) setup script"
-    prompt: "Include Redis?"
+    placeholder: '__INCLUDE_REDIS__'
+    description: 'Include Fly Redis (Upstash) setup script'
+    prompt: 'Include Redis?'
     default: false
 
   - name: IncludeCi
     type: bool
-    placeholder: "__INCLUDE_CI__"
-    description: "Include GitHub Actions deploy workflow"
-    prompt: "Include CI/CD?"
+    placeholder: '__INCLUDE_CI__'
+    description: 'Include GitHub Actions deploy workflow'
+    prompt: 'Include CI/CD?'
     default: true
 
 conditionals:
-  - path: "scripts/setup-db.sh"
+  - path: 'scripts/setup-db.sh'
     when: IncludePostgres
-  - path: "scripts/setup-redis.sh"
+  - path: 'scripts/setup-redis.sh'
     when: IncludeRedis
-  - path: ".github/workflows/deploy.yml"
+  - path: '.github/workflows/deploy.yml'
     when: IncludeCi
 
 composition:
@@ -94,5 +94,5 @@ composition:
 
 prerequisites:
   - name: flyctl
-    purpose: "Fly.io CLI for deploying and managing apps"
+    purpose: 'Fly.io CLI for deploying and managing apps'
     optional: true

--- a/templates/infra-gcp/README.md
+++ b/templates/infra-gcp/README.md
@@ -13,15 +13,15 @@ GCP deployment configuration using gcloud CLI. Deploys to Cloud Run with a multi
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `GCP infrastructure` | Project description |
-| `GcpProject` | string | (required) | GCP project ID |
-| `GcpRegion` | string | `us-central1` | GCP region |
-| `IncludeCloudSql` | bool | `false` | Include Cloud SQL PostgreSQL |
-| `IncludeMonitoring` | bool | `true` | Include Cloud Monitoring |
-| `IncludeCi` | bool | `true` | Include GitHub Actions workflow |
+| Variable            | Type   | Default              | Description                     |
+| ------------------- | ------ | -------------------- | ------------------------------- |
+| `ProjectName`       | string | (required)           | Kebab-case project name         |
+| `Description`       | string | `GCP infrastructure` | Project description             |
+| `GcpProject`        | string | (required)           | GCP project ID                  |
+| `GcpRegion`         | string | `us-central1`        | GCP region                      |
+| `IncludeCloudSql`   | bool   | `false`              | Include Cloud SQL PostgreSQL    |
+| `IncludeMonitoring` | bool   | `true`               | Include Cloud Monitoring        |
+| `IncludeCi`         | bool   | `true`               | Include GitHub Actions workflow |
 
 ## Project layout
 

--- a/templates/infra-gcp/template.yaml
+++ b/templates/infra-gcp/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: infra-gcp
-displayName: "GCP Cloud Run Deployment"
+displayName: 'GCP Cloud Run Deployment'
 description: >
   Scaffolds a GCP deployment configuration using gcloud CLI. Deploys to
   Cloud Run with a multi-stage Dockerfile, deploy scripts, and optional
   Cloud SQL PostgreSQL, Cloud Monitoring dashboards, and GitHub Actions
   CI/CD workflow. Designed to pair with service templates for a complete
   deploy pipeline.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -17,72 +17,72 @@ tags: [gcp, cloud-run, deployment, infrastructure, docker]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as directory name and identifiers"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as directory name and identifiers'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README"
-    prompt: "Project description"
-    default: "GCP infrastructure"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README'
+    prompt: 'Project description'
+    default: 'GCP infrastructure'
 
   - name: GcpProject
     type: string
-    placeholder: "__GCP_PROJECT__"
-    description: "GCP project ID"
-    prompt: "GCP project ID"
+    placeholder: '__GCP_PROJECT__'
+    description: 'GCP project ID'
+    prompt: 'GCP project ID'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]{4,28}[a-z0-9]$"
-      message: "Must be a valid GCP project ID (6-30 chars, lowercase, hyphens allowed)"
+      pattern: '^[a-z][a-z0-9-]{4,28}[a-z0-9]$'
+      message: 'Must be a valid GCP project ID (6-30 chars, lowercase, hyphens allowed)'
 
   - name: GcpRegion
     type: string
-    placeholder: "__GCP_REGION__"
-    description: "GCP region for deployment"
-    prompt: "GCP region"
-    default: "us-central1"
+    placeholder: '__GCP_REGION__'
+    description: 'GCP region for deployment'
+    prompt: 'GCP region'
+    default: 'us-central1'
     validation:
-      pattern: "^[a-z]+-[a-z]+[0-9]+$"
-      message: "Must be a valid GCP region (e.g. us-central1, europe-west1)"
+      pattern: '^[a-z]+-[a-z]+[0-9]+$'
+      message: 'Must be a valid GCP region (e.g. us-central1, europe-west1)'
 
   - name: IncludeCloudSql
     type: bool
-    placeholder: "__INCLUDE_CLOUD_SQL__"
-    description: "Include Cloud SQL PostgreSQL instance and connection script"
-    prompt: "Include Cloud SQL?"
+    placeholder: '__INCLUDE_CLOUD_SQL__'
+    description: 'Include Cloud SQL PostgreSQL instance and connection script'
+    prompt: 'Include Cloud SQL?'
     default: false
 
   - name: IncludeMonitoring
     type: bool
-    placeholder: "__INCLUDE_MONITORING__"
-    description: "Include Cloud Monitoring dashboard and alert policies"
-    prompt: "Include monitoring?"
+    placeholder: '__INCLUDE_MONITORING__'
+    description: 'Include Cloud Monitoring dashboard and alert policies'
+    prompt: 'Include monitoring?'
     default: true
 
   - name: IncludeCi
     type: bool
-    placeholder: "__INCLUDE_CI__"
-    description: "Include GitHub Actions deploy workflow"
-    prompt: "Include CI/CD?"
+    placeholder: '__INCLUDE_CI__'
+    description: 'Include GitHub Actions deploy workflow'
+    prompt: 'Include CI/CD?'
     default: true
 
 conditionals:
-  - path: "scripts/setup-db.sh"
+  - path: 'scripts/setup-db.sh'
     when: IncludeCloudSql
-  - path: "monitoring/dashboard.json"
+  - path: 'monitoring/dashboard.json'
     when: IncludeMonitoring
-  - path: "monitoring/alerts.json"
+  - path: 'monitoring/alerts.json'
     when: IncludeMonitoring
-  - path: "scripts/setup-monitoring.sh"
+  - path: 'scripts/setup-monitoring.sh'
     when: IncludeMonitoring
-  - path: ".github/workflows/deploy.yml"
+  - path: '.github/workflows/deploy.yml'
     when: IncludeCi
 
 composition:
@@ -91,8 +91,8 @@ composition:
 
 prerequisites:
   - name: gcloud
-    purpose: "Google Cloud CLI for deploying and managing GCP resources"
+    purpose: 'Google Cloud CLI for deploying and managing GCP resources'
     optional: false
   - name: docker
-    purpose: "Container runtime for building images"
+    purpose: 'Container runtime for building images'
     optional: true

--- a/templates/infra-vercel/README.md
+++ b/templates/infra-vercel/README.md
@@ -11,12 +11,12 @@ Vercel deployment configuration with vercel.json, deploy scripts, and optional C
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `Vercel deployment` | Project description |
-| `Framework` | string | `nextjs` | Framework preset for vercel.json |
-| `IncludeCi` | bool | `true` | Include GitHub Actions workflow |
+| Variable      | Type   | Default             | Description                      |
+| ------------- | ------ | ------------------- | -------------------------------- |
+| `ProjectName` | string | (required)          | Kebab-case project name          |
+| `Description` | string | `Vercel deployment` | Project description              |
+| `Framework`   | string | `nextjs`            | Framework preset for vercel.json |
+| `IncludeCi`   | bool   | `true`              | Include GitHub Actions workflow  |
 
 ## Project layout
 

--- a/templates/infra-vercel/template.yaml
+++ b/templates/infra-vercel/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: infra-vercel
-displayName: "Vercel Deployment"
+displayName: 'Vercel Deployment'
 description: >
   Scaffolds a Vercel deployment configuration with vercel.json, environment
   variable setup, deploy scripts, and an optional GitHub Actions CI/CD
   workflow for preview deploys on pull requests and production deploys on
   push to main. Designed to pair with Next.js and TypeScript service
   templates for a complete deploy pipeline.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -17,37 +17,37 @@ tags: [vercel, deployment, infrastructure, ci-cd]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as directory name and identifiers"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as directory name and identifiers'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README"
-    prompt: "Project description"
-    default: "Vercel deployment"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README'
+    prompt: 'Project description'
+    default: 'Vercel deployment'
 
   - name: Framework
     type: string
-    placeholder: "__FRAMEWORK__"
-    description: "Framework preset for vercel.json (nextjs, vite, etc.)"
-    prompt: "Framework preset"
-    default: "nextjs"
+    placeholder: '__FRAMEWORK__'
+    description: 'Framework preset for vercel.json (nextjs, vite, etc.)'
+    prompt: 'Framework preset'
+    default: 'nextjs'
 
   - name: IncludeCi
     type: bool
-    placeholder: "__INCLUDE_CI__"
-    description: "Include GitHub Actions workflow for preview and production deploys"
-    prompt: "Include CI/CD?"
+    placeholder: '__INCLUDE_CI__'
+    description: 'Include GitHub Actions workflow for preview and production deploys'
+    prompt: 'Include CI/CD?'
     default: true
 
 conditionals:
-  - path: ".github/workflows/deploy.yml"
+  - path: '.github/workflows/deploy.yml'
     when: IncludeCi
 
 composition:
@@ -56,9 +56,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for Vercel CLI"
+    version: '>=22'
+    purpose: 'Node.js runtime for Vercel CLI'
     optional: false
   - name: vercel
-    purpose: "Vercel CLI for deploying and managing projects"
+    purpose: 'Vercel CLI for deploying and managing projects'
     optional: true

--- a/templates/istio-policy/README.md
+++ b/templates/istio-policy/README.md
@@ -8,22 +8,22 @@ Drops alongside any containerized service — pairs naturally with [spring-boot-
 
 - **`request-authentication.yaml`** — configures the JWT issuer + JWKs endpoint so the sidecar decodes incoming tokens and exposes their claims to the authorization layer. Requests without a valid token proceed without an authenticated principal (the AuthorizationPolicy decides what to do with them).
 - **`authorization-policy.yaml`** — enforces that inbound traffic carries a JWT issued by the configured issuer with the expected audience. Blocks unauthenticated requests at the sidecar, before they reach the application.
-- **`peer-authentication.yaml`** *(conditional)* — enforces STRICT mTLS between sidecars in the namespace. Only turn this on once every workload in the namespace has a sidecar; in STRICT mode, non-mTLS traffic is rejected.
-- **`virtual-service.yaml`** *(conditional)* — routing template attached to either the internal mesh (`gateways: [mesh]`) or an external Istio gateway. Ships with a single catch-all route; add path-based splits or traffic shifting as needed.
+- **`peer-authentication.yaml`** _(conditional)_ — enforces STRICT mTLS between sidecars in the namespace. Only turn this on once every workload in the namespace has a sidecar; in STRICT mode, non-mTLS traffic is rejected.
+- **`virtual-service.yaml`** _(conditional)_ — routing template attached to either the internal mesh (`gateways: [mesh]`) or an external Istio gateway. Ships with a single catch-all route; add path-based splits or traffic shifting as needed.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name; drives resource names and selector labels |
-| `Namespace` | string | `default` | Kubernetes namespace |
-| `OidcIssuer` | string | (required) | OIDC issuer URL that signs inbound JWTs |
-| `JwksUri` | string | `<OidcIssuer>/.well-known/jwks.json` | JWKs endpoint URL |
-| `AllowedAudience` | string | `<ProjectName>` | Required JWT `aud` claim value |
-| `ServiceHost` | string | `<ProjectName>.<Namespace>.svc.cluster.local` | Fully-qualified service host (for VirtualService) |
-| `GatewayName` | string | `mesh` | Gateway the VirtualService attaches to (`mesh` = internal-only) |
-| `IncludeMTls` | bool | `false` | Ship a STRICT PeerAuthentication |
-| `IncludeVirtualService` | bool | `false` | Ship a VirtualService |
+| Variable                | Type   | Default                                       | Description                                                        |
+| ----------------------- | ------ | --------------------------------------------- | ------------------------------------------------------------------ |
+| `ProjectName`           | string | (required)                                    | Kebab-case project name; drives resource names and selector labels |
+| `Namespace`             | string | `default`                                     | Kubernetes namespace                                               |
+| `OidcIssuer`            | string | (required)                                    | OIDC issuer URL that signs inbound JWTs                            |
+| `JwksUri`               | string | `<OidcIssuer>/.well-known/jwks.json`          | JWKs endpoint URL                                                  |
+| `AllowedAudience`       | string | `<ProjectName>`                               | Required JWT `aud` claim value                                     |
+| `ServiceHost`           | string | `<ProjectName>.<Namespace>.svc.cluster.local` | Fully-qualified service host (for VirtualService)                  |
+| `GatewayName`           | string | `mesh`                                        | Gateway the VirtualService attaches to (`mesh` = internal-only)    |
+| `IncludeMTls`           | bool   | `false`                                       | Ship a STRICT PeerAuthentication                                   |
+| `IncludeVirtualService` | bool   | `false`                                       | Ship a VirtualService                                              |
 
 ## Project layout
 

--- a/templates/istio-policy/template.yaml
+++ b/templates/istio-policy/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: istio-policy
-displayName: "Istio Service-Mesh Policy"
+displayName: 'Istio Service-Mesh Policy'
 description: >
   Scaffolds an Istio policy bundle for an HTTP workload on a service mesh:
   an AuthorizationPolicy that enforces JWT authentication, a
@@ -9,7 +9,7 @@ description: >
   an optional PeerAuthentication enforcing STRICT mTLS, and an optional
   VirtualService routing template. Designed to drop alongside any
   containerized service template (spring-boot-service, go-service, ts-service).
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -18,86 +18,86 @@ tags: [istio, kubernetes, k8s, service-mesh, authorization, oidc, mtls, security
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used for resource names and selector labels"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used for resource names and selector labels'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Namespace
     type: string
-    placeholder: "__NAMESPACE__"
-    description: "Kubernetes namespace the policy resources are applied to"
-    prompt: "Namespace"
-    default: "default"
+    placeholder: '__NAMESPACE__'
+    description: 'Kubernetes namespace the policy resources are applied to'
+    prompt: 'Namespace'
+    default: 'default'
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be a valid Kubernetes namespace (lowercase kebab-case)"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be a valid Kubernetes namespace (lowercase kebab-case)'
 
   - name: OidcIssuer
     type: string
-    placeholder: "__OIDC_ISSUER__"
-    description: "OIDC issuer URL that signs inbound JWTs (e.g. https://auth.example.com)"
-    prompt: "OIDC issuer URL"
+    placeholder: '__OIDC_ISSUER__'
+    description: 'OIDC issuer URL that signs inbound JWTs (e.g. https://auth.example.com)'
+    prompt: 'OIDC issuer URL'
     required: true
 
   - name: JwksUri
     type: string
-    placeholder: "__JWKS_URI__"
+    placeholder: '__JWKS_URI__'
     description: >
       JWKs endpoint URL. For standard OIDC providers this is usually
       {issuer}/.well-known/jwks.json — override if your provider uses a
       different path.
-    prompt: "JWKs URI"
-    default: "${OidcIssuer}/.well-known/jwks.json"
+    prompt: 'JWKs URI'
+    default: '${OidcIssuer}/.well-known/jwks.json'
     required: true
 
   - name: AllowedAudience
     type: string
-    placeholder: "__ALLOWED_AUD__"
-    description: "JWT `aud` claim value required for requests to this service"
-    prompt: "Expected JWT audience"
-    default: "${ProjectName}"
+    placeholder: '__ALLOWED_AUD__'
+    description: 'JWT `aud` claim value required for requests to this service'
+    prompt: 'Expected JWT audience'
+    default: '${ProjectName}'
     required: true
 
   - name: ServiceHost
     type: string
-    placeholder: "__SERVICE_HOST__"
-    description: "Fully-qualified service host for the VirtualService"
-    prompt: "Service host"
-    default: "${ProjectName}.${Namespace}.svc.cluster.local"
+    placeholder: '__SERVICE_HOST__'
+    description: 'Fully-qualified service host for the VirtualService'
+    prompt: 'Service host'
+    default: '${ProjectName}.${Namespace}.svc.cluster.local'
 
   - name: GatewayName
     type: string
-    placeholder: "__GATEWAY_NAME__"
+    placeholder: '__GATEWAY_NAME__'
     description: >
       Istio Gateway resource name the VirtualService attaches to. Use
       "mesh" for internal-only (default) or the name of an external
       ingress gateway (e.g. "istio-system/public-gateway") for
       externally-reachable traffic.
     prompt: "Gateway (use 'mesh' for internal-only)"
-    default: "mesh"
+    default: 'mesh'
 
   - name: IncludeMTls
     type: bool
-    placeholder: "__INCLUDE_MTLS__"
-    description: "Include a PeerAuthentication resource enforcing STRICT mTLS"
-    prompt: "Include STRICT mTLS PeerAuthentication?"
+    placeholder: '__INCLUDE_MTLS__'
+    description: 'Include a PeerAuthentication resource enforcing STRICT mTLS'
+    prompt: 'Include STRICT mTLS PeerAuthentication?'
     default: false
 
   - name: IncludeVirtualService
     type: bool
-    placeholder: "__INCLUDE_VIRTUAL_SERVICE__"
-    description: "Include a VirtualService routing template"
-    prompt: "Include VirtualService?"
+    placeholder: '__INCLUDE_VIRTUAL_SERVICE__'
+    description: 'Include a VirtualService routing template'
+    prompt: 'Include VirtualService?'
     default: false
 
 conditionals:
-  - path: "peer-authentication.yaml"
+  - path: 'peer-authentication.yaml'
     when: IncludeMTls
-  - path: "virtual-service.yaml"
+  - path: 'virtual-service.yaml'
     when: IncludeVirtualService
 
 composition:
@@ -106,9 +106,9 @@ composition:
 
 prerequisites:
   - name: kubectl
-    purpose: "Apply Istio policy manifests to the cluster"
+    purpose: 'Apply Istio policy manifests to the cluster'
     optional: false
   - name: istioctl
-    version: ">=1.20"
-    purpose: "Validate Istio resource manifests (`istioctl analyze`) before apply"
+    version: '>=1.20'
+    purpose: 'Validate Istio resource manifests (`istioctl analyze`) before apply'
     optional: true

--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -9,28 +9,28 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
   - `service.yaml` — ClusterIP
   - `serviceaccount.yaml` — pod ServiceAccount, name pinned to the app name; bound to its IAM role by a landing-zone EKS Pod Identity association, so no role-arn annotation and never inline IAM
   - `networkpolicy.yaml` — default-deny + explicit egress allow-list (DNS + `:443`, IMDS blocked)
-  - `externalsecret.yaml` — *(toggle, off by default)* AWS Secrets Manager → k8s Secret via External Secrets Operator, mounted `envFrom`
-  - `prometheusrule.yaml` — *(on by default)* SLI recording rules + multi-window multi-burn-rate error-budget alerts (the `observability-slo` standard), driven by the `slo.*` values
-  - `grafana-dashboard.yaml` + `dashboards/<app>.json` — *(on by default)* a `GrafanaDashboard` CR (grafana-operator → external Amazon Managed Grafana): self-contained SRE board — SLO/error-budget row + traffic + errors + latency p50/p95/p99 + saturation
-  - `servicemonitor.yaml` — *(toggle, off by default)* Prometheus scrape for apps that expose `/metrics` instead of pushing via OTLP
+  - `externalsecret.yaml` — _(toggle, off by default)_ AWS Secrets Manager → k8s Secret via External Secrets Operator, mounted `envFrom`
+  - `prometheusrule.yaml` — _(on by default)_ SLI recording rules + multi-window multi-burn-rate error-budget alerts (the `observability-slo` standard), driven by the `slo.*` values
+  - `grafana-dashboard.yaml` + `dashboards/<app>.json` — _(on by default)_ a `GrafanaDashboard` CR (grafana-operator → external Amazon Managed Grafana): self-contained SRE board — SLO/error-budget row + traffic + errors + latency p50/p95/p99 + saturation
+  - `servicemonitor.yaml` — _(toggle, off by default)_ Prometheus scrape for apps that expose `/metrics` instead of pushing via OTLP
 - **ApplicationSet entry** in `gitops/applicationset-entry.yaml` ready to copy into `nanohype/eks-gitops/applicationsets/`
 - **Platform CR** in `platform.yaml` — a `Platform` (`platform.nanohype.dev/v1alpha1`) plus its required `BudgetPolicy` (`governance.nanohype.dev/v1alpha1`). The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IRSA role (scoped to `spec.identity.allowedModelFamilies`); the BudgetPolicy drives the spend kill-switch
 - **Skeleton README** documenting how to apply the Platform CR, register the ApplicationSet entry, and roll out new versions
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `AppName` | string | (required) | Kebab-case app name — chart name, namespace, Platform/BudgetPolicy CR name, service account name |
-| `AppMetric` | string | `${AppName}` | Underscored metric prefix for the RED/SLO panels + burn-rate rules (`competitive_intelligence`). Single-word names inherit `AppName`; multi-word names must set the snake_case form |
-| `Description` | string | `k8s-native Platform tenant` | Short description for Chart.yaml + README |
-| `Tenant` | string | (required) | Owning team (drives namespace prefix `tenants-<team>`, AppProject, quotas) |
-| `Persona` | string | `generic` | Platform persona — `sales-ops`, `support`, `finance`, `ops`, `founder`, `eng`, `marketing`, `legal`, `generic` |
-| `MonthlyUsd` | string | `2500` | Soft monthly Bedrock spend cap (USD); kill-switch at 120% |
-| `Image` | string | (required) | Container image base (no tag) |
-| `Port` | string | `8080` | Container port |
-| `GitopsRepo` | string | `nanohype/eks-gitops` | Target gitops repo for the ApplicationSet entry |
-| `SyncWave` | string | `100` | ArgoCD sync wave (apps land after addons which use waves 0–52) |
+| Variable      | Type   | Default                      | Description                                                                                                                                                                         |
+| ------------- | ------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AppName`     | string | (required)                   | Kebab-case app name — chart name, namespace, Platform/BudgetPolicy CR name, service account name                                                                                    |
+| `AppMetric`   | string | `${AppName}`                 | Underscored metric prefix for the RED/SLO panels + burn-rate rules (`competitive_intelligence`). Single-word names inherit `AppName`; multi-word names must set the snake_case form |
+| `Description` | string | `k8s-native Platform tenant` | Short description for Chart.yaml + README                                                                                                                                           |
+| `Tenant`      | string | (required)                   | Owning team (drives namespace prefix `tenants-<team>`, AppProject, quotas)                                                                                                          |
+| `Persona`     | string | `generic`                    | Platform persona — `sales-ops`, `support`, `finance`, `ops`, `founder`, `eng`, `marketing`, `legal`, `generic`                                                                      |
+| `MonthlyUsd`  | string | `2500`                       | Soft monthly Bedrock spend cap (USD); kill-switch at 120%                                                                                                                           |
+| `Image`       | string | (required)                   | Container image base (no tag)                                                                                                                                                       |
+| `Port`        | string | `8080`                       | Container port                                                                                                                                                                      |
+| `GitopsRepo`  | string | `nanohype/eks-gitops`        | Target gitops repo for the ApplicationSet entry                                                                                                                                     |
+| `SyncWave`    | string | `100`                        | ArgoCD sync wave (apps land after addons which use waves 0–52)                                                                                                                      |
 
 ## Project layout
 

--- a/templates/k8s-app-tenant/template.yaml
+++ b/templates/k8s-app-tenant/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: k8s-app-tenant
-displayName: "K8s App as Platform Tenant"
+displayName: 'K8s App as Platform Tenant'
 description: >
   Primary scaffolding for a nanohype-org k8s-native application. Produces
   a Helm chart with per-environment values, an ArgoCD ApplicationSet entry
@@ -11,7 +11,7 @@ description: >
   boundary for the eks-agent-platform operator to reconcile. Use this for
   every k8s-native deliverable unless an explicit escape hatch
   (aws-lambda, fly, vercel, cloudflare) is justified.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -20,91 +20,91 @@ tags: [kubernetes, k8s, helm, argocd, platform, nanohype]
 variables:
   - name: AppName
     type: string
-    placeholder: "__APP_NAME__"
-    description: "Kebab-case app name. Used as chart name, namespace, Platform CR name, and service account name."
-    prompt: "App name"
+    placeholder: '__APP_NAME__'
+    description: 'Kebab-case app name. Used as chart name, namespace, Platform CR name, and service account name.'
+    prompt: 'App name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: AppMetric
     type: string
-    placeholder: "__APP_METRIC__"
-    description: "Metric-name prefix for the RED/SLO panels and burn-rate rules — the service name with dashes converted to underscores (e.g. competitive_intelligence). The app emits <prefix>_requests_total / _errors_total / _request_duration_seconds. Defaults to AppName, so single-word names need nothing; multi-word names must set the underscored form."
-    prompt: "Metric prefix (underscored)"
-    default: "${AppName}"
+    placeholder: '__APP_METRIC__'
+    description: 'Metric-name prefix for the RED/SLO panels and burn-rate rules — the service name with dashes converted to underscores (e.g. competitive_intelligence). The app emits <prefix>_requests_total / _errors_total / _request_duration_seconds. Defaults to AppName, so single-word names need nothing; multi-word names must set the underscored form.'
+    prompt: 'Metric prefix (underscored)'
+    default: '${AppName}'
     validation:
-      pattern: "^[a-z][a-z0-9_]*$"
-      message: "Must be lowercase snake_case (service name with dashes → underscores)"
+      pattern: '^[a-z][a-z0-9_]*$'
+      message: 'Must be lowercase snake_case (service name with dashes → underscores)'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short app description for Chart.yaml and README."
-    prompt: "Description"
-    default: "k8s-native Platform tenant"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short app description for Chart.yaml and README.'
+    prompt: 'Description'
+    default: 'k8s-native Platform tenant'
 
   - name: Tenant
     type: string
-    placeholder: "__TENANT__"
-    description: "Owning team. Drives the namespace prefix (tenants-<team>), ArgoCD AppProject, and per-tenant resource quotas."
-    prompt: "Owning team"
+    placeholder: '__TENANT__'
+    description: 'Owning team. Drives the namespace prefix (tenants-<team>), ArgoCD AppProject, and per-tenant resource quotas.'
+    prompt: 'Owning team'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case'
 
   - name: Persona
     type: string
-    placeholder: "__PERSONA__"
-    description: "Platform persona — drives default guardrails, dashboards, and fleet shape. One of: sales-ops, support, finance, ops, founder, eng, marketing, legal, generic."
-    prompt: "Persona"
-    default: "generic"
+    placeholder: '__PERSONA__'
+    description: 'Platform persona — drives default guardrails, dashboards, and fleet shape. One of: sales-ops, support, finance, ops, founder, eng, marketing, legal, generic.'
+    prompt: 'Persona'
+    default: 'generic'
     validation:
-      pattern: "^(sales-ops|support|finance|ops|founder|eng|marketing|legal|generic)$"
-      message: "Must be a persona the operator accepts"
+      pattern: '^(sales-ops|support|finance|ops|founder|eng|marketing|legal|generic)$'
+      message: 'Must be a persona the operator accepts'
 
   - name: MonthlyUsd
     type: string
-    placeholder: "__MONTHLY_USD__"
-    description: "Soft monthly Bedrock spend cap (USD) for the BudgetPolicy. Kill-switch fires at 120%."
-    prompt: "Monthly budget (USD)"
-    default: "2500"
+    placeholder: '__MONTHLY_USD__'
+    description: 'Soft monthly Bedrock spend cap (USD) for the BudgetPolicy. Kill-switch fires at 120%.'
+    prompt: 'Monthly budget (USD)'
+    default: '2500'
     validation:
-      pattern: "^[0-9]+$"
-      message: "Must be a whole-dollar amount"
+      pattern: '^[0-9]+$'
+      message: 'Must be a whole-dollar amount'
 
   - name: Image
     type: string
-    placeholder: "__IMAGE__"
-    description: "Container image base (no tag — tag pinned per-env in values-{env}.yaml)."
-    prompt: "Container image"
+    placeholder: '__IMAGE__'
+    description: 'Container image base (no tag — tag pinned per-env in values-{env}.yaml).'
+    prompt: 'Container image'
     required: true
 
   - name: Port
     type: string
-    placeholder: "__PORT__"
-    description: "Container port the app listens on."
-    prompt: "Container port"
-    default: "8080"
+    placeholder: '__PORT__'
+    description: 'Container port the app listens on.'
+    prompt: 'Container port'
+    default: '8080'
 
   - name: GitopsRepo
     type: string
-    placeholder: "__GITOPS_REPO__"
-    description: "Target gitops repo for the ApplicationSet entry."
-    prompt: "Gitops repo (org/repo)"
-    default: "nanohype/eks-gitops"
+    placeholder: '__GITOPS_REPO__'
+    description: 'Target gitops repo for the ApplicationSet entry.'
+    prompt: 'Gitops repo (org/repo)'
+    default: 'nanohype/eks-gitops'
     validation:
-      pattern: "^[a-z0-9-]+/[a-z0-9-]+$"
-      message: "Must be org/repo (e.g., nanohype/eks-gitops)"
+      pattern: '^[a-z0-9-]+/[a-z0-9-]+$'
+      message: 'Must be org/repo (e.g., nanohype/eks-gitops)'
 
   - name: SyncWave
     type: string
-    placeholder: "__SYNC_WAVE__"
+    placeholder: '__SYNC_WAVE__'
     description: "ArgoCD sync wave for this app's ApplicationSet entry. Apps typically deploy after addons (wave >= 100)."
-    prompt: "Sync wave"
-    default: "100"
+    prompt: 'Sync wave'
+    default: '100'
 
 conditionals: []
 
@@ -114,16 +114,16 @@ composition:
 
 prerequisites:
   - name: helm
-    version: ">=3.0"
-    purpose: "Render and lint the chart locally before pushing"
+    version: '>=3.0'
+    purpose: 'Render and lint the chart locally before pushing'
     optional: false
   - name: kubectl
-    version: ">=1.28"
-    purpose: "Apply the Platform CR during initial tenant setup (before ArgoCD takes over via the ApplicationSet)"
+    version: '>=1.28'
+    purpose: 'Apply the Platform CR during initial tenant setup (before ArgoCD takes over via the ApplicationSet)'
     optional: false
   - name: kustomize
-    version: ">=5.0"
-    purpose: "Build per-env overlays consumed by the ApplicationSet entry"
+    version: '>=5.0'
+    purpose: 'Build per-env overlays consumed by the ApplicationSet entry'
     optional: false
 
 hooks: {}

--- a/templates/k8s-deploy/README.md
+++ b/templates/k8s-deploy/README.md
@@ -18,16 +18,16 @@ Generic Kubernetes deployment with raw manifests and an optional Helm chart. Wor
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `Kubernetes deployment` | Project description |
-| `Namespace` | string | `default` | Kubernetes namespace |
-| `Replicas` | string | `2` | Replica count |
-| `IncludeIngress` | bool | `true` | Include Ingress resource |
-| `IncludeHpa` | bool | `true` | Include HorizontalPodAutoscaler |
-| `IncludeHelm` | bool | `true` | Include Helm chart |
-| `IncludeCi` | bool | `true` | Include GitHub Actions workflow |
+| Variable         | Type   | Default                 | Description                     |
+| ---------------- | ------ | ----------------------- | ------------------------------- |
+| `ProjectName`    | string | (required)              | Kebab-case project name         |
+| `Description`    | string | `Kubernetes deployment` | Project description             |
+| `Namespace`      | string | `default`               | Kubernetes namespace            |
+| `Replicas`       | string | `2`                     | Replica count                   |
+| `IncludeIngress` | bool   | `true`                  | Include Ingress resource        |
+| `IncludeHpa`     | bool   | `true`                  | Include HorizontalPodAutoscaler |
+| `IncludeHelm`    | bool   | `true`                  | Include Helm chart              |
+| `IncludeCi`      | bool   | `true`                  | Include GitHub Actions workflow |
 
 ## Project layout
 

--- a/templates/k8s-deploy/template.yaml
+++ b/templates/k8s-deploy/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: k8s-deploy
-displayName: "Kubernetes Deployment"
+displayName: 'Kubernetes Deployment'
 description: >
   Scaffolds a Kubernetes deployment with raw manifests and an optional
   Helm chart. Includes Deployment, Service, and ConfigMap resources with
@@ -10,7 +10,7 @@ description: >
   namespace awareness. Optionally adds Ingress, HorizontalPodAutoscaler,
   a Helm chart for parameterized deploys, and a GitHub Actions CI/CD
   workflow.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -19,77 +19,77 @@ tags: [kubernetes, k8s, deployment, helm, infrastructure]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as resource names and labels"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as resource names and labels'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README and chart metadata"
-    prompt: "Project description"
-    default: "Kubernetes deployment"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README and chart metadata'
+    prompt: 'Project description'
+    default: 'Kubernetes deployment'
 
   - name: Namespace
     type: string
-    placeholder: "__NAMESPACE__"
-    description: "Kubernetes namespace for all resources"
-    prompt: "Namespace"
-    default: "default"
+    placeholder: '__NAMESPACE__'
+    description: 'Kubernetes namespace for all resources'
+    prompt: 'Namespace'
+    default: 'default'
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be a valid Kubernetes namespace (lowercase kebab-case)"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be a valid Kubernetes namespace (lowercase kebab-case)'
 
   - name: Replicas
     type: string
-    placeholder: "__REPLICAS__"
-    description: "Number of pod replicas"
-    prompt: "Replica count"
-    default: "2"
+    placeholder: '__REPLICAS__'
+    description: 'Number of pod replicas'
+    prompt: 'Replica count'
+    default: '2'
     validation:
-      pattern: "^[1-9][0-9]*$"
-      message: "Must be a positive integer"
+      pattern: '^[1-9][0-9]*$'
+      message: 'Must be a positive integer'
 
   - name: IncludeIngress
     type: bool
-    placeholder: "__INCLUDE_INGRESS__"
-    description: "Include Ingress resource for external HTTP routing"
-    prompt: "Include Ingress?"
+    placeholder: '__INCLUDE_INGRESS__'
+    description: 'Include Ingress resource for external HTTP routing'
+    prompt: 'Include Ingress?'
     default: true
 
   - name: IncludeHpa
     type: bool
-    placeholder: "__INCLUDE_HPA__"
-    description: "Include HorizontalPodAutoscaler for auto-scaling"
-    prompt: "Include HPA?"
+    placeholder: '__INCLUDE_HPA__'
+    description: 'Include HorizontalPodAutoscaler for auto-scaling'
+    prompt: 'Include HPA?'
     default: true
 
   - name: IncludeHelm
     type: bool
-    placeholder: "__INCLUDE_HELM__"
-    description: "Include Helm chart for parameterized deployments"
-    prompt: "Include Helm chart?"
+    placeholder: '__INCLUDE_HELM__'
+    description: 'Include Helm chart for parameterized deployments'
+    prompt: 'Include Helm chart?'
     default: true
 
   - name: IncludeCi
     type: bool
-    placeholder: "__INCLUDE_CI__"
-    description: "Include GitHub Actions deploy workflow"
-    prompt: "Include CI/CD?"
+    placeholder: '__INCLUDE_CI__'
+    description: 'Include GitHub Actions deploy workflow'
+    prompt: 'Include CI/CD?'
     default: true
 
 conditionals:
-  - path: "k8s/ingress.yaml"
+  - path: 'k8s/ingress.yaml'
     when: IncludeIngress
-  - path: "k8s/hpa.yaml"
+  - path: 'k8s/hpa.yaml'
     when: IncludeHpa
-  - path: "chart"
+  - path: 'chart'
     when: IncludeHelm
-  - path: ".github/workflows/deploy.yml"
+  - path: '.github/workflows/deploy.yml'
     when: IncludeCi
 
 composition:
@@ -98,9 +98,9 @@ composition:
 
 prerequisites:
   - name: kubectl
-    purpose: "Kubernetes CLI for applying manifests and managing clusters"
+    purpose: 'Kubernetes CLI for applying manifests and managing clusters'
     optional: false
   - name: helm
-    version: ">=3.0"
-    purpose: "Helm CLI for chart-based deployments (only needed if Helm chart is included)"
+    version: '>=3.0'
+    purpose: 'Helm CLI for chart-based deployments (only needed if Helm chart is included)'
     optional: true

--- a/templates/landing-zone-component/README.md
+++ b/templates/landing-zone-component/README.md
@@ -15,11 +15,11 @@ AWS variant only for now; GCP and Azure follow the same shape and can be added b
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
+| Variable        | Type   | Default    | Description                                             |
+| --------------- | ------ | ---------- | ------------------------------------------------------- |
 | `ComponentName` | string | (required) | Snake_case component name (directory + resource prefix) |
-| `Description` | string | (required) | One-sentence component description |
-| `Multitenant` | bool | `false` | Add `modules/tenant/` + `for_each` skeleton |
+| `Description`   | string | (required) | One-sentence component description                      |
+| `Multitenant`   | bool   | `false`    | Add `modules/tenant/` + `for_each` skeleton             |
 
 ## Project layout
 

--- a/templates/landing-zone-component/template.yaml
+++ b/templates/landing-zone-component/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: landing-zone-component
-displayName: "Landing-zone Component (OpenTofu/Terragrunt)"
+displayName: 'Landing-zone Component (OpenTofu/Terragrunt)'
 description: >
   Scaffolds a new component into nanohype/landing-zone. Produces the
   components/<cloud>/<name>/ Tofu root module (main.tf, variables.tf,
@@ -10,7 +10,7 @@ description: >
   for multi-tenant components (used by druid, pipeline, gateway, llm,
   mlops, rag, governance). AWS variant for now; gcp and azure follow
   the same shape and can be added by copying.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -19,30 +19,30 @@ tags: [opentofu, terragrunt, aws, landing-zone, nanohype]
 variables:
   - name: ComponentName
     type: string
-    placeholder: "__COMPONENT_NAME__"
-    description: "Snake_case component name. Used as directory name and resource-prefix in tags."
-    prompt: "Component name"
+    placeholder: '__COMPONENT_NAME__'
+    description: 'Snake_case component name. Used as directory name and resource-prefix in tags.'
+    prompt: 'Component name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9_]*$"
-      message: "Must be lowercase snake_case starting with a letter"
+      pattern: '^[a-z][a-z0-9_]*$'
+      message: 'Must be lowercase snake_case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "What this component provisions (one sentence — appears in main.tf header + README + envcommon comment)."
-    prompt: "Description"
+    placeholder: '__DESCRIPTION__'
+    description: 'What this component provisions (one sentence — appears in main.tf header + README + envcommon comment).'
+    prompt: 'Description'
     required: true
 
   - name: Multitenant
     type: bool
-    placeholder: "__MULTITENANT__"
-    description: "If true, adds a modules/tenant/ submodule and wires var.tenants + for_each in main.tf."
-    prompt: "Multi-tenant pattern?"
-    default: "false"
+    placeholder: '__MULTITENANT__'
+    description: 'If true, adds a modules/tenant/ submodule and wires var.tenants + for_each in main.tf.'
+    prompt: 'Multi-tenant pattern?'
+    default: 'false'
 
 conditionals:
-  - path: "components/aws/__COMPONENT_NAME__/modules/tenant"
+  - path: 'components/aws/__COMPONENT_NAME__/modules/tenant'
     when: Multitenant
 
 composition:
@@ -51,12 +51,12 @@ composition:
 
 prerequisites:
   - name: tofu
-    version: ">=1.11.0"
-    purpose: "OpenTofu CLI — never terraform"
+    version: '>=1.11.0'
+    purpose: 'OpenTofu CLI — never terraform'
     optional: false
   - name: terragrunt
-    version: ">=0.59"
-    purpose: "Drives the live/ env-specific overrides + dependency wiring"
+    version: '>=0.59'
+    purpose: 'Drives the live/ env-specific overrides + dependency wiring'
     optional: false
   - name: tflint
     purpose: "Required by landing-zone's lint job — validates naming + documented variables/outputs"

--- a/templates/launch-checklist/README.md
+++ b/templates/launch-checklist/README.md
@@ -11,11 +11,11 @@ Scaffolds a structured launch package with go/no-go criteria organized by functi
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `LaunchType` | enum | `ga` | Launch phase: alpha, beta, or ga |
-| `IncludeComms` | bool | `true` | Include communications plan |
+| Variable       | Type   | Default    | Description                      |
+| -------------- | ------ | ---------- | -------------------------------- |
+| `ProjectName`  | string | (required) | Kebab-case project name          |
+| `LaunchType`   | enum   | `ga`       | Launch phase: alpha, beta, or ga |
+| `IncludeComms` | bool   | `true`     | Include communications plan      |
 
 ## Project layout
 

--- a/templates/launch-checklist/template.yaml
+++ b/templates/launch-checklist/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: launch-checklist
-displayName: "Launch Checklist"
+displayName: 'Launch Checklist'
 description: >
   Scaffolds a structured launch package with go/no-go criteria organized
   by functional area, a stakeholder sign-off matrix, monitoring setup
   guidance, and rollback plan. Optionally includes an internal and
   external communications plan. Designed for product and engineering
   teams coordinating multi-team launches.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [product]
 category: product
@@ -17,31 +17,31 @@ tags: [launch, checklist, go-no-go, sign-off, monitoring, rollback, comms]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: LaunchType
     type: enum
-    placeholder: "__LAUNCH_TYPE__"
-    description: "Launch phase determining the scope of checklist criteria"
-    prompt: "Launch type"
-    default: "ga"
+    placeholder: '__LAUNCH_TYPE__'
+    description: 'Launch phase determining the scope of checklist criteria'
+    prompt: 'Launch type'
+    default: 'ga'
     options: [alpha, beta, ga]
 
   - name: IncludeComms
     type: bool
-    placeholder: "__INCLUDE_COMMS__"
-    description: "Include a communications plan document"
-    prompt: "Include comms plan?"
+    placeholder: '__INCLUDE_COMMS__'
+    description: 'Include a communications plan document'
+    prompt: 'Include comms plan?'
     default: true
 
 conditionals:
-  - path: "launch/comms-plan.md"
+  - path: 'launch/comms-plan.md'
     when: IncludeComms
 
 composition:

--- a/templates/llm-wiki/README.md
+++ b/templates/llm-wiki/README.md
@@ -19,16 +19,16 @@ Multi-tenant LLM-maintained knowledge base. Agents incrementally build structure
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|----------|------|---------|-------------|
-| `ProjectName` | string | *(required)* | Kebab-case project name |
-| `Description` | string | `"Multi-tenant LLM-maintained knowledge base"` | Short description |
-| `StorageProvider` | string | `"git"` | Default wiki storage backend |
-| `LlmProvider` | string | `"anthropic"` | Default LLM provider |
-| `SourceProvider` | string | `"local"` | Default source ingestion provider |
-| `IncludeApi` | bool | `true` | Include HTTP API server |
-| `IncludeCli` | bool | `true` | Include CLI interface |
-| `IncludeTests` | bool | `true` | Include test suite |
+| Variable          | Type   | Default                                        | Description                       |
+| ----------------- | ------ | ---------------------------------------------- | --------------------------------- |
+| `ProjectName`     | string | _(required)_                                   | Kebab-case project name           |
+| `Description`     | string | `"Multi-tenant LLM-maintained knowledge base"` | Short description                 |
+| `StorageProvider` | string | `"git"`                                        | Default wiki storage backend      |
+| `LlmProvider`     | string | `"anthropic"`                                  | Default LLM provider              |
+| `SourceProvider`  | string | `"local"`                                      | Default source ingestion provider |
+| `IncludeApi`      | bool   | `true`                                         | Include HTTP API server           |
+| `IncludeCli`      | bool   | `true`                                         | Include CLI interface             |
+| `IncludeTests`    | bool   | `true`                                         | Include test suite                |
 
 ## Project layout
 

--- a/templates/llm-wiki/template.yaml
+++ b/templates/llm-wiki/template.yaml
@@ -1,11 +1,11 @@
 apiVersion: nanohype/v1
 name: llm-wiki
-displayName: "LLM Wiki"
+displayName: 'LLM Wiki'
 description: >
   Multi-tenant LLM-maintained knowledge base. Agents incrementally
   build structured markdown wikis from raw sources — knowledge
   compounds over time rather than being re-derived per query.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -14,58 +14,58 @@ variables:
   - name: ProjectName
     type: string
     placeholder: __PROJECT_NAME__
-    description: "Kebab-case project name"
+    description: 'Kebab-case project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be kebab-case"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be kebab-case'
   - name: Description
     type: string
     placeholder: __DESCRIPTION__
-    description: "Short project description"
-    default: "Multi-tenant LLM-maintained knowledge base"
+    description: 'Short project description'
+    default: 'Multi-tenant LLM-maintained knowledge base'
   - name: StorageProvider
     type: string
     placeholder: __STORAGE_PROVIDER__
-    description: "Default wiki storage backend"
-    default: "git"
+    description: 'Default wiki storage backend'
+    default: 'git'
   - name: LlmProvider
     type: string
     placeholder: __LLM_PROVIDER__
-    description: "Default LLM provider for wiki operations"
-    default: "anthropic"
+    description: 'Default LLM provider for wiki operations'
+    default: 'anthropic'
   - name: SourceProvider
     type: string
     placeholder: __SOURCE_PROVIDER__
-    description: "Default source ingestion provider"
-    default: "local"
+    description: 'Default source ingestion provider'
+    default: 'local'
   - name: IncludeApi
     type: bool
     placeholder: __INCLUDE_API__
-    description: "Include HTTP API server (Hono)"
+    description: 'Include HTTP API server (Hono)'
     default: true
   - name: IncludeCli
     type: bool
     placeholder: __INCLUDE_CLI__
-    description: "Include CLI interface"
+    description: 'Include CLI interface'
     default: true
   - name: IncludeTests
     type: bool
     placeholder: __INCLUDE_TESTS__
-    description: "Include test suite"
+    description: 'Include test suite'
     default: true
 conditionals:
-  - path: "src/api"
+  - path: 'src/api'
     when: IncludeApi
-  - path: "src/cli"
+  - path: 'src/cli'
     when: IncludeCli
-  - path: "src/__tests__"
+  - path: 'src/__tests__'
     when: IncludeTests
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
+      description: 'Install npm dependencies'
+      run: 'npm install'
 composition:
   pairsWith: [agentic-loop, rag-pipeline, module-llm-gateway, eval-harness]
   nestsInside: [monorepo]

--- a/templates/mcp-server-python/README.md
+++ b/templates/mcp-server-python/README.md
@@ -13,12 +13,12 @@ Scaffolds a [Model Context Protocol](https://modelcontextprotocol.io) server in 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `"An MCP server in Python"` | Short project description |
-| `Transport` | string | `"stdio"` | Transport protocol: `stdio` or `http` |
-| `IncludeTests` | bool | `true` | Include test suite with pytest |
+| Variable       | Type   | Default                     | Description                           |
+| -------------- | ------ | --------------------------- | ------------------------------------- |
+| `ProjectName`  | string | _(required)_                | Kebab-case project name               |
+| `Description`  | string | `"An MCP server in Python"` | Short project description             |
+| `Transport`    | string | `"stdio"`                   | Transport protocol: `stdio` or `http` |
+| `IncludeTests` | bool   | `true`                      | Include test suite with pytest        |
 
 ## Project layout
 

--- a/templates/mcp-server-python/template.yaml
+++ b/templates/mcp-server-python/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: mcp-server-python
-displayName: "MCP Server (Python)"
+displayName: 'MCP Server (Python)'
 description: >
   Scaffolds a Model Context Protocol server in Python using the official
   mcp SDK and FastMCP. Produces a working server with example tools and
   resources, configurable for stdio or streamable-http transport. Uses
   Pydantic for input validation and structlog for structured logging.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -16,45 +16,45 @@ tags: [mcp, python, ai, tools, server]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for pyproject.toml and README"
-    prompt: "Project description"
-    default: "An MCP server in Python"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for pyproject.toml and README'
+    prompt: 'Project description'
+    default: 'An MCP server in Python'
 
   - name: Transport
     type: string
-    placeholder: "__TRANSPORT__"
-    description: "Server transport protocol (stdio or http)"
-    prompt: "Transport"
-    default: "stdio"
+    placeholder: '__TRANSPORT__'
+    description: 'Server transport protocol (stdio or http)'
+    prompt: 'Transport'
+    default: 'stdio'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test suite with pytest"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test suite with pytest'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "tests/"
+  - path: 'tests/'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install Python dependencies"
+      description: 'Install Python dependencies'
       run: "pip install -e '.[dev]'"
-      workdir: "."
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, eval-harness]
@@ -62,9 +62,9 @@ composition:
 
 prerequisites:
   - name: python
-    version: ">=3.10"
-    purpose: "Python runtime for the MCP server"
+    version: '>=3.10'
+    purpose: 'Python runtime for the MCP server'
     optional: false
   - name: pip
-    purpose: "Package management and dependency installation"
+    purpose: 'Package management and dependency installation'
     optional: false

--- a/templates/mcp-server-ts/README.md
+++ b/templates/mcp-server-ts/README.md
@@ -12,13 +12,13 @@ Scaffolds a [Model Context Protocol](https://modelcontextprotocol.io) server in 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `ServerName` | string | _(required)_ | Human-readable server name for MCP clients |
-| `Description` | string | `"An MCP server"` | Short project description |
-| `Transport` | enum | `"stdio"` | Transport protocol: `stdio` or `streamable-http` |
-| `IncludeResources` | bool | `true` | Include example resource endpoints |
+| Variable           | Type   | Default           | Description                                      |
+| ------------------ | ------ | ----------------- | ------------------------------------------------ |
+| `ProjectName`      | string | _(required)_      | Kebab-case project name                          |
+| `ServerName`       | string | _(required)_      | Human-readable server name for MCP clients       |
+| `Description`      | string | `"An MCP server"` | Short project description                        |
+| `Transport`        | enum   | `"stdio"`         | Transport protocol: `stdio` or `streamable-http` |
+| `IncludeResources` | bool   | `true`            | Include example resource endpoints               |
 
 ## Project layout
 

--- a/templates/mcp-server-ts/template.yaml
+++ b/templates/mcp-server-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: mcp-server-ts
-displayName: "MCP Server (TypeScript)"
+displayName: 'MCP Server (TypeScript)'
 description: >
   Scaffolds a Model Context Protocol server in TypeScript using the
   official @modelcontextprotocol/sdk. Produces a working server with
   example tools and optional resource endpoints, configurable for stdio
   or streamable-http transport. Includes MCP Inspector integration for
   interactive debugging during development.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -17,53 +17,53 @@ tags: [mcp, typescript, ai, tools, server]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ServerName
     type: string
-    placeholder: "__SERVER_NAME__"
-    description: "Human-readable server name displayed in MCP client UIs"
-    prompt: "Server display name"
+    placeholder: '__SERVER_NAME__'
+    description: 'Human-readable server name displayed in MCP client UIs'
+    prompt: 'Server display name'
     required: true
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "An MCP server"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'An MCP server'
 
   - name: Transport
     type: enum
-    placeholder: "__TRANSPORT__"
-    description: "Server transport protocol"
-    prompt: "Transport"
-    default: "stdio"
-    options: ["stdio", "streamable-http"]
+    placeholder: '__TRANSPORT__'
+    description: 'Server transport protocol'
+    prompt: 'Transport'
+    default: 'stdio'
+    options: ['stdio', 'streamable-http']
 
   - name: IncludeResources
     type: bool
-    placeholder: "__INCLUDE_RESOURCES__"
-    description: "Include example MCP resource endpoints"
-    prompt: "Include resource examples?"
+    placeholder: '__INCLUDE_RESOURCES__'
+    description: 'Include example MCP resource endpoints'
+    prompt: 'Include resource examples?'
     default: true
 
 conditionals:
-  - path: "src/resources/example.ts"
+  - path: 'src/resources/example.ts'
     when: IncludeResources
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, eval-harness]
@@ -71,9 +71,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the MCP server"
+    version: '>=22'
+    purpose: 'Node.js runtime for the MCP server'
     optional: false
   - name: npm
-    purpose: "Package management and script execution"
+    purpose: 'Package management and script execution'
     optional: false

--- a/templates/module-analytics-ts/README.md
+++ b/templates/module-analytics-ts/README.md
@@ -17,11 +17,11 @@ Event tracking and product analytics with pluggable backends.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Event tracking and product analytics` | Project description |
-| `AnalyticsProvider` | string | `posthog` | Default analytics provider (posthog/segment/mixpanel/amplitude/mock or custom) |
+| Variable            | Type   | Default                                | Description                                                                    |
+| ------------------- | ------ | -------------------------------------- | ------------------------------------------------------------------------------ |
+| `ProjectName`       | string | --                                     | Kebab-case project name                                                        |
+| `Description`       | string | `Event tracking and product analytics` | Project description                                                            |
+| `AnalyticsProvider` | string | `posthog`                              | Default analytics provider (posthog/segment/mixpanel/amplitude/mock or custom) |
 
 ## Project layout
 

--- a/templates/module-analytics-ts/template.yaml
+++ b/templates/module-analytics-ts/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-analytics-ts
-displayName: "Module: Product Analytics"
+displayName: 'Module: Product Analytics'
 description: >
   Event tracking and product analytics with pluggable backends. Ships
   with providers for Segment (HTTP batch API), PostHog (batch capture),
@@ -10,7 +10,7 @@ description: >
   event buffer with interval and capacity flushing, plus Hono and
   Express middleware factories for automatic request tracking. Factory-based
   registry, circuit breakers, and OTel metrics.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -19,34 +19,34 @@ tags: [analytics, tracking, segment, posthog, mixpanel, amplitude, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Event tracking and product analytics"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Event tracking and product analytics'
 
   - name: AnalyticsProvider
     type: string
-    placeholder: "__ANALYTICS_PROVIDER__"
-    description: "Default analytics provider (posthog, segment, mixpanel, amplitude, mock, or a custom name)"
-    prompt: "Analytics provider"
-    default: "posthog"
+    placeholder: '__ANALYTICS_PROVIDER__'
+    description: 'Default analytics provider (posthog, segment, mixpanel, amplitude, mock, or a custom name)'
+    prompt: 'Analytics provider'
+    default: 'posthog'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, next-app, go-service]
@@ -54,6 +54,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the analytics module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the analytics module'
     optional: false

--- a/templates/module-audit-ledger-ts/README.md
+++ b/templates/module-audit-ledger-ts/README.md
@@ -13,15 +13,15 @@ An append-only audit ledger with pluggable storage backends. One `AuditLedger` p
 - Deterministic, content-addressed event ids so an append is idempotent across all backends
 - OTel counters: `audit_append_total` (by provider + result) and `audit_query_total`
 
-**Boundary:** this module owns *persistence only*. Domain logic — approval gates, edit-distance scoring, PII scrubbing — stays in the app that owns the events. Scrub `details` before appending.
+**Boundary:** this module owns _persistence only_. Domain logic — approval gates, edit-distance scoring, PII scrubbing — stays in the app that owns the events. Scrub `details` before appending.
 
 ## Variables
 
-| Variable | Placeholder | Default | Description |
-| --- | --- | --- | --- |
-| `ProjectName` | `__PROJECT_NAME__` | — | Package name + directory (kebab-case, required) |
-| `Description` | `__DESCRIPTION__` | Append-only audit ledger… | package.json + README description |
-| `AuditProvider` | `__AUDIT_PROVIDER__` | `memory` | Default backend (memory, postgres, dynamodb, sqs, or a custom name) |
+| Variable        | Placeholder          | Default                   | Description                                                         |
+| --------------- | -------------------- | ------------------------- | ------------------------------------------------------------------- |
+| `ProjectName`   | `__PROJECT_NAME__`   | —                         | Package name + directory (kebab-case, required)                     |
+| `Description`   | `__DESCRIPTION__`    | Append-only audit ledger… | package.json + README description                                   |
+| `AuditProvider` | `__AUDIT_PROVIDER__` | `memory`                  | Default backend (memory, postgres, dynamodb, sqs, or a custom name) |
 
 ## Project layout
 

--- a/templates/module-audit-ledger-ts/template.yaml
+++ b/templates/module-audit-ledger-ts/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-audit-ledger-ts
-displayName: "Module: Audit Ledger"
+displayName: 'Module: Audit Ledger'
 description: >
   Append-only audit ledger with pluggable storage backends. One AuditLedger
   port (append + queryByContext) over four adapters: an in-memory store for
@@ -10,7 +10,7 @@ description: >
   at-least-once delivery). The module owns persistence only — domain logic such
   as approval gates, edit-distance scoring, and PII scrubbing stays in the app
   that owns the events.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -19,27 +19,27 @@ tags: [audit, ledger, compliance, postgres, dynamodb, sqs, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Append-only audit ledger with pluggable storage backends"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Append-only audit ledger with pluggable storage backends'
 
   - name: AuditProvider
     type: string
-    placeholder: "__AUDIT_PROVIDER__"
-    description: "Default audit backend (memory, postgres, dynamodb, sqs, or a custom name)"
-    prompt: "Audit backend"
-    default: "memory"
+    placeholder: '__AUDIT_PROVIDER__'
+    description: 'Default audit backend (memory, postgres, dynamodb, sqs, or a custom name)'
+    prompt: 'Audit backend'
+    default: 'memory'
 
 conditionals: []
 
@@ -52,5 +52,5 @@ prerequisites: []
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
+      description: 'Install npm dependencies'
+      run: 'npm install'

--- a/templates/module-auth-go/README.md
+++ b/templates/module-auth-go/README.md
@@ -17,13 +17,13 @@ pluggable providers. The Go-side analog of `module-auth-ts`.
 
 ## Variables
 
-| Variable | Placeholder | Default | Description |
-|----------|-------------|---------|-------------|
-| `ProjectName` | `__PROJECT_NAME__` | *(required)* | Kebab-case module directory name |
-| `GoModule` | `__GO_MODULE__` | `github.com/${Org}/${ProjectName}` | Full Go module path |
-| `Org` | `__ORG__` | *(required)* | GitHub organization or username |
-| `Description` | `__DESCRIPTION__` | Composable authentication middleware... | Module description |
-| `AuthProvider` | `__AUTH_PROVIDER__` | `jwt` | Default provider name |
+| Variable       | Placeholder         | Default                                 | Description                      |
+| -------------- | ------------------- | --------------------------------------- | -------------------------------- |
+| `ProjectName`  | `__PROJECT_NAME__`  | _(required)_                            | Kebab-case module directory name |
+| `GoModule`     | `__GO_MODULE__`     | `github.com/${Org}/${ProjectName}`      | Full Go module path              |
+| `Org`          | `__ORG__`           | _(required)_                            | GitHub organization or username  |
+| `Description`  | `__DESCRIPTION__`   | Composable authentication middleware... | Module description               |
+| `AuthProvider` | `__AUTH_PROVIDER__` | `jwt`                                   | Default provider name            |
 
 ## Project layout
 

--- a/templates/module-auth-go/template.yaml
+++ b/templates/module-auth-go/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-auth-go
-displayName: "Auth Middleware Module (Go)"
+displayName: 'Auth Middleware Module (Go)'
 description: >
   Composable authentication middleware module for Go HTTP services with
   pluggable providers. Ships with reference implementations for JWT
@@ -9,7 +9,7 @@ description: >
   The provider registry pattern makes it trivial to add custom auth
   strategies. Middleware is compatible with chi, gorilla/mux, and any
   net/http-based router.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -18,55 +18,55 @@ tags: [auth, middleware, jwt, go, security]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as module directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as module directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: GoModule
     type: string
-    placeholder: "__GO_MODULE__"
-    description: "Full Go module path"
-    prompt: "Go module path"
-    default: "github.com/${Org}/${ProjectName}"
+    placeholder: '__GO_MODULE__'
+    description: 'Full Go module path'
+    prompt: 'Go module path'
+    default: 'github.com/${Org}/${ProjectName}'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9./-]*$"
-      message: "Must be a valid Go module path"
+      pattern: '^[a-z][a-z0-9./-]*$'
+      message: 'Must be a valid Go module path'
 
   - name: Org
     type: string
-    placeholder: "__ORG__"
-    description: "GitHub organization or username"
-    prompt: "GitHub org/username"
+    placeholder: '__ORG__'
+    description: 'GitHub organization or username'
+    prompt: 'GitHub org/username'
     required: true
     validation:
-      pattern: "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
-      message: "Must be a valid GitHub org or username"
+      pattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*$'
+      message: 'Must be a valid GitHub org or username'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README"
-    prompt: "Project description"
-    default: "Composable authentication middleware with pluggable providers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README'
+    prompt: 'Project description'
+    default: 'Composable authentication middleware with pluggable providers'
 
   - name: AuthProvider
     type: string
-    placeholder: "__AUTH_PROVIDER__"
-    description: "Default auth provider (jwt, auth0, clerk, supabase, apikey, or a custom name)"
-    prompt: "Default auth provider"
-    default: "jwt"
+    placeholder: '__AUTH_PROVIDER__'
+    description: 'Default auth provider (jwt, auth0, clerk, supabase, apikey, or a custom name)'
+    prompt: 'Default auth provider'
+    default: 'jwt'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Tidy Go module dependencies"
-      run: "go mod tidy"
-      workdir: "."
+      description: 'Tidy Go module dependencies'
+      run: 'go mod tidy'
+      workdir: '.'
 
 composition:
   pairsWith: [go-service]
@@ -74,6 +74,6 @@ composition:
 
 prerequisites:
   - name: go
-    version: ">=1.24"
-    purpose: "Go compilation and module management"
+    version: '>=1.24'
+    purpose: 'Go compilation and module management'
     optional: false

--- a/templates/module-auth-ts/README.md
+++ b/templates/module-auth-ts/README.md
@@ -11,11 +11,11 @@ Composable authentication middleware module with pluggable providers.
 
 ## Variables
 
-| Variable | Placeholder | Default | Description |
-|----------|-------------|---------|-------------|
-| `ProjectName` | `__PROJECT_NAME__` | *(required)* | Kebab-case package name |
-| `Description` | `__DESCRIPTION__` | Composable authentication middleware... | Package description |
-| `AuthProvider` | `__AUTH_PROVIDER__` | `jwt` | Default auth provider |
+| Variable       | Placeholder         | Default                                 | Description             |
+| -------------- | ------------------- | --------------------------------------- | ----------------------- |
+| `ProjectName`  | `__PROJECT_NAME__`  | _(required)_                            | Kebab-case package name |
+| `Description`  | `__DESCRIPTION__`   | Composable authentication middleware... | Package description     |
+| `AuthProvider` | `__AUTH_PROVIDER__` | `jwt`                                   | Default auth provider   |
 
 ## Project layout
 
@@ -56,18 +56,18 @@ Composable authentication middleware module with pluggable providers.
 ## Quick start
 
 ```typescript
-import { createAuthMiddleware, requireAuth, requireRole } from "your-auth-module";
+import { createAuthMiddleware, requireAuth, requireRole } from 'your-auth-module';
 
-import { Hono } from "hono";
+import { Hono } from 'hono';
 const app = new Hono();
 
-app.use("/api/*", createAuthMiddleware({ provider: "jwt" }));
-app.get("/api/profile", requireAuth, (c) => {
-  const user = c.get("authUser");
+app.use('/api/*', createAuthMiddleware({ provider: 'jwt' }));
+app.get('/api/profile', requireAuth, (c) => {
+  const user = c.get('authUser');
   return c.json({ user });
 });
-app.get("/api/admin", requireAuth, requireRole("admin"), (c) => {
-  return c.json({ message: "admin access granted" });
+app.get('/api/admin', requireAuth, requireRole('admin'), (c) => {
+  return c.json({ message: 'admin access granted' });
 });
 ```
 
@@ -75,24 +75,24 @@ app.get("/api/admin", requireAuth, requireRole("admin"), (c) => {
 
 Each provider reads its configuration from environment variables:
 
-| Provider | Environment Variables |
-|----------|---------------------|
-| `jwt` | `AUTH_JWT_SECRET` or `AUTH_JWT_JWKS_URL`, optional `AUTH_JWT_ISSUER`, `AUTH_JWT_AUDIENCE` |
-| `clerk` | `CLERK_SECRET_KEY` |
-| `auth0` | `AUTH0_DOMAIN`, `AUTH0_AUDIENCE` |
-| `supabase` | `SUPABASE_URL`, `SUPABASE_ANON_KEY` |
-| `apikey` | `AUTH_API_KEYS` (comma-separated, format: `key:role1+role2:label`) |
+| Provider   | Environment Variables                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| `jwt`      | `AUTH_JWT_SECRET` or `AUTH_JWT_JWKS_URL`, optional `AUTH_JWT_ISSUER`, `AUTH_JWT_AUDIENCE` |
+| `clerk`    | `CLERK_SECRET_KEY`                                                                        |
+| `auth0`    | `AUTH0_DOMAIN`, `AUTH0_AUDIENCE`                                                          |
+| `supabase` | `SUPABASE_URL`, `SUPABASE_ANON_KEY`                                                       |
+| `apikey`   | `AUTH_API_KEYS` (comma-separated, format: `key:role1+role2:label`)                        |
 
 ## Adding a custom provider
 
 ```typescript
-import { registerProvider } from "your-auth-module/providers";
-import type { AuthProvider } from "your-auth-module/providers";
+import { registerProvider } from 'your-auth-module/providers';
+import type { AuthProvider } from 'your-auth-module/providers';
 
 const myProvider: AuthProvider = {
-  name: "custom",
+  name: 'custom',
   async verifyRequest(request) {
-    return { authenticated: true, user: { id: "1", roles: [], metadata: {} } };
+    return { authenticated: true, user: { id: '1', roles: [], metadata: {} } };
   },
 };
 

--- a/templates/module-auth-ts/template.yaml
+++ b/templates/module-auth-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-auth-ts
-displayName: "Auth Middleware Module"
+displayName: 'Auth Middleware Module'
 description: >
   Composable authentication middleware module with pluggable providers.
   Ships with reference implementations for JWT, Clerk, Auth0, Supabase,
   and API key validation. The provider registry pattern makes it trivial
   to add custom auth strategies. Middleware is compatible with both Hono
   and Express request handlers.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,34 +17,34 @@ tags: [auth, middleware, jwt, typescript, security]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Composable authentication middleware with pluggable providers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Composable authentication middleware with pluggable providers'
 
   - name: AuthProvider
     type: string
-    placeholder: "__AUTH_PROVIDER__"
-    description: "Default auth provider to use (jwt, clerk, auth0, supabase, apikey, or a custom name)"
-    prompt: "Default auth provider"
-    default: "jwt"
+    placeholder: '__AUTH_PROVIDER__'
+    description: 'Default auth provider to use (jwt, clerk, auth0, supabase, apikey, or a custom name)'
+    prompt: 'Default auth provider'
+    default: 'jwt'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, mcp-server-ts]
@@ -52,6 +52,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the auth module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the auth module'
     optional: false

--- a/templates/module-billing-ts/README.md
+++ b/templates/module-billing-ts/README.md
@@ -14,11 +14,11 @@ Usage metering, invoice generation, and payment processing with Stripe.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Usage metering and billing with Stripe` | Project description |
-| `PaymentProvider` | string | `stripe` | Default payment provider (stripe/mock or custom) |
+| Variable          | Type   | Default                                  | Description                                      |
+| ----------------- | ------ | ---------------------------------------- | ------------------------------------------------ |
+| `ProjectName`     | string | --                                       | Kebab-case project name                          |
+| `Description`     | string | `Usage metering and billing with Stripe` | Project description                              |
+| `PaymentProvider` | string | `stripe`                                 | Default payment provider (stripe/mock or custom) |
 
 ## Project layout
 

--- a/templates/module-billing-ts/template.yaml
+++ b/templates/module-billing-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-billing-ts
-displayName: "Module: Billing"
+displayName: 'Module: Billing'
 description: >
   Composable usage metering, invoice generation, and payment processing
   with Stripe. Records usage events with per-metric tracking, aggregates
   by customer and billing period, generates invoices with tiered pricing,
   and processes payments through a pluggable provider registry. Ships
   with a Stripe provider and an in-memory mock for testing.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,34 +17,34 @@ tags: [billing, payments, stripe, metering, invoicing, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Usage metering and billing with Stripe"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Usage metering and billing with Stripe'
 
   - name: PaymentProvider
     type: string
-    placeholder: "__PAYMENT_PROVIDER__"
-    description: "Default payment provider (stripe, mock, or a custom name)"
-    prompt: "Payment provider"
-    default: "stripe"
+    placeholder: '__PAYMENT_PROVIDER__'
+    description: 'Default payment provider (stripe, mock, or a custom name)'
+    prompt: 'Payment provider'
+    default: 'stripe'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, module-webhook-ts, module-queue-ts]
@@ -52,6 +52,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the billing module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the billing module'
     optional: false

--- a/templates/module-cache-ts/README.md
+++ b/templates/module-cache-ts/README.md
@@ -14,11 +14,11 @@ Composable caching with pluggable backends.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `Description` | string | `Pluggable caching layer with TTL and namespace support` | Project description |
-| `CacheProvider` | string | `memory` | Default cache provider (memory/redis/memcached or custom) |
+| Variable        | Type   | Default                                                  | Description                                               |
+| --------------- | ------ | -------------------------------------------------------- | --------------------------------------------------------- |
+| `ProjectName`   | string | —                                                        | Kebab-case project name                                   |
+| `Description`   | string | `Pluggable caching layer with TTL and namespace support` | Project description                                       |
+| `CacheProvider` | string | `memory`                                                 | Default cache provider (memory/redis/memcached or custom) |
 
 ## Project layout
 

--- a/templates/module-cache-ts/template.yaml
+++ b/templates/module-cache-ts/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: module-cache-ts
-displayName: "Module: Pluggable Cache"
+displayName: 'Module: Pluggable Cache'
 description: >
   Composable caching with pluggable backends. Ships with an in-memory
   provider for development, a Redis provider for distributed caching,
   and a Memcached provider for legacy infrastructure. Supports TTL,
   namespacing, and a cache-aside helper for read-through patterns.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -16,34 +16,34 @@ tags: [cache, caching, redis, memcached, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Pluggable caching layer with TTL and namespace support"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Pluggable caching layer with TTL and namespace support'
 
   - name: CacheProvider
     type: string
-    placeholder: "__CACHE_PROVIDER__"
-    description: "Default cache provider (memory, redis, memcached, or a custom name)"
-    prompt: "Cache provider"
-    default: "memory"
+    placeholder: '__CACHE_PROVIDER__'
+    description: 'Default cache provider (memory, redis, memcached, or a custom name)'
+    prompt: 'Cache provider'
+    default: 'memory'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop, rag-pipeline]
@@ -51,6 +51,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the cache module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the cache module'
     optional: false

--- a/templates/module-database-ts/README.md
+++ b/templates/module-database-ts/README.md
@@ -15,11 +15,11 @@ Composable database connection and query layer built on Drizzle ORM with pluggab
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `"Database module with Drizzle ORM and pluggable drivers"` | Short project description |
-| `DatabaseDriver` | string | `"postgres"` | Default driver (`postgres`, `sqlite`, `turso`, or custom) |
+| Variable         | Type   | Default                                                    | Description                                               |
+| ---------------- | ------ | ---------------------------------------------------------- | --------------------------------------------------------- |
+| `ProjectName`    | string | _(required)_                                               | Kebab-case project name                                   |
+| `Description`    | string | `"Database module with Drizzle ORM and pluggable drivers"` | Short project description                                 |
+| `DatabaseDriver` | string | `"postgres"`                                               | Default driver (`postgres`, `sqlite`, `turso`, or custom) |
 
 ## Project layout
 
@@ -90,12 +90,12 @@ Never edit a migration that has already been applied to a shared environment -- 
 ## Usage
 
 ```typescript
-import { createDatabase, getDb } from "./db/index.js";
+import { createDatabase, getDb } from './db/index.js';
 
 // Explicit connection
 const db = await createDatabase({
-  driver: "postgres",
-  url: "postgres://localhost:5432/mydb",
+  driver: 'postgres',
+  url: 'postgres://localhost:5432/mydb',
 });
 
 // Or use environment variables (DB_DRIVER + DATABASE_URL)

--- a/templates/module-database-ts/template.yaml
+++ b/templates/module-database-ts/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-database-ts
-displayName: "Database Module (Drizzle ORM)"
+displayName: 'Database Module (Drizzle ORM)'
 description: >
   Composable database connection and query layer built on Drizzle ORM with
   pluggable drivers. Ships with PostgreSQL (node-postgres), SQLite
@@ -10,7 +10,7 @@ description: >
   initialization, typed Drizzle schema definitions, and a migration runner
   powered by drizzle-kit. Designed to be dropped into any TypeScript service
   as a standalone data-access module.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -19,34 +19,34 @@ tags: [database, drizzle, orm, typescript, sql]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Database module with Drizzle ORM and pluggable drivers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Database module with Drizzle ORM and pluggable drivers'
 
   - name: DatabaseDriver
     type: string
-    placeholder: "__DATABASE_DRIVER__"
-    description: "Default database driver (postgres, sqlite, turso, or a custom name)"
-    prompt: "Default database driver"
-    default: "postgres"
+    placeholder: '__DATABASE_DRIVER__'
+    description: 'Default database driver (postgres, sqlite, turso, or a custom name)'
+    prompt: 'Default database driver'
+    default: 'postgres'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop, rag-pipeline]
@@ -54,6 +54,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for Drizzle ORM and database drivers"
+    version: '>=22'
+    purpose: 'Node.js runtime for Drizzle ORM and database drivers'
     optional: false

--- a/templates/module-feature-flags-ts/README.md
+++ b/templates/module-feature-flags-ts/README.md
@@ -16,12 +16,12 @@ Composable feature flags with pluggable stores and AI variant tracking.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `Feature flags with AI variant tracking` | Project description |
-| `FlagStore` | string | `memory` | Default flag store (memory/redis/json-file or custom) |
-| `IncludeTests` | bool | `true` | Include test suite |
+| Variable       | Type   | Default                                  | Description                                           |
+| -------------- | ------ | ---------------------------------------- | ----------------------------------------------------- |
+| `ProjectName`  | string | _(required)_                             | Kebab-case project name                               |
+| `Description`  | string | `Feature flags with AI variant tracking` | Project description                                   |
+| `FlagStore`    | string | `memory`                                 | Default flag store (memory/redis/json-file or custom) |
+| `IncludeTests` | bool   | `true`                                   | Include test suite                                    |
 
 ## Project layout
 

--- a/templates/module-feature-flags-ts/template.yaml
+++ b/templates/module-feature-flags-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-feature-flags-ts
-displayName: "Module: Feature Flags"
+displayName: 'Module: Feature Flags'
 description: >
   Composable feature flags with pluggable flag stores and AI variant
   tracking. Ships with in-memory, Redis, and JSON file stores.
   Supports percentage rollout with deterministic hashing, user
   allowlists, and property-based targeting rules. Includes a variant
   tracker for observability pairing.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,51 +17,51 @@ tags: [feature-flags, rollout, targeting, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Feature flags with AI variant tracking"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Feature flags with AI variant tracking'
 
   - name: FlagStore
     type: string
-    placeholder: "__FLAG_STORE__"
-    description: "Default flag store backend (memory, redis, json-file, or a custom name)"
-    prompt: "Flag store"
-    default: "memory"
+    placeholder: '__FLAG_STORE__'
+    description: 'Default flag store backend (memory, redis, json-file, or a custom name)'
+    prompt: 'Flag store'
+    default: 'memory'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include the test suite"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include the test suite'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/feature-flags/__tests__/evaluator.test.ts"
+  - path: 'src/feature-flags/__tests__/evaluator.test.ts'
     when: IncludeTests
-  - path: "src/feature-flags/__tests__/store-registry.test.ts"
+  - path: 'src/feature-flags/__tests__/store-registry.test.ts'
     when: IncludeTests
-  - path: "src/feature-flags/__tests__/tracker.test.ts"
+  - path: 'src/feature-flags/__tests__/tracker.test.ts'
     when: IncludeTests
-  - path: "src/feature-flags/resilience/__tests__/circuit-breaker.test.ts"
+  - path: 'src/feature-flags/resilience/__tests__/circuit-breaker.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop, next-app]
@@ -69,6 +69,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the feature flags module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the feature flags module'
     optional: false

--- a/templates/module-knowledge-base-ts/README.md
+++ b/templates/module-knowledge-base-ts/README.md
@@ -17,11 +17,11 @@ Knowledge base integration with pluggable providers.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Knowledge base integration with pluggable providers` | Project description |
-| `Provider` | string | `notion` | Default provider (notion/confluence/google-docs/coda/mock or custom) |
+| Variable      | Type   | Default                                               | Description                                                          |
+| ------------- | ------ | ----------------------------------------------------- | -------------------------------------------------------------------- |
+| `ProjectName` | string | --                                                    | Kebab-case project name                                              |
+| `Description` | string | `Knowledge base integration with pluggable providers` | Project description                                                  |
+| `Provider`    | string | `notion`                                              | Default provider (notion/confluence/google-docs/coda/mock or custom) |
 
 ## Project layout
 

--- a/templates/module-knowledge-base-ts/template.yaml
+++ b/templates/module-knowledge-base-ts/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-knowledge-base-ts
-displayName: "Module: Knowledge Base"
+displayName: 'Module: Knowledge Base'
 description: >
   Knowledge base integration with pluggable providers. Ships with Notion,
   Confluence, Google Docs, and Coda providers out of the box, plus an
@@ -9,7 +9,7 @@ description: >
   Includes a data-pipeline IngestSource adapter for bridging pages into
   document ingestion workflows. Factory-based registry, circuit breakers
   per instance, OTel metrics, and native fetch throughout.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -18,34 +18,34 @@ tags: [knowledge-base, notion, confluence, google-docs, coda, markdown, typescri
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Knowledge base integration with pluggable providers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Knowledge base integration with pluggable providers'
 
   - name: Provider
     type: string
-    placeholder: "__PROVIDER__"
-    description: "Default knowledge base provider (notion, confluence, google-docs, coda, mock, or a custom name)"
-    prompt: "Knowledge base provider"
-    default: "notion"
+    placeholder: '__PROVIDER__'
+    description: 'Default knowledge base provider (notion, confluence, google-docs, coda, mock, or a custom name)'
+    prompt: 'Knowledge base provider'
+    default: 'notion'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, rag-pipeline, data-pipeline, agentic-loop]
@@ -53,6 +53,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the knowledge base module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the knowledge base module'
     optional: false

--- a/templates/module-llm-gateway/README.md
+++ b/templates/module-llm-gateway/README.md
@@ -28,12 +28,12 @@ standardizes on Converse for measured caching.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Unified LLM gateway with routing, fallback, and cost tracking` | Project description |
-| `DefaultProvider` | string | `anthropic` | Default LLM provider (anthropic/openai/groq or custom) |
-| `RoutingStrategy` | string | `adaptive` | Default routing strategy (static/round-robin/latency/cost/adaptive) |
+| Variable          | Type   | Default                                                         | Description                                                         |
+| ----------------- | ------ | --------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `ProjectName`     | string | --                                                              | Kebab-case project name                                             |
+| `Description`     | string | `Unified LLM gateway with routing, fallback, and cost tracking` | Project description                                                 |
+| `DefaultProvider` | string | `anthropic`                                                     | Default LLM provider (anthropic/openai/groq or custom)              |
+| `RoutingStrategy` | string | `adaptive`                                                      | Default routing strategy (static/round-robin/latency/cost/adaptive) |
 
 ## Project layout
 

--- a/templates/module-llm-gateway/template.yaml
+++ b/templates/module-llm-gateway/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-llm-gateway
-displayName: "Module: LLM Gateway"
+displayName: 'Module: LLM Gateway'
 description: >
   Unified LLM gateway with pluggable routing strategies, response caching,
   and cost tracking. Ships with Bedrock (Converse + prompt caching, IRSA
@@ -10,7 +10,7 @@ description: >
   cost, adaptive, linucb), three caching modes (hash, sliding-TTL, none),
   token counting via js-tiktoken, and cost anomaly detection using z-score
   analysis.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -19,41 +19,41 @@ tags: [llm, gateway, routing, caching, cost-tracking, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Unified LLM gateway with routing, fallback, and cost tracking"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Unified LLM gateway with routing, fallback, and cost tracking'
 
   - name: DefaultProvider
     type: string
-    placeholder: "__DEFAULT_PROVIDER__"
-    description: "Default LLM provider (bedrock, anthropic, openai, groq, or a custom name)"
-    prompt: "Default LLM provider"
-    default: "bedrock"
+    placeholder: '__DEFAULT_PROVIDER__'
+    description: 'Default LLM provider (bedrock, anthropic, openai, groq, or a custom name)'
+    prompt: 'Default LLM provider'
+    default: 'bedrock'
 
   - name: RoutingStrategy
     type: string
-    placeholder: "__ROUTING_STRATEGY__"
-    description: "Default routing strategy (static, round-robin, latency, cost, adaptive)"
-    prompt: "Routing strategy"
-    default: "adaptive"
+    placeholder: '__ROUTING_STRATEGY__'
+    description: 'Default routing strategy (static, round-robin, latency, cost, adaptive)'
+    prompt: 'Routing strategy'
+    default: 'adaptive'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop, rag-pipeline]
@@ -61,6 +61,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=24"
-    purpose: "Node.js runtime for the LLM gateway module"
+    version: '>=24'
+    purpose: 'Node.js runtime for the LLM gateway module'
     optional: false

--- a/templates/module-llm-observability/README.md
+++ b/templates/module-llm-observability/README.md
@@ -15,12 +15,12 @@ AI-specific telemetry module with LLM call tracing, cost tracking, quality monit
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `Description` | string | `LLM observability module with tracing, cost tracking, and quality monitoring` | Description |
-| `Exporter` | string | `console` | Default exporter (console/otlp/json-file or custom) |
-| `IncludeCostTracking` | bool | `true` | Include cost tracking and anomaly detection |
+| Variable              | Type   | Default                                                                        | Description                                         |
+| --------------------- | ------ | ------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `ProjectName`         | string | —                                                                              | Kebab-case project name                             |
+| `Description`         | string | `LLM observability module with tracing, cost tracking, and quality monitoring` | Description                                         |
+| `Exporter`            | string | `console`                                                                      | Default exporter (console/otlp/json-file or custom) |
+| `IncludeCostTracking` | bool   | `true`                                                                         | Include cost tracking and anomaly detection         |
 
 ## Project layout
 

--- a/templates/module-llm-observability/template.yaml
+++ b/templates/module-llm-observability/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-llm-observability
-displayName: "Module: LLM Observability"
+displayName: 'Module: LLM Observability'
 description: >
   AI-specific telemetry module layered on OpenTelemetry. Wraps any async
   LLM call with trace capture, records per-request cost from a shared
@@ -10,7 +10,7 @@ description: >
   (console, OTLP, JSON file). Factory-based architecture with no
   module-level mutable state — all tracers, calculators, and monitors
   are instance-scoped via createLlmObserver().
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -19,45 +19,45 @@ tags: [llm, observability, tracing, cost-tracking, quality, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "LLM observability module with tracing, cost tracking, and quality monitoring"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'LLM observability module with tracing, cost tracking, and quality monitoring'
 
   - name: Exporter
     type: string
-    placeholder: "__EXPORTER__"
-    description: "Default LLM exporter (console, otlp, json-file, or a custom name)"
-    prompt: "Default exporter"
-    default: "console"
+    placeholder: '__EXPORTER__'
+    description: 'Default LLM exporter (console, otlp, json-file, or a custom name)'
+    prompt: 'Default exporter'
+    default: 'console'
 
   - name: IncludeCostTracking
     type: bool
-    placeholder: "__INCLUDE_COST_TRACKING__"
-    description: "Include cost tracking with per-model pricing and anomaly detection"
-    prompt: "Include cost tracking?"
+    placeholder: '__INCLUDE_COST_TRACKING__'
+    description: 'Include cost tracking with per-model pricing and anomaly detection'
+    prompt: 'Include cost tracking?'
     default: true
 
 conditionals:
-  - path: "src/llm-observability/cost/"
+  - path: 'src/llm-observability/cost/'
     when: IncludeCostTracking
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop, rag-pipeline, module-llm-gateway]
@@ -65,6 +65,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for LLM observability module"
+    version: '>=22'
+    purpose: 'Node.js runtime for LLM observability module'
     optional: false

--- a/templates/module-llm-providers/README.md
+++ b/templates/module-llm-providers/README.md
@@ -19,16 +19,16 @@ Shared LLM provider pack -- the canonical interface for all AI templates.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `LLM provider pack for Anthropic, OpenAI, Bedrock, Azure, and more` | Project description |
-| `DefaultProvider` | string | `anthropic` | Default LLM provider |
-| `IncludeBedrock` | bool | `false` | Include AWS Bedrock provider |
-| `IncludeAzure` | bool | `false` | Include Azure OpenAI provider |
-| `IncludeVertex` | bool | `false` | Include Google Vertex AI provider |
-| `IncludeHuggingFace` | bool | `false` | Include Hugging Face Inference provider |
-| `IncludeOllama` | bool | `false` | Include Ollama local inference provider |
+| Variable             | Type   | Default                                                             | Description                             |
+| -------------------- | ------ | ------------------------------------------------------------------- | --------------------------------------- |
+| `ProjectName`        | string | --                                                                  | Kebab-case project name                 |
+| `Description`        | string | `LLM provider pack for Anthropic, OpenAI, Bedrock, Azure, and more` | Project description                     |
+| `DefaultProvider`    | string | `anthropic`                                                         | Default LLM provider                    |
+| `IncludeBedrock`     | bool   | `false`                                                             | Include AWS Bedrock provider            |
+| `IncludeAzure`       | bool   | `false`                                                             | Include Azure OpenAI provider           |
+| `IncludeVertex`      | bool   | `false`                                                             | Include Google Vertex AI provider       |
+| `IncludeHuggingFace` | bool   | `false`                                                             | Include Hugging Face Inference provider |
+| `IncludeOllama`      | bool   | `false`                                                             | Include Ollama local inference provider |
 
 ## Project layout
 

--- a/templates/module-llm-providers/template.yaml
+++ b/templates/module-llm-providers/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-llm-providers
-displayName: "Module: LLM Providers"
+displayName: 'Module: LLM Providers'
 description: >
   Shared LLM provider pack — the canonical interface for all AI templates.
   Ships with Anthropic, OpenAI, and Groq providers out of the box, plus
   optional Bedrock, Azure OpenAI, Vertex AI, Hugging Face, and Ollama
   providers. Factory-based registry, streaming, token counting via
   js-tiktoken, circuit breakers, OTel metrics, and a gateway adapter.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,71 +17,71 @@ tags: [llm, providers, anthropic, openai, groq, streaming, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "LLM provider pack for Anthropic, OpenAI, Bedrock, Azure, and more"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'LLM provider pack for Anthropic, OpenAI, Bedrock, Azure, and more'
 
   - name: DefaultProvider
     type: string
-    placeholder: "__DEFAULT_PROVIDER__"
-    description: "Default LLM provider (anthropic, openai, groq, or a custom name)"
-    prompt: "Default LLM provider"
-    default: "anthropic"
+    placeholder: '__DEFAULT_PROVIDER__'
+    description: 'Default LLM provider (anthropic, openai, groq, or a custom name)'
+    prompt: 'Default LLM provider'
+    default: 'anthropic'
 
   - name: IncludeBedrock
     type: bool
-    placeholder: "__INCLUDE_BEDROCK__"
-    description: "Include AWS Bedrock provider"
+    placeholder: '__INCLUDE_BEDROCK__'
+    description: 'Include AWS Bedrock provider'
 
   - name: IncludeAzure
     type: bool
-    placeholder: "__INCLUDE_AZURE__"
-    description: "Include Azure OpenAI provider"
+    placeholder: '__INCLUDE_AZURE__'
+    description: 'Include Azure OpenAI provider'
 
   - name: IncludeVertex
     type: bool
-    placeholder: "__INCLUDE_VERTEX__"
-    description: "Include Google Vertex AI provider"
+    placeholder: '__INCLUDE_VERTEX__'
+    description: 'Include Google Vertex AI provider'
 
   - name: IncludeHuggingFace
     type: bool
-    placeholder: "__INCLUDE_HUGGING_FACE__"
-    description: "Include Hugging Face Inference provider"
+    placeholder: '__INCLUDE_HUGGING_FACE__'
+    description: 'Include Hugging Face Inference provider'
 
   - name: IncludeOllama
     type: bool
-    placeholder: "__INCLUDE_OLLAMA__"
-    description: "Include Ollama local inference provider"
+    placeholder: '__INCLUDE_OLLAMA__'
+    description: 'Include Ollama local inference provider'
 
 conditionals:
-  - path: "src/llm-providers/providers/bedrock.ts"
+  - path: 'src/llm-providers/providers/bedrock.ts'
     when: IncludeBedrock
-  - path: "src/llm-providers/providers/azure-openai.ts"
+  - path: 'src/llm-providers/providers/azure-openai.ts'
     when: IncludeAzure
-  - path: "src/llm-providers/providers/vertex.ts"
+  - path: 'src/llm-providers/providers/vertex.ts'
     when: IncludeVertex
-  - path: "src/llm-providers/providers/huggingface.ts"
+  - path: 'src/llm-providers/providers/huggingface.ts'
     when: IncludeHuggingFace
-  - path: "src/llm-providers/providers/ollama.ts"
+  - path: 'src/llm-providers/providers/ollama.ts'
     when: IncludeOllama
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop, rag-pipeline, module-llm-gateway, module-llm-observability]
@@ -89,6 +89,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the LLM providers module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the LLM providers module'
     optional: false

--- a/templates/module-media-ts/README.md
+++ b/templates/module-media-ts/README.md
@@ -16,11 +16,11 @@ Media processing and delivery with pluggable providers.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Media processing and delivery with pluggable providers` | Project description |
-| `MediaProvider` | string | `cloudinary` | Default media provider (cloudinary/uploadcare/imgix/mock or custom) |
+| Variable        | Type   | Default                                                  | Description                                                         |
+| --------------- | ------ | -------------------------------------------------------- | ------------------------------------------------------------------- |
+| `ProjectName`   | string | --                                                       | Kebab-case project name                                             |
+| `Description`   | string | `Media processing and delivery with pluggable providers` | Project description                                                 |
+| `MediaProvider` | string | `cloudinary`                                             | Default media provider (cloudinary/uploadcare/imgix/mock or custom) |
 
 ## Project layout
 

--- a/templates/module-media-ts/template.yaml
+++ b/templates/module-media-ts/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-media-ts
-displayName: "Module: Media Processing"
+displayName: 'Module: Media Processing'
 description: >
   Media processing and delivery with pluggable providers. Ships with
   providers for Cloudinary (Upload API + URL-based transforms), Uploadcare
@@ -10,7 +10,7 @@ description: >
   plus an in-memory mock for testing. Includes a fluent immutable
   TransformBuilder, named transform presets, factory-based registry,
   per-instance circuit breakers, OTel metrics, and native fetch throughout.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -19,34 +19,34 @@ tags: [media, images, cloudinary, uploadcare, imgix, transforms, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Media processing and delivery with pluggable providers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Media processing and delivery with pluggable providers'
 
   - name: MediaProvider
     type: string
-    placeholder: "__MEDIA_PROVIDER__"
-    description: "Default media provider (cloudinary, uploadcare, imgix, mock, or a custom name)"
-    prompt: "Media provider"
-    default: "cloudinary"
+    placeholder: '__MEDIA_PROVIDER__'
+    description: 'Default media provider (cloudinary, uploadcare, imgix, mock, or a custom name)'
+    prompt: 'Media provider'
+    default: 'cloudinary'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, next-app, module-storage-ts]
@@ -54,6 +54,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the media module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the media module'
     optional: false

--- a/templates/module-notifications-ts/README.md
+++ b/templates/module-notifications-ts/README.md
@@ -14,13 +14,13 @@ Composable notification service with pluggable providers for email, SMS, and pus
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `Description` | string | `Notification service with pluggable providers` | Project description |
-| `EmailProvider` | string | `resend` | Default email provider (resend/sendgrid or custom) |
-| `IncludeSms` | bool | `false` | Include SMS channel with Twilio provider |
-| `IncludePush` | bool | `false` | Include push channel with web-push provider |
+| Variable        | Type   | Default                                         | Description                                        |
+| --------------- | ------ | ----------------------------------------------- | -------------------------------------------------- |
+| `ProjectName`   | string | —                                               | Kebab-case project name                            |
+| `Description`   | string | `Notification service with pluggable providers` | Project description                                |
+| `EmailProvider` | string | `resend`                                        | Default email provider (resend/sendgrid or custom) |
+| `IncludeSms`    | bool   | `false`                                         | Include SMS channel with Twilio provider           |
+| `IncludePush`   | bool   | `false`                                         | Include push channel with web-push provider        |
 
 ## Project layout
 

--- a/templates/module-notifications-ts/template.yaml
+++ b/templates/module-notifications-ts/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: module-notifications-ts
-displayName: "Module: Notifications"
+displayName: 'Module: Notifications'
 description: >
   Composable notification service with pluggable providers for email,
   SMS, and push. Ships with Resend and SendGrid for email, Twilio
   for SMS, and web-push for browser notifications. Includes template
   rendering with variable substitution.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -16,55 +16,55 @@ tags: [notifications, email, sms, push, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Notification service with pluggable providers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Notification service with pluggable providers'
 
   - name: EmailProvider
     type: string
-    placeholder: "__EMAIL_PROVIDER__"
-    description: "Default email provider (resend, sendgrid, or a custom name)"
-    prompt: "Email provider"
-    default: "resend"
+    placeholder: '__EMAIL_PROVIDER__'
+    description: 'Default email provider (resend, sendgrid, or a custom name)'
+    prompt: 'Email provider'
+    default: 'resend'
 
   - name: IncludeSms
     type: bool
-    placeholder: "__INCLUDE_SMS__"
-    description: "Include SMS channel with Twilio provider"
-    prompt: "Include SMS support?"
+    placeholder: '__INCLUDE_SMS__'
+    description: 'Include SMS channel with Twilio provider'
+    prompt: 'Include SMS support?'
     default: false
 
   - name: IncludePush
     type: bool
-    placeholder: "__INCLUDE_PUSH__"
-    description: "Include push notification channel with web-push provider"
-    prompt: "Include push notification support?"
+    placeholder: '__INCLUDE_PUSH__'
+    description: 'Include push notification channel with web-push provider'
+    prompt: 'Include push notification support?'
     default: false
 
 conditionals:
-  - path: "src/notifications/channels/sms"
+  - path: 'src/notifications/channels/sms'
     when: IncludeSms
 
-  - path: "src/notifications/channels/push"
+  - path: 'src/notifications/channels/push'
     when: IncludePush
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, module-queue-ts, module-auth-ts]
@@ -72,6 +72,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the notification module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the notification module'
     optional: false

--- a/templates/module-oauth-delegation-ts/README.md
+++ b/templates/module-oauth-delegation-ts/README.md
@@ -2,7 +2,7 @@
 
 Composable **outbound** OAuth 2.0 delegation module — stores per-user access tokens and calls third-party APIs on the user's behalf.
 
-> **Not inbound auth.** Use [module-auth-ts](../module-auth-ts/) to verify incoming requests. Use this module when your service needs to call Notion, Google, Atlassian, Slack, or HubSpot *as the user*.
+> **Not inbound auth.** Use [module-auth-ts](../module-auth-ts/) to verify incoming requests. Use this module when your service needs to call Notion, Google, Atlassian, Slack, or HubSpot _as the user_.
 
 ## What you get
 
@@ -17,10 +17,10 @@ Composable **outbound** OAuth 2.0 delegation module — stores per-user access t
 
 ## Variables
 
-| Variable | Placeholder | Default | Description |
-|----------|-------------|---------|-------------|
-| `ProjectName` | `__PROJECT_NAME__` | *(required)* | Kebab-case package name |
-| `Description` | `__DESCRIPTION__` | Per-user OAuth 2.0 delegation... | Package description |
+| Variable      | Placeholder        | Default                          | Description             |
+| ------------- | ------------------ | -------------------------------- | ----------------------- |
+| `ProjectName` | `__PROJECT_NAME__` | _(required)_                     | Kebab-case package name |
+| `Description` | `__DESCRIPTION__`  | Per-user OAuth 2.0 delegation... | Package description     |
 
 ## Project layout
 
@@ -77,7 +77,7 @@ import {
   notionProvider,
   googleProvider,
   InMemoryTokenStorage,
-} from "your-oauth-module";
+} from 'your-oauth-module';
 
 const router = createOAuthRouter({
   providers: {
@@ -88,7 +88,7 @@ const router = createOAuthRouter({
   stateSigningSecret: process.env.OAUTH_STATE_SIGNING_SECRET!,
   resolveUserId: async (req) => {
     // plug in your inbound auth — e.g., module-auth-ts's getAuthUser()
-    return req.headers.get("x-user-id");
+    return req.headers.get('x-user-id');
   },
   clientCredentials: {
     notion: {
@@ -105,10 +105,10 @@ const router = createOAuthRouter({
 });
 
 // In steady state, consumer code calls one thing:
-const accessToken = await router.getValidToken(userId, "notion");
+const accessToken = await router.getValidToken(userId, 'notion');
 if (accessToken) {
-  await fetch("https://api.notion.com/v1/users/me", {
-    headers: { Authorization: `Bearer ${accessToken}`, "Notion-Version": "2022-06-28" },
+  await fetch('https://api.notion.com/v1/users/me', {
+    headers: { Authorization: `Bearer ${accessToken}`, 'Notion-Version': '2022-06-28' },
   });
 }
 
@@ -120,20 +120,20 @@ if (accessToken) {
 
 Each adapter is a plain `OAuthProvider` object that self-registers at import time.
 
-| Provider | Auth URL | Notes |
-|----------|----------|-------|
-| `notion` | `api.notion.com/v1/oauth/authorize` | No refresh tokens — grants are long-lived |
-| `google` | `accounts.google.com/o/oauth2/v2/auth` | Sends `access_type=offline&prompt=consent` on first grant for refresh; reuses refresh token if response omits it |
-| `atlassian` | `auth.atlassian.com/authorize` | Adds `audience=api.atlassian.com` |
-| `slack` | `slack.com/oauth/v2/authorize` | Reads `authed_user.access_token` for user-scope flows |
-| `hubspot` | `app.hubspot.com/oauth/authorize` | Space-separated scopes |
+| Provider    | Auth URL                               | Notes                                                                                                            |
+| ----------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `notion`    | `api.notion.com/v1/oauth/authorize`    | No refresh tokens — grants are long-lived                                                                        |
+| `google`    | `accounts.google.com/o/oauth2/v2/auth` | Sends `access_type=offline&prompt=consent` on first grant for refresh; reuses refresh token if response omits it |
+| `atlassian` | `auth.atlassian.com/authorize`         | Adds `audience=api.atlassian.com`                                                                                |
+| `slack`     | `slack.com/oauth/v2/authorize`         | Reads `authed_user.access_token` for user-scope flows                                                            |
+| `hubspot`   | `app.hubspot.com/oauth/authorize`      | Space-separated scopes                                                                                           |
 
 ## Storage backends
 
-| Backend | Use case | Persistence | Encryption |
-|---------|----------|-------------|------------|
-| `InMemoryTokenStorage` | Tests, local dev | Process memory | None |
-| `DDBKmsTokenStorage` | Production | DynamoDB | KMS envelope, `EncryptionContext: { purpose, userId, provider }` |
+| Backend                | Use case         | Persistence    | Encryption                                                       |
+| ---------------------- | ---------------- | -------------- | ---------------------------------------------------------------- |
+| `InMemoryTokenStorage` | Tests, local dev | Process memory | None                                                             |
+| `DDBKmsTokenStorage`   | Production       | DynamoDB       | KMS envelope, `EncryptionContext: { purpose, userId, provider }` |
 
 `DDBKmsTokenStorage` depends on `@aws-sdk/client-dynamodb`, `@aws-sdk/client-kms`, and `@smithy/node-http-handler` as **optional peer dependencies** — install them only if you use this backend. DynamoDB key schema: PK `userId`, SK `provider`. The KMS `EncryptionContext` binds each ciphertext to its user/provider pair, so a leaked blob cannot be decrypted for a different user.
 
@@ -156,15 +156,15 @@ The per-key mutex deduplicates concurrent refreshes within a single Node.js proc
 Some consumers have a signed `/start` URL as their only caller-identity signal, with no parallel session on the `/callback` side. Their `resolveUserId` needs to answer both cases:
 
 ```typescript
-import { readStatePayloadUnverified, type ResolveUserId } from "your-oauth-module";
+import { readStatePayloadUnverified, type ResolveUserId } from 'your-oauth-module';
 
 const resolveUserId: ResolveUserId = async (req) => {
   const url = new URL(req.url);
-  const signedToken = url.searchParams.get("t");
+  const signedToken = url.searchParams.get('t');
   if (signedToken) return verifyMySignedToken(signedToken); // /start
 
   // /callback — no signed URL token present. Fall back to the cookie.
-  const cookie = req.headers.get("cookie") ?? "";
+  const cookie = req.headers.get('cookie') ?? '';
   const payload = readStatePayloadUnverified(cookie);
   return payload?.userId ?? null;
 };
@@ -174,31 +174,31 @@ const resolveUserId: ResolveUserId = async (req) => {
 
 ## module-auth-ts vs module-oauth-delegation-ts
 
-| | `module-auth-ts` | `module-oauth-delegation-ts` |
-|---|---|---|
-| Direction | Inbound — verify requests | Outbound — call APIs on user's behalf |
-| Question answered | "Is this request authenticated?" | "Can we call Notion as this user?" |
-| State | Request-scoped (no storage) | Durable per-(userId, provider) row |
-| Surface | Middleware + `requireAuth`/`requireRole` guards | Four handlers + `getValidToken()` |
-| Providers | JWT, Clerk, Auth0, Supabase, API key | Notion, Google, Atlassian, Slack, HubSpot |
+|                   | `module-auth-ts`                                | `module-oauth-delegation-ts`              |
+| ----------------- | ----------------------------------------------- | ----------------------------------------- |
+| Direction         | Inbound — verify requests                       | Outbound — call APIs on user's behalf     |
+| Question answered | "Is this request authenticated?"                | "Can we call Notion as this user?"        |
+| State             | Request-scoped (no storage)                     | Durable per-(userId, provider) row        |
+| Surface           | Middleware + `requireAuth`/`requireRole` guards | Four handlers + `getValidToken()`         |
+| Providers         | JWT, Clerk, Auth0, Supabase, API key            | Notion, Google, Atlassian, Slack, HubSpot |
 
 Most services want both: `module-auth-ts` to decide who's calling, `module-oauth-delegation-ts` to call downstream services on their behalf.
 
 ## Adding a custom provider
 
 ```typescript
-import { registerProvider } from "your-oauth-module/providers";
-import type { OAuthProvider } from "your-oauth-module";
+import { registerProvider } from 'your-oauth-module/providers';
+import type { OAuthProvider } from 'your-oauth-module';
 
 const githubProvider: OAuthProvider = {
-  name: "github",
+  name: 'github',
   authUrl:
-    "https://github.com/login/oauth/authorize" +
-    "?client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}&state={state}" +
-    "&code_challenge={code_challenge}&code_challenge_method={code_challenge_method}",
-  tokenUrl: "https://github.com/login/oauth/access_token",
+    'https://github.com/login/oauth/authorize' +
+    '?client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}&state={state}' +
+    '&code_challenge={code_challenge}&code_challenge_method={code_challenge_method}',
+  tokenUrl: 'https://github.com/login/oauth/access_token',
   revokeUrl: undefined,
-  defaultScopes: ["repo", "read:user"],
+  defaultScopes: ['repo', 'read:user'],
   usePkce: true,
   parseTokenResponse(raw) {
     const r = raw as { access_token: string; refresh_token?: string; expires_in?: number };
@@ -210,5 +210,5 @@ const githubProvider: OAuthProvider = {
   },
 };
 
-registerProvider("github", () => githubProvider);
+registerProvider('github', () => githubProvider);
 ```

--- a/templates/module-oauth-delegation-ts/template.yaml
+++ b/templates/module-oauth-delegation-ts/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-oauth-delegation-ts
-displayName: "OAuth Delegation Module"
+displayName: 'OAuth Delegation Module'
 description: >
   Composable outbound OAuth 2.0 delegation module. Handles the Authorization
   Code flow with PKCE, HMAC-signed state cookies, durable per-user token
@@ -10,7 +10,7 @@ description: >
   and HubSpot, plus in-memory and DynamoDB+KMS envelope-encrypted storage
   backends. Complements module-auth-ts — that verifies inbound requests, this
   delegates outbound calls on a user's behalf.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -19,27 +19,27 @@ tags: [oauth, oauth2, pkce, delegation, integrations, typescript, security]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Per-user OAuth 2.0 delegation with PKCE, token storage, and automatic refresh"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Per-user OAuth 2.0 delegation with PKCE, token storage, and automatic refresh'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, mcp-server-ts]
@@ -47,9 +47,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the OAuth delegation module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the OAuth delegation module'
     optional: false
   - name: aws-cli
-    purpose: "Provision the DynamoDB table and KMS key used by DDBKmsTokenStorage"
+    purpose: 'Provision the DynamoDB table and KMS key used by DDBKmsTokenStorage'
     optional: true

--- a/templates/module-observability-ts/README.md
+++ b/templates/module-observability-ts/README.md
@@ -13,13 +13,13 @@ Composable OpenTelemetry instrumentation module with pluggable exporters for tra
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `Description` | string | `OpenTelemetry instrumentation module` | Description |
-| `Exporter` | string | `console` | Default exporter (console/otlp/datadog or custom) |
-| `IncludeMetrics` | bool | `true` | Include metrics helpers |
-| `IncludeTracing` | bool | `true` | Include tracing helpers |
+| Variable         | Type   | Default                                | Description                                       |
+| ---------------- | ------ | -------------------------------------- | ------------------------------------------------- |
+| `ProjectName`    | string | —                                      | Kebab-case project name                           |
+| `Description`    | string | `OpenTelemetry instrumentation module` | Description                                       |
+| `Exporter`       | string | `console`                              | Default exporter (console/otlp/datadog or custom) |
+| `IncludeMetrics` | bool   | `true`                                 | Include metrics helpers                           |
+| `IncludeTracing` | bool   | `true`                                 | Include tracing helpers                           |
 
 ## Project layout
 

--- a/templates/module-observability-ts/template.yaml
+++ b/templates/module-observability-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-observability-ts
-displayName: "Observability Module (OpenTelemetry)"
+displayName: 'Observability Module (OpenTelemetry)'
 description: >
   Composable OpenTelemetry instrumentation module for TypeScript services.
   Provides one-call SDK initialization with pluggable exporters (console,
   OTLP, Datadog), structured logging with trace context propagation, and
   optional metrics and tracing helpers. Designed to be layered into any
   TypeScript service as a drop-in telemetry layer.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,54 +17,54 @@ tags: [observability, opentelemetry, tracing, metrics, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "OpenTelemetry observability module"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'OpenTelemetry observability module'
 
   - name: Exporter
     type: string
-    placeholder: "__EXPORTER__"
-    description: "Default telemetry exporter (console, otlp, datadog, or a custom name)"
-    prompt: "Default exporter"
-    default: "console"
+    placeholder: '__EXPORTER__'
+    description: 'Default telemetry exporter (console, otlp, datadog, or a custom name)'
+    prompt: 'Default exporter'
+    default: 'console'
 
   - name: IncludeMetrics
     type: bool
-    placeholder: "__INCLUDE_METRICS__"
-    description: "Include metrics helpers (counters, histograms)"
-    prompt: "Include metrics support?"
+    placeholder: '__INCLUDE_METRICS__'
+    description: 'Include metrics helpers (counters, histograms)'
+    prompt: 'Include metrics support?'
     default: true
 
   - name: IncludeTracing
     type: bool
-    placeholder: "__INCLUDE_TRACING__"
-    description: "Include tracing helpers (tracer wrapper, span creation)"
-    prompt: "Include tracing support?"
+    placeholder: '__INCLUDE_TRACING__'
+    description: 'Include tracing helpers (tracer wrapper, span creation)'
+    prompt: 'Include tracing support?'
     default: true
 
 conditionals:
-  - path: "src/telemetry/metrics.ts"
+  - path: 'src/telemetry/metrics.ts'
     when: IncludeMetrics
-  - path: "src/telemetry/tracer.ts"
+  - path: 'src/telemetry/tracer.ts'
     when: IncludeTracing
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, go-service, agentic-loop, mcp-server-ts]
@@ -72,6 +72,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for OpenTelemetry SDK"
+    version: '>=22'
+    purpose: 'Node.js runtime for OpenTelemetry SDK'
     optional: false

--- a/templates/module-project-mgmt-ts/README.md
+++ b/templates/module-project-mgmt-ts/README.md
@@ -18,11 +18,11 @@ Project management integration with pluggable providers.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Project management integration with pluggable providers` | Project description |
-| `Provider` | string | `linear` | Default project management provider |
+| Variable      | Type   | Default                                                   | Description                         |
+| ------------- | ------ | --------------------------------------------------------- | ----------------------------------- |
+| `ProjectName` | string | --                                                        | Kebab-case project name             |
+| `Description` | string | `Project management integration with pluggable providers` | Project description                 |
+| `Provider`    | string | `linear`                                                  | Default project management provider |
 
 ## Project layout
 

--- a/templates/module-project-mgmt-ts/template.yaml
+++ b/templates/module-project-mgmt-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-project-mgmt-ts
-displayName: "Module: Project Management"
+displayName: 'Module: Project Management'
 description: >
   Project management integration with pluggable providers. Ships with
   Linear (GraphQL), Jira (REST v3), Asana (REST), and Shortcut (REST)
   providers out of the box plus a mock provider for testing. Factory-based
   registry, unified priority mapping, cursor pagination, circuit breakers,
   and OTel metrics. All providers use native fetch — no SDK dependencies.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,34 +17,34 @@ tags: [project-management, linear, jira, asana, shortcut, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Project management integration with pluggable providers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Project management integration with pluggable providers'
 
   - name: Provider
     type: string
-    placeholder: "__PROVIDER__"
-    description: "Default project management provider (linear, jira, asana, shortcut, or a custom name)"
-    prompt: "Default provider"
-    default: "linear"
+    placeholder: '__PROVIDER__'
+    description: 'Default project management provider (linear, jira, asana, shortcut, or a custom name)'
+    prompt: 'Default provider'
+    default: 'linear'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, module-webhook-ts, module-queue-ts]
@@ -52,6 +52,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the project management module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the project management module'
     optional: false

--- a/templates/module-queue-ts/README.md
+++ b/templates/module-queue-ts/README.md
@@ -14,11 +14,11 @@ Composable background job processing with pluggable brokers.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `Description` | string | `Background job processing with pluggable queue providers` | Project description |
-| `QueueProvider` | string | `memory` | Default queue provider (memory/bullmq/sqs or custom) |
+| Variable        | Type   | Default                                                    | Description                                          |
+| --------------- | ------ | ---------------------------------------------------------- | ---------------------------------------------------- |
+| `ProjectName`   | string | —                                                          | Kebab-case project name                              |
+| `Description`   | string | `Background job processing with pluggable queue providers` | Project description                                  |
+| `QueueProvider` | string | `memory`                                                   | Default queue provider (memory/bullmq/sqs or custom) |
 
 ## Project layout
 

--- a/templates/module-queue-ts/template.yaml
+++ b/templates/module-queue-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-queue-ts
-displayName: "Module: Background Job Queue"
+displayName: 'Module: Background Job Queue'
 description: >
   Composable background job processing with pluggable brokers. Ships with
   an in-memory provider for development and testing, a BullMQ provider for
   Redis-backed queues, and an AWS SQS provider for cloud-native workloads.
   Uses a self-registering provider registry so custom brokers can be added
   without modifying core code.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,34 +17,34 @@ tags: [queue, jobs, background, typescript, workers]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Background job processing with pluggable queue providers"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Background job processing with pluggable queue providers'
 
   - name: QueueProvider
     type: string
-    placeholder: "__QUEUE_PROVIDER__"
-    description: "Default queue provider (memory, bullmq, sqs, or a custom name)"
-    prompt: "Queue provider"
-    default: "memory"
+    placeholder: '__QUEUE_PROVIDER__'
+    description: 'Default queue provider (memory, bullmq, sqs, or a custom name)'
+    prompt: 'Queue provider'
+    default: 'memory'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop]
@@ -52,6 +52,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the queue module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the queue module'
     optional: false

--- a/templates/module-rate-limit-ts/README.md
+++ b/templates/module-rate-limit-ts/README.md
@@ -13,12 +13,12 @@ Composable rate limiting with pluggable algorithms and state stores.
 
 ## Variables
 
-| Variable | Placeholder | Default | Description |
-|----------|-------------|---------|-------------|
-| `ProjectName` | `__PROJECT_NAME__` | *(required)* | Kebab-case package name |
-| `Description` | `__DESCRIPTION__` | Rate limiting middleware with pluggable algorithms | Package description |
-| `Algorithm` | `__ALGORITHM__` | `token-bucket` | Default rate limiting algorithm |
-| `Store` | `__STORE__` | `memory` | Default state store |
+| Variable      | Placeholder        | Default                                            | Description                     |
+| ------------- | ------------------ | -------------------------------------------------- | ------------------------------- |
+| `ProjectName` | `__PROJECT_NAME__` | _(required)_                                       | Kebab-case package name         |
+| `Description` | `__DESCRIPTION__`  | Rate limiting middleware with pluggable algorithms | Package description             |
+| `Algorithm`   | `__ALGORITHM__`    | `token-bucket`                                     | Default rate limiting algorithm |
+| `Store`       | `__STORE__`        | `memory`                                           | Default state store             |
 
 ## Project layout
 

--- a/templates/module-rate-limit-ts/template.yaml
+++ b/templates/module-rate-limit-ts/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: module-rate-limit-ts
-displayName: "Module: Rate Limiting"
+displayName: 'Module: Rate Limiting'
 description: >
   Composable rate limiting with pluggable algorithms and state stores.
   Ships with token bucket, sliding window, and fixed window algorithms.
   In-memory store for development, Redis for distributed deployments.
   Includes middleware factories for Hono and Express.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -16,41 +16,41 @@ tags: [rate-limit, throttle, middleware, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Rate limiting middleware with pluggable algorithms"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Rate limiting middleware with pluggable algorithms'
 
   - name: Algorithm
     type: string
-    placeholder: "__ALGORITHM__"
-    description: "Default rate limiting algorithm (token-bucket, sliding-window, fixed-window, or a custom name)"
-    prompt: "Rate limiting algorithm"
-    default: "token-bucket"
+    placeholder: '__ALGORITHM__'
+    description: 'Default rate limiting algorithm (token-bucket, sliding-window, fixed-window, or a custom name)'
+    prompt: 'Rate limiting algorithm'
+    default: 'token-bucket'
 
   - name: Store
     type: string
-    placeholder: "__STORE__"
-    description: "Default state store for rate limit counters (memory, redis, or a custom name)"
-    prompt: "State store"
-    default: "memory"
+    placeholder: '__STORE__'
+    description: 'Default state store for rate limit counters (memory, redis, or a custom name)'
+    prompt: 'State store'
+    default: 'memory'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, module-auth-ts]
@@ -58,6 +58,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the rate limiting module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the rate limiting module'
     optional: false

--- a/templates/module-search-ts/README.md
+++ b/templates/module-search-ts/README.md
@@ -15,11 +15,11 @@ Full-text search with pluggable backends.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Full-text search with pluggable backends` | Project description |
-| `SearchProvider` | string | `typesense` | Default search provider (typesense/algolia/meilisearch/mock or custom) |
+| Variable         | Type   | Default                                    | Description                                                            |
+| ---------------- | ------ | ------------------------------------------ | ---------------------------------------------------------------------- |
+| `ProjectName`    | string | --                                         | Kebab-case project name                                                |
+| `Description`    | string | `Full-text search with pluggable backends` | Project description                                                    |
+| `SearchProvider` | string | `typesense`                                | Default search provider (typesense/algolia/meilisearch/mock or custom) |
 
 ## Project layout
 

--- a/templates/module-search-ts/template.yaml
+++ b/templates/module-search-ts/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-search-ts
-displayName: "Module: Full-Text Search"
+displayName: 'Module: Full-Text Search'
 description: >
   Full-text search with pluggable backends. Ships with providers for
   Algolia (REST API), Typesense (HTTP API), and Meilisearch (HTTP API),
@@ -9,7 +9,7 @@ description: >
   counting. Includes a reciprocal rank fusion combiner for hybrid
   keyword + vector search. Factory-based registry, circuit breakers,
   OTel metrics, and native fetch throughout (no heavy SDKs).
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -18,34 +18,34 @@ tags: [search, full-text, algolia, typesense, meilisearch, hybrid, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Full-text search with pluggable backends"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Full-text search with pluggable backends'
 
   - name: SearchProvider
     type: string
-    placeholder: "__SEARCH_PROVIDER__"
-    description: "Default search provider (typesense, algolia, meilisearch, mock, or a custom name)"
-    prompt: "Search provider"
-    default: "typesense"
+    placeholder: '__SEARCH_PROVIDER__'
+    description: 'Default search provider (typesense, algolia, meilisearch, mock, or a custom name)'
+    prompt: 'Search provider'
+    default: 'typesense'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, rag-pipeline, module-vector-store]
@@ -53,6 +53,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the search module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the search module'
     optional: false

--- a/templates/module-semantic-cache/README.md
+++ b/templates/module-semantic-cache/README.md
@@ -16,12 +16,12 @@ Embedding-based LLM response caching using vector similarity search.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Semantic caching for LLM responses` | Project description |
-| `EmbeddingProvider` | string | `openai` | Default embedding provider (openai/mock or custom) |
-| `VectorBackend` | string | `memory` | Default vector store backend (memory or custom) |
+| Variable            | Type   | Default                              | Description                                        |
+| ------------------- | ------ | ------------------------------------ | -------------------------------------------------- |
+| `ProjectName`       | string | --                                   | Kebab-case project name                            |
+| `Description`       | string | `Semantic caching for LLM responses` | Project description                                |
+| `EmbeddingProvider` | string | `openai`                             | Default embedding provider (openai/mock or custom) |
+| `VectorBackend`     | string | `memory`                             | Default vector store backend (memory or custom)    |
 
 ## Project layout
 

--- a/templates/module-semantic-cache/template.yaml
+++ b/templates/module-semantic-cache/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-semantic-cache
-displayName: "Module: Semantic Cache"
+displayName: 'Module: Semantic Cache'
 description: >
   Embedding-based LLM response caching using vector similarity search.
   Stores prompt embeddings alongside cached responses and retrieves them
@@ -9,7 +9,7 @@ description: >
   Titan embedding provider (default), an OpenAI alternate, and an
   in-memory vector store for development. Includes a gateway adapter for
   drop-in integration with LLM gateway caching strategies.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -18,41 +18,41 @@ tags: [semantic-cache, embeddings, vector-search, llm, caching, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Semantic caching for LLM responses"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Semantic caching for LLM responses'
 
   - name: EmbeddingProvider
     type: string
-    placeholder: "__EMBEDDING_PROVIDER__"
-    description: "Default embedding provider (bedrock, openai, mock, or a custom name)"
-    prompt: "Embedding provider"
-    default: "bedrock"
+    placeholder: '__EMBEDDING_PROVIDER__'
+    description: 'Default embedding provider (bedrock, openai, mock, or a custom name)'
+    prompt: 'Embedding provider'
+    default: 'bedrock'
 
   - name: VectorBackend
     type: string
-    placeholder: "__VECTOR_BACKEND__"
-    description: "Default vector cache store backend (memory or a custom name)"
-    prompt: "Vector store backend"
-    default: "memory"
+    placeholder: '__VECTOR_BACKEND__'
+    description: 'Default vector cache store backend (memory or a custom name)'
+    prompt: 'Vector store backend'
+    default: 'memory'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, agentic-loop, rag-pipeline, module-cache-ts]
@@ -60,6 +60,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=24"
-    purpose: "Node.js runtime for the semantic cache module"
+    version: '>=24'
+    purpose: 'Node.js runtime for the semantic cache module'
     optional: false

--- a/templates/module-spring-security/README.md
+++ b/templates/module-spring-security/README.md
@@ -12,21 +12,21 @@ Unlike the TypeScript [`module-auth-ts`](../module-auth-ts/), this module doesn'
 - **`ApiKeyAuthenticationFilter.java`** — `OncePerRequestFilter` that pulls the configured header (default `X-API-Key`), constructs an `ApiKeyAuthenticationToken`, and delegates to the shared `AuthenticationManager`
 - **`ApiKeyAuthenticationProvider.java`** — an `AuthenticationProvider` that validates tokens via a pluggable `ApiKeyValidator` bean
 - **`InMemoryApiKeyValidator.java`** — a default `ApiKeyValidator` implementation backed by a static map in properties (useful for bootstrapping; real deployments swap in a DB or secret-store-backed validator)
-- **`MethodSecurityConfig.java`** *(conditional)* — `@EnableMethodSecurity` with `prePostEnabled` so you can use `@PreAuthorize` / `@PostAuthorize` on service methods
-- **`TestSecurityConfig.java`** *(conditional)* — `@TestConfiguration` exposing a stub `JwtDecoder` for slice tests that need the security context to load without hitting a real OIDC issuer
-- **`SecurityConfigTest.java`** *(conditional)* — verifies the multi-provider filter chain accepts JWT + API-key authentication paths
+- **`MethodSecurityConfig.java`** _(conditional)_ — `@EnableMethodSecurity` with `prePostEnabled` so you can use `@PreAuthorize` / `@PostAuthorize` on service methods
+- **`TestSecurityConfig.java`** _(conditional)_ — `@TestConfiguration` exposing a stub `JwtDecoder` for slice tests that need the security context to load without hitting a real OIDC issuer
+- **`SecurityConfigTest.java`** _(conditional)_ — verifies the multi-provider filter chain accepts JWT + API-key authentication paths
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `JavaPackage` | string | `com.example.app` | Root Java package (dot form) |
-| `PackageDir` | string | `com/example/app` | Root Java package (slash form) |
-| `OidcIssuer` | string | `https://auth.example.com` | Default OIDC issuer (override via env var at runtime) |
-| `AllowedAudience` | string | `<ProjectName>` | Default JWT `aud` claim |
-| `IncludeMethodSecurity` | bool | `true` | Ship `@EnableMethodSecurity` config |
-| `IncludeTests` | bool | `true` | Ship test helpers |
+| Variable                | Type   | Default                    | Description                                           |
+| ----------------------- | ------ | -------------------------- | ----------------------------------------------------- |
+| `ProjectName`           | string | (required)                 | Kebab-case project name                               |
+| `JavaPackage`           | string | `com.example.app`          | Root Java package (dot form)                          |
+| `PackageDir`            | string | `com/example/app`          | Root Java package (slash form)                        |
+| `OidcIssuer`            | string | `https://auth.example.com` | Default OIDC issuer (override via env var at runtime) |
+| `AllowedAudience`       | string | `<ProjectName>`            | Default JWT `aud` claim                               |
+| `IncludeMethodSecurity` | bool   | `true`                     | Ship `@EnableMethodSecurity` config                   |
+| `IncludeTests`          | bool   | `true`                     | Ship test helpers                                     |
 
 ## Project layout
 

--- a/templates/module-spring-security/template.yaml
+++ b/templates/module-spring-security/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-spring-security
-displayName: "Spring Security Auth Module"
+displayName: 'Spring Security Auth Module'
 description: >
   Drop-in Spring Security module for a Spring Boot service. Configures a
   multi-provider SecurityFilterChain supporting OAuth 2.0 JWT resource
@@ -11,7 +11,7 @@ description: >
   AuthenticationManager. Includes a custom JWT claim-to-authority
   converter, optional @EnableMethodSecurity configuration, and a test
   stub for bypassing real token validation in slice and integration tests.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -20,83 +20,83 @@ tags: [java, spring, spring-security, oauth2, oidc, jwt, api-key, identity, auth
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in bean names and log identifiers"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in bean names and log identifiers'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: JavaPackage
     type: string
-    placeholder: "__JAVA_PKG__"
-    description: "Root Java package (dot form) of the consuming project"
-    prompt: "Root Java package (dot form)"
-    default: "com.example.app"
+    placeholder: '__JAVA_PKG__'
+    description: 'Root Java package (dot form) of the consuming project'
+    prompt: 'Root Java package (dot form)'
+    default: 'com.example.app'
     required: true
     validation:
       pattern: "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
-      message: "Must be a valid Java package (e.g. com.example.app)"
+      message: 'Must be a valid Java package (e.g. com.example.app)'
 
   - name: PackageDir
     type: string
-    placeholder: "__PKG_DIR__"
+    placeholder: '__PKG_DIR__'
     description: >
       Root Java package as a directory path (slash form). Must be the
       slash-form of JavaPackage — e.g. if JavaPackage is 'com.example.app'
       then PackageDir is 'com/example/app'.
-    prompt: "Root Java package (slash form)"
-    default: "com/example/app"
+    prompt: 'Root Java package (slash form)'
+    default: 'com/example/app'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9_]*(/[a-z][a-z0-9_]*)*$"
-      message: "Must be lowercase segments separated by slashes"
+      pattern: '^[a-z][a-z0-9_]*(/[a-z][a-z0-9_]*)*$'
+      message: 'Must be lowercase segments separated by slashes'
 
   - name: OidcIssuer
     type: string
-    placeholder: "__OIDC_ISSUER__"
+    placeholder: '__OIDC_ISSUER__'
     description: >
       Default OIDC issuer URL baked into application.yaml documentation.
       Override at runtime via the SECURITY_JWT_ISSUER_URI env var.
-    prompt: "OIDC issuer URL"
-    default: "https://auth.example.com"
+    prompt: 'OIDC issuer URL'
+    default: 'https://auth.example.com'
 
   - name: AllowedAudience
     type: string
-    placeholder: "__ALLOWED_AUD__"
-    description: "Default JWT `aud` claim value expected on inbound tokens"
-    prompt: "Expected JWT audience"
-    default: "${ProjectName}"
+    placeholder: '__ALLOWED_AUD__'
+    description: 'Default JWT `aud` claim value expected on inbound tokens'
+    prompt: 'Expected JWT audience'
+    default: '${ProjectName}'
 
   - name: IncludeMethodSecurity
     type: bool
-    placeholder: "__INCLUDE_METHOD_SECURITY__"
-    description: "Enable @PreAuthorize / @PostAuthorize via a MethodSecurityConfig"
-    prompt: "Enable method-level security?"
+    placeholder: '__INCLUDE_METHOD_SECURITY__'
+    description: 'Enable @PreAuthorize / @PostAuthorize via a MethodSecurityConfig'
+    prompt: 'Enable method-level security?'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test helpers (stub JwtDecoder, filter-chain assertions)"
-    prompt: "Include test helpers?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test helpers (stub JwtDecoder, filter-chain assertions)'
+    prompt: 'Include test helpers?'
     default: true
 
 conditionals:
-  - path: "src/main/java/__PKG_DIR__/security/MethodSecurityConfig.java"
+  - path: 'src/main/java/__PKG_DIR__/security/MethodSecurityConfig.java'
     when: IncludeMethodSecurity
-  - path: "src/test/java/__PKG_DIR__/security/TestSecurityConfig.java"
+  - path: 'src/test/java/__PKG_DIR__/security/TestSecurityConfig.java'
     when: IncludeTests
-  - path: "src/test/java/__PKG_DIR__/security/SecurityConfigTest.java"
+  - path: 'src/test/java/__PKG_DIR__/security/SecurityConfigTest.java'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Resolve Maven dependencies for the consuming project"
-      run: "mvn -q -DskipTests dependency:resolve"
-      workdir: "."
+      description: 'Resolve Maven dependencies for the consuming project'
+      run: 'mvn -q -DskipTests dependency:resolve'
+      workdir: '.'
 
 composition:
   pairsWith: [spring-boot-service, istio-policy]
@@ -104,10 +104,10 @@ composition:
 
 prerequisites:
   - name: java
-    version: ">=25"
-    purpose: "JDK 25 (latest LTS) for compiling the security module"
+    version: '>=25'
+    purpose: 'JDK 25 (latest LTS) for compiling the security module'
     optional: false
   - name: mvn
-    version: ">=3.8"
-    purpose: "Maven build tool for dependency resolution"
+    version: '>=3.8'
+    purpose: 'Maven build tool for dependency resolution'
     optional: false

--- a/templates/module-storage-ts/README.md
+++ b/templates/module-storage-ts/README.md
@@ -15,11 +15,11 @@ Composable blob storage abstraction with pluggable backends for local filesystem
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `A composable blob storage module` | Project description |
-| `StorageProvider` | string | `local` | Default storage backend (local/s3/r2/gcs or custom) |
+| Variable          | Type   | Default                            | Description                                         |
+| ----------------- | ------ | ---------------------------------- | --------------------------------------------------- |
+| `ProjectName`     | string | --                                 | Kebab-case project name                             |
+| `Description`     | string | `A composable blob storage module` | Project description                                 |
+| `StorageProvider` | string | `local`                            | Default storage backend (local/s3/r2/gcs or custom) |
 
 ## Project layout
 

--- a/templates/module-storage-ts/template.yaml
+++ b/templates/module-storage-ts/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: module-storage-ts
-displayName: "Blob Storage Module"
+displayName: 'Blob Storage Module'
 description: >
   Composable blob storage abstraction with pluggable backends. Ships with
   providers for local filesystem, AWS S3, Cloudflare R2 (S3-compatible),
   and Google Cloud Storage. Uses a self-registering provider pattern so
   custom backends can be added without modifying core code. Handles
   streams for large files and supports signed URL generation.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -17,34 +17,34 @@ tags: [storage, s3, blob, typescript, infrastructure]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "A composable blob storage module"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'A composable blob storage module'
 
   - name: StorageProvider
     type: string
-    placeholder: "__STORAGE_PROVIDER__"
-    description: "Default storage backend (local, s3, r2, gcs, or a custom provider name)"
-    prompt: "Storage provider"
-    default: "local"
+    placeholder: '__STORAGE_PROVIDER__'
+    description: 'Default storage backend (local, s3, r2, gcs, or a custom provider name)'
+    prompt: 'Storage provider'
+    default: 'local'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, rag-pipeline, agentic-loop]
@@ -52,6 +52,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the storage module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the storage module'
     optional: false

--- a/templates/module-vector-store/README.md
+++ b/templates/module-vector-store/README.md
@@ -17,11 +17,11 @@ Pluggable vector database abstraction for embedding storage and similarity searc
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Pluggable vector store for embedding storage and similarity search` | Project description |
-| `VectorProvider` | string | `memory` | Default vector backend (memory/pgvector/qdrant/pinecone or custom) |
+| Variable         | Type   | Default                                                              | Description                                                        |
+| ---------------- | ------ | -------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `ProjectName`    | string | --                                                                   | Kebab-case project name                                            |
+| `Description`    | string | `Pluggable vector store for embedding storage and similarity search` | Project description                                                |
+| `VectorProvider` | string | `memory`                                                             | Default vector backend (memory/pgvector/qdrant/pinecone or custom) |
 
 ## Project layout
 

--- a/templates/module-vector-store/template.yaml
+++ b/templates/module-vector-store/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: module-vector-store
-displayName: "Vector Store Module"
+displayName: 'Vector Store Module'
 description: >
   Pluggable vector database abstraction for embedding storage and similarity
   search. Ships with providers for in-memory (Map-backed with cosine similarity),
@@ -9,7 +9,7 @@ description: >
   composable filter expression compiler that translates logical predicates into
   backend-native query formats. Uses the self-registering provider pattern so
   custom backends can be added without modifying core code.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -18,34 +18,34 @@ tags: [vector-store, embeddings, similarity-search, typescript, infrastructure]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Pluggable vector store for embedding storage and similarity search"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Pluggable vector store for embedding storage and similarity search'
 
   - name: VectorProvider
     type: string
-    placeholder: "__VECTOR_PROVIDER__"
-    description: "Default vector backend (memory, pgvector, qdrant, pinecone, or a custom provider name)"
-    prompt: "Vector provider"
-    default: "memory"
+    placeholder: '__VECTOR_PROVIDER__'
+    description: 'Default vector backend (memory, pgvector, qdrant, pinecone, or a custom provider name)'
+    prompt: 'Vector provider'
+    default: 'memory'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, rag-pipeline, agentic-loop]
@@ -53,6 +53,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the vector store module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the vector store module'
     optional: false

--- a/templates/module-webhook-ts/README.md
+++ b/templates/module-webhook-ts/README.md
@@ -14,11 +14,11 @@ Composable webhook infrastructure with pluggable signature verification and retr
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `Description` | string | `Webhook receiver and sender with retry` | Project description |
-| `SignatureMethod` | string | `hmac-sha256` | Default signature method (hmac-sha256/hmac-sha1 or custom) |
+| Variable          | Type   | Default                                  | Description                                                |
+| ----------------- | ------ | ---------------------------------------- | ---------------------------------------------------------- |
+| `ProjectName`     | string | —                                        | Kebab-case project name                                    |
+| `Description`     | string | `Webhook receiver and sender with retry` | Project description                                        |
+| `SignatureMethod` | string | `hmac-sha256`                            | Default signature method (hmac-sha256/hmac-sha1 or custom) |
 
 ## Project layout
 

--- a/templates/module-webhook-ts/template.yaml
+++ b/templates/module-webhook-ts/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: module-webhook-ts
-displayName: "Module: Webhooks"
+displayName: 'Module: Webhooks'
 description: >
   Composable webhook infrastructure. Receive webhooks with pluggable
   signature verification, send webhooks with exponential backoff retry,
   and log all events for debugging. Ships with HMAC-SHA256 and
   HMAC-SHA1 signature providers.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: composable-modules
@@ -16,34 +16,34 @@ tags: [webhook, events, http, retry, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Webhook receiver and sender with retry"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Webhook receiver and sender with retry'
 
   - name: SignatureMethod
     type: string
-    placeholder: "__SIGNATURE_METHOD__"
-    description: "Default signature method (hmac-sha256, hmac-sha1, or a custom name)"
-    prompt: "Signature method"
-    default: "hmac-sha256"
+    placeholder: '__SIGNATURE_METHOD__'
+    description: 'Default signature method (hmac-sha256, hmac-sha1, or a custom name)'
+    prompt: 'Signature method'
+    default: 'hmac-sha256'
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [ts-service, module-queue-ts]
@@ -51,6 +51,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the webhook module"
+    version: '>=22'
+    purpose: 'Node.js runtime for the webhook module'
     optional: false

--- a/templates/monitoring-stack/README.md
+++ b/templates/monitoring-stack/README.md
@@ -15,12 +15,12 @@ Standalone observability bundle with Grafana, Prometheus, and Loki. One command 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `Observability stack with Grafana, Prometheus, and Loki` | Project description |
-| `DeployTarget` | string | `docker-compose` | Primary deployment target |
-| `IncludeAlerts` | bool | `true` | Include Prometheus alert rules |
+| Variable        | Type   | Default                                                  | Description                    |
+| --------------- | ------ | -------------------------------------------------------- | ------------------------------ |
+| `ProjectName`   | string | (required)                                               | Kebab-case project name        |
+| `Description`   | string | `Observability stack with Grafana, Prometheus, and Loki` | Project description            |
+| `DeployTarget`  | string | `docker-compose`                                         | Primary deployment target      |
+| `IncludeAlerts` | bool   | `true`                                                   | Include Prometheus alert rules |
 
 ## Project layout
 

--- a/templates/monitoring-stack/template.yaml
+++ b/templates/monitoring-stack/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: monitoring-stack
-displayName: "Monitoring Stack"
+displayName: 'Monitoring Stack'
 description: >
   Standalone observability bundle with Grafana, Prometheus, and Loki.
   Ships a working docker-compose setup with auto-provisioned datasources,
   pre-built service and system dashboards, alert rules for errors, latency,
   CPU, memory, and disk, plus an alternative Helm chart for Kubernetes
   deployment. Single command to start, batteries included.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -17,37 +17,37 @@ tags: [monitoring, observability, grafana, prometheus, loki, infrastructure]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as resource names and labels"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as resource names and labels'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README and chart metadata"
-    prompt: "Project description"
-    default: "Observability stack with Grafana, Prometheus, and Loki"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README and chart metadata'
+    prompt: 'Project description'
+    default: 'Observability stack with Grafana, Prometheus, and Loki'
 
   - name: DeployTarget
     type: string
-    placeholder: "__DEPLOY_TARGET__"
-    description: "Primary deployment target (docker-compose or kubernetes)"
-    prompt: "Deploy target"
-    default: "docker-compose"
+    placeholder: '__DEPLOY_TARGET__'
+    description: 'Primary deployment target (docker-compose or kubernetes)'
+    prompt: 'Deploy target'
+    default: 'docker-compose'
 
   - name: IncludeAlerts
     type: bool
-    placeholder: "__INCLUDE_ALERTS__"
-    description: "Include Prometheus alert rules for service and system metrics"
-    prompt: "Include alert rules?"
+    placeholder: '__INCLUDE_ALERTS__'
+    description: 'Include Prometheus alert rules for service and system metrics'
+    prompt: 'Include alert rules?'
     default: true
 
 conditionals:
-  - path: "prometheus/rules/"
+  - path: 'prometheus/rules/'
     when: IncludeAlerts
 
 composition:
@@ -56,16 +56,16 @@ composition:
 
 prerequisites:
   - name: docker
-    purpose: "Container runtime for running the monitoring stack via docker-compose"
+    purpose: 'Container runtime for running the monitoring stack via docker-compose'
     optional: false
   - name: docker-compose
-    version: ">=2.0"
-    purpose: "Orchestrate multi-container monitoring stack"
+    version: '>=2.0'
+    purpose: 'Orchestrate multi-container monitoring stack'
     optional: false
   - name: helm
-    version: ">=3.0"
-    purpose: "Helm CLI for Kubernetes chart deployment (only needed for Helm alternative)"
+    version: '>=3.0'
+    purpose: 'Helm CLI for Kubernetes chart deployment (only needed for Helm alternative)'
     optional: true
   - name: kubectl
-    purpose: "Kubernetes CLI for applying chart output and managing cluster resources"
+    purpose: 'Kubernetes CLI for applying chart output and managing cluster resources'
     optional: true

--- a/templates/monorepo/README.md
+++ b/templates/monorepo/README.md
@@ -14,13 +14,13 @@ Scaffolds a Turborepo monorepo workspace using pnpm. Includes a shared TypeScrip
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Description` | string | `A Turborepo monorepo workspace` | Short project description |
-| `PackageManager` | string | `pnpm` | Package manager for the workspace |
-| `IncludeSharedUi` | bool | `false` | Include shared-ui component library |
-| `IncludeSharedUtils` | bool | `true` | Include shared-utils library |
+| Variable             | Type   | Default                          | Description                         |
+| -------------------- | ------ | -------------------------------- | ----------------------------------- |
+| `ProjectName`        | string | (required)                       | Kebab-case project name             |
+| `Description`        | string | `A Turborepo monorepo workspace` | Short project description           |
+| `PackageManager`     | string | `pnpm`                           | Package manager for the workspace   |
+| `IncludeSharedUi`    | bool   | `false`                          | Include shared-ui component library |
+| `IncludeSharedUtils` | bool   | `true`                           | Include shared-utils library        |
 
 ## Project layout
 

--- a/templates/monorepo/template.yaml
+++ b/templates/monorepo/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: monorepo
-displayName: "Turborepo Monorepo"
+displayName: 'Turborepo Monorepo'
 description: >
   Scaffolds a Turborepo monorepo workspace using pnpm. Includes a shared
   TypeScript base config, ESLint setup, Turborepo pipeline definitions for
   build/test/lint/dev, and GitHub Actions CI. Optionally includes shared
   utility and UI library packages under packages/.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -16,62 +16,62 @@ tags: [monorepo, turborepo, pnpm, typescript, workspace]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as the root workspace name"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as the root workspace name'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for the root package.json and README"
-    prompt: "Project description"
-    default: "A Turborepo monorepo workspace"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for the root package.json and README'
+    prompt: 'Project description'
+    default: 'A Turborepo monorepo workspace'
 
   - name: PackageManager
     type: string
-    placeholder: "__PACKAGE_MANAGER__"
-    description: "Package manager used for the workspace"
-    prompt: "Package manager"
-    default: "pnpm"
+    placeholder: '__PACKAGE_MANAGER__'
+    description: 'Package manager used for the workspace'
+    prompt: 'Package manager'
+    default: 'pnpm'
 
   - name: IncludeSharedUi
     type: bool
-    placeholder: "__INCLUDE_SHARED_UI__"
-    description: "Include a shared UI component library package"
-    prompt: "Include shared-ui package?"
+    placeholder: '__INCLUDE_SHARED_UI__'
+    description: 'Include a shared UI component library package'
+    prompt: 'Include shared-ui package?'
     default: false
 
   - name: IncludeSharedUtils
     type: bool
-    placeholder: "__INCLUDE_SHARED_UTILS__"
-    description: "Include a shared utilities library package"
-    prompt: "Include shared-utils package?"
+    placeholder: '__INCLUDE_SHARED_UTILS__'
+    description: 'Include a shared utilities library package'
+    prompt: 'Include shared-utils package?'
     default: true
 
 conditionals:
-  - path: "packages/shared-utils/package.json"
+  - path: 'packages/shared-utils/package.json'
     when: IncludeSharedUtils
-  - path: "packages/shared-utils/src/index.ts"
+  - path: 'packages/shared-utils/src/index.ts'
     when: IncludeSharedUtils
-  - path: "packages/shared-utils/tsconfig.json"
+  - path: 'packages/shared-utils/tsconfig.json'
     when: IncludeSharedUtils
-  - path: "packages/shared-ui/package.json"
+  - path: 'packages/shared-ui/package.json'
     when: IncludeSharedUi
-  - path: "packages/shared-ui/src/index.ts"
+  - path: 'packages/shared-ui/src/index.ts'
     when: IncludeSharedUi
-  - path: "packages/shared-ui/tsconfig.json"
+  - path: 'packages/shared-ui/tsconfig.json'
     when: IncludeSharedUi
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install workspace dependencies with pnpm"
-      run: "pnpm install"
-      workdir: "."
+      description: 'Install workspace dependencies with pnpm'
+      run: 'pnpm install'
+      workdir: '.'
 
 composition:
   pairsWith: []
@@ -79,10 +79,10 @@ composition:
 
 prerequisites:
   - name: pnpm
-    version: ">=9"
-    purpose: "Workspace-aware package manager for the monorepo"
+    version: '>=9'
+    purpose: 'Workspace-aware package manager for the monorepo'
     optional: false
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript tooling and Turborepo"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript tooling and Turborepo'
     optional: false

--- a/templates/multimodal-pipeline/README.md
+++ b/templates/multimodal-pipeline/README.md
@@ -14,14 +14,14 @@ Scaffolds a multimodal processing pipeline in TypeScript. Accepts image, audio, 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | "A multimodal processing pipeline" | Project description |
-| `LlmProvider` | string | `anthropic` | anthropic or openai |
-| `IncludeAudio` | bool | `true` | Include audio processing support |
-| `IncludeVideo` | bool | `false` | Include video processing support |
-| `IncludeTests` | bool | `true` | Include vitest test suite |
+| Variable       | Type   | Default                            | Description                      |
+| -------------- | ------ | ---------------------------------- | -------------------------------- |
+| `ProjectName`  | string | _(required)_                       | Kebab-case project name          |
+| `Description`  | string | "A multimodal processing pipeline" | Project description              |
+| `LlmProvider`  | string | `anthropic`                        | anthropic or openai              |
+| `IncludeAudio` | bool   | `true`                             | Include audio processing support |
+| `IncludeVideo` | bool   | `false`                            | Include video processing support |
+| `IncludeTests` | bool   | `true`                             | Include vitest test suite        |
 
 ## Project layout
 

--- a/templates/multimodal-pipeline/template.yaml
+++ b/templates/multimodal-pipeline/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: multimodal-pipeline
-displayName: "Multimodal Pipeline"
+displayName: 'Multimodal Pipeline'
 description: >
   Scaffolds a multimodal processing pipeline in TypeScript. Accepts image,
   audio, and video inputs, detects modality automatically, routes each input
@@ -11,7 +11,7 @@ description: >
   components are built from first principles using provider SDKs directly.
   Processors and LLM providers use a self-registering registry pattern for
   easy extension.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -20,65 +20,65 @@ tags: [typescript, multimodal, vision, audio, video, llm, ai, structured-output]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory names"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory names'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "A multimodal processing pipeline"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'A multimodal processing pipeline'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for multimodal analysis (e.g. anthropic, openai)"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for multimodal analysis (e.g. anthropic, openai)'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeAudio
     type: bool
-    placeholder: "__INCLUDE_AUDIO__"
-    description: "Include audio processing support (whisper transcription + LLM analysis)"
-    prompt: "Include audio processing?"
+    placeholder: '__INCLUDE_AUDIO__'
+    description: 'Include audio processing support (whisper transcription + LLM analysis)'
+    prompt: 'Include audio processing?'
     default: true
 
   - name: IncludeVideo
     type: bool
-    placeholder: "__INCLUDE_VIDEO__"
-    description: "Include video processing support (frame extraction + LLM analysis)"
-    prompt: "Include video processing?"
+    placeholder: '__INCLUDE_VIDEO__'
+    description: 'Include video processing support (frame extraction + LLM analysis)'
+    prompt: 'Include video processing?'
     default: false
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include vitest test suite with pipeline and processor tests"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include vitest test suite with pipeline and processor tests'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/processors/audio.ts"
+  - path: 'src/processors/audio.ts'
     when: IncludeAudio
-  - path: "src/processors/video.ts"
+  - path: 'src/processors/video.ts'
     when: IncludeVideo
-  - path: "src/__tests__/pipeline.test.ts"
+  - path: 'src/__tests__/pipeline.test.ts'
     when: IncludeTests
-  - path: "src/__tests__/image.test.ts"
+  - path: 'src/__tests__/image.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, rag-pipeline, eval-harness]
@@ -86,6 +86,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/next-app/README.md
+++ b/templates/next-app/README.md
@@ -16,15 +16,15 @@ Next.js 15 application with App Router, streaming AI chat, Tailwind CSS, and a p
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `An AI-powered web application` | Project description |
-| `LlmProvider` | string | `anthropic` | Default LLM provider |
-| `IncludeAuth` | bool | `true` | Include NextAuth.js authentication |
-| `IncludeDatabase` | bool | `true` | Include Drizzle ORM + Postgres |
-| `IncludeDocker` | bool | `true` | Include Dockerfile and Compose |
-| `IncludeTests` | bool | `true` | Include Vitest test suite |
+| Variable          | Type   | Default                         | Description                        |
+| ----------------- | ------ | ------------------------------- | ---------------------------------- |
+| `ProjectName`     | string | --                              | Kebab-case project name            |
+| `Description`     | string | `An AI-powered web application` | Project description                |
+| `LlmProvider`     | string | `anthropic`                     | Default LLM provider               |
+| `IncludeAuth`     | bool   | `true`                          | Include NextAuth.js authentication |
+| `IncludeDatabase` | bool   | `true`                          | Include Drizzle ORM + Postgres     |
+| `IncludeDocker`   | bool   | `true`                          | Include Dockerfile and Compose     |
+| `IncludeTests`    | bool   | `true`                          | Include Vitest test suite          |
 
 ## Project layout
 

--- a/templates/next-app/template.yaml
+++ b/templates/next-app/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: next-app
-displayName: "Next.js AI Application"
+displayName: 'Next.js AI Application'
 description: >
   Scaffolds a Next.js 15 application with App Router, streaming AI chat,
   and a pluggable provider registry. Includes Tailwind CSS styling, a
   chat UI with message streaming, server-side AI calls via route handlers,
   structured JSON logging, and optional auth, database (Drizzle + Postgres),
   and Docker configurations.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -17,76 +17,76 @@ tags: [typescript, nextjs, react, ai, chat, tailwind]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "An AI-powered web application"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'An AI-powered web application'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider for AI features (anthropic, openai, or custom)"
-    prompt: "LLM provider"
-    default: "anthropic"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider for AI features (anthropic, openai, or custom)'
+    prompt: 'LLM provider'
+    default: 'anthropic'
 
   - name: IncludeAuth
     type: bool
-    placeholder: "__INCLUDE_AUTH__"
-    description: "Include authentication setup with NextAuth.js"
-    prompt: "Include auth?"
+    placeholder: '__INCLUDE_AUTH__'
+    description: 'Include authentication setup with NextAuth.js'
+    prompt: 'Include auth?'
     default: true
 
   - name: IncludeDatabase
     type: bool
-    placeholder: "__INCLUDE_DATABASE__"
-    description: "Include database setup with Drizzle ORM and Postgres"
-    prompt: "Include database?"
+    placeholder: '__INCLUDE_DATABASE__'
+    description: 'Include database setup with Drizzle ORM and Postgres'
+    prompt: 'Include database?'
     default: true
 
   - name: IncludeDocker
     type: bool
-    placeholder: "__INCLUDE_DOCKER__"
-    description: "Include Dockerfile and docker-compose.yml"
-    prompt: "Include Docker files?"
+    placeholder: '__INCLUDE_DOCKER__'
+    description: 'Include Dockerfile and docker-compose.yml'
+    prompt: 'Include Docker files?'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include Vitest test suite and example tests"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include Vitest test suite and example tests'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/lib/auth"
+  - path: 'src/lib/auth'
     when: IncludeAuth
-  - path: "src/lib/db"
+  - path: 'src/lib/db'
     when: IncludeDatabase
-  - path: "Dockerfile"
+  - path: 'Dockerfile'
     when: IncludeDocker
-  - path: "docker-compose.yml"
+  - path: 'docker-compose.yml'
     when: IncludeDocker
-  - path: "vitest.config.ts"
+  - path: 'vitest.config.ts'
     when: IncludeTests
-  - path: "src/__tests__"
+  - path: 'src/__tests__'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [module-auth-ts, module-database-ts, infra-vercel, infra-aws]
@@ -94,6 +94,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=24"
-    purpose: "Node.js runtime for the Next.js application"
+    version: '>=24'
+    purpose: 'Node.js runtime for the Next.js application'
     optional: false

--- a/templates/okr-framework/README.md
+++ b/templates/okr-framework/README.md
@@ -11,12 +11,12 @@ Scaffolds an OKR structure with company, team, and individual levels, key result
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `OrgName` | string | (required) | Organization name |
-| `Cadence` | enum | `quarterly` | Review cadence: quarterly or monthly |
-| `IncludeScoring` | bool | `true` | Include scoring rubric |
+| Variable         | Type   | Default     | Description                          |
+| ---------------- | ------ | ----------- | ------------------------------------ |
+| `ProjectName`    | string | (required)  | Kebab-case project name              |
+| `OrgName`        | string | (required)  | Organization name                    |
+| `Cadence`        | enum   | `quarterly` | Review cadence: quarterly or monthly |
+| `IncludeScoring` | bool   | `true`      | Include scoring rubric               |
 
 ## Project layout
 

--- a/templates/okr-framework/template.yaml
+++ b/templates/okr-framework/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: okr-framework
-displayName: "OKR Framework"
+displayName: 'OKR Framework'
 description: >
   Scaffolds an OKR structure with company, team, and individual levels,
   key result templates, review cadence configuration, and scoring
   calibration. Optionally includes a scoring rubric with calibration
   examples. Designed for product and leadership teams establishing
   goal-setting practices.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [product]
 category: product
@@ -17,38 +17,38 @@ tags: [okr, objectives, key-results, goals, scoring, review-cadence]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: OrgName
     type: string
-    placeholder: "__ORG_NAME__"
-    description: "Organization name used in document titles and headers"
-    prompt: "Organization name"
+    placeholder: '__ORG_NAME__'
+    description: 'Organization name used in document titles and headers'
+    prompt: 'Organization name'
     required: true
 
   - name: Cadence
     type: enum
-    placeholder: "__CADENCE__"
-    description: "Review cadence for OKR cycles"
-    prompt: "Review cadence"
-    default: "quarterly"
+    placeholder: '__CADENCE__'
+    description: 'Review cadence for OKR cycles'
+    prompt: 'Review cadence'
+    default: 'quarterly'
     options: [quarterly, monthly]
 
   - name: IncludeScoring
     type: bool
-    placeholder: "__INCLUDE_SCORING__"
-    description: "Include a scoring rubric with calibration examples"
-    prompt: "Include scoring rubric?"
+    placeholder: '__INCLUDE_SCORING__'
+    description: 'Include a scoring rubric with calibration examples'
+    prompt: 'Include scoring rubric?'
     default: true
 
 conditionals:
-  - path: "okrs/scoring-rubric.md"
+  - path: 'okrs/scoring-rubric.md'
     when: IncludeScoring
 
 composition:

--- a/templates/onboarding-playbook/README.md
+++ b/templates/onboarding-playbook/README.md
@@ -11,12 +11,12 @@ Scaffolds a customer onboarding playbook with milestone definitions, success cri
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ProductName` | string | (required) | Human-readable product name |
-| `OnboardingType` | enum | `guided` | Workflow: self-serve, guided, or enterprise |
-| `IncludeHealthScoring` | bool | `true` | Include health scoring model |
+| Variable               | Type   | Default    | Description                                 |
+| ---------------------- | ------ | ---------- | ------------------------------------------- |
+| `ProjectName`          | string | (required) | Kebab-case project name                     |
+| `ProductName`          | string | (required) | Human-readable product name                 |
+| `OnboardingType`       | enum   | `guided`   | Workflow: self-serve, guided, or enterprise |
+| `IncludeHealthScoring` | bool   | `true`     | Include health scoring model                |
 
 ## Project layout
 

--- a/templates/onboarding-playbook/template.yaml
+++ b/templates/onboarding-playbook/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: onboarding-playbook
-displayName: "Customer Onboarding Playbook"
+displayName: 'Customer Onboarding Playbook'
 description: >
   Scaffolds a customer onboarding playbook with milestone definitions,
   success criteria, health checks, and sales-to-CS handoff checklists.
   Supports self-serve, guided, and enterprise onboarding workflows.
   Optionally includes a health scoring model for proactive account
   management.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [customer-success]
 category: customer-success
@@ -17,38 +17,38 @@ tags: [onboarding, customer-success, milestones, health-scoring, handoff]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ProductName
     type: string
-    placeholder: "__PRODUCT_NAME__"
-    description: "Human-readable product name for document titles"
-    prompt: "Product name"
+    placeholder: '__PRODUCT_NAME__'
+    description: 'Human-readable product name for document titles'
+    prompt: 'Product name'
     required: true
 
   - name: OnboardingType
     type: enum
-    placeholder: "__ONBOARDING_TYPE__"
-    description: "Onboarding workflow type"
-    prompt: "Onboarding type"
-    default: "guided"
-    options: ["self-serve", "guided", "enterprise"]
+    placeholder: '__ONBOARDING_TYPE__'
+    description: 'Onboarding workflow type'
+    prompt: 'Onboarding type'
+    default: 'guided'
+    options: ['self-serve', 'guided', 'enterprise']
 
   - name: IncludeHealthScoring
     type: bool
-    placeholder: "__INCLUDE_HEALTH_SCORING__"
-    description: "Include a health scoring model"
-    prompt: "Include health scoring?"
+    placeholder: '__INCLUDE_HEALTH_SCORING__'
+    description: 'Include a health scoring model'
+    prompt: 'Include health scoring?'
     default: true
 
 conditionals:
-  - path: "onboarding/health-scoring.yaml"
+  - path: 'onboarding/health-scoring.yaml'
     when: IncludeHealthScoring
 
 composition:

--- a/templates/prd-template/README.md
+++ b/templates/prd-template/README.md
@@ -11,12 +11,12 @@ Scaffolds a structured Product Requirements Document with problem statement, use
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ProductName` | string | (required) | Human-readable product name |
-| `IncludeUserStories` | bool | `true` | Include user stories document |
-| `IncludeMetrics` | bool | `true` | Include success metrics YAML |
+| Variable             | Type   | Default    | Description                   |
+| -------------------- | ------ | ---------- | ----------------------------- |
+| `ProjectName`        | string | (required) | Kebab-case project name       |
+| `ProductName`        | string | (required) | Human-readable product name   |
+| `IncludeUserStories` | bool   | `true`     | Include user stories document |
+| `IncludeMetrics`     | bool   | `true`     | Include success metrics YAML  |
 
 ## Project layout
 

--- a/templates/prd-template/template.yaml
+++ b/templates/prd-template/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: prd-template
-displayName: "Product Requirements Document"
+displayName: 'Product Requirements Document'
 description: >
   Scaffolds a structured PRD with problem statement, user stories,
   success metrics, constraints, and milestones. Produces a complete
   requirements package that aligns engineering, design, and stakeholders
   around what to build and why. Optionally includes dedicated user story
   and success metrics documents.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [product]
 category: product
@@ -17,39 +17,39 @@ tags: [prd, requirements, product, user-stories, metrics]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ProductName
     type: string
-    placeholder: "__PRODUCT_NAME__"
-    description: "Human-readable product name for document titles"
-    prompt: "Product name"
+    placeholder: '__PRODUCT_NAME__'
+    description: 'Human-readable product name for document titles'
+    prompt: 'Product name'
     required: true
 
   - name: IncludeUserStories
     type: bool
-    placeholder: "__INCLUDE_USER_STORIES__"
-    description: "Include a dedicated user stories document"
-    prompt: "Include user stories?"
+    placeholder: '__INCLUDE_USER_STORIES__'
+    description: 'Include a dedicated user stories document'
+    prompt: 'Include user stories?'
     default: true
 
   - name: IncludeMetrics
     type: bool
-    placeholder: "__INCLUDE_METRICS__"
-    description: "Include a success metrics YAML definition"
-    prompt: "Include success metrics?"
+    placeholder: '__INCLUDE_METRICS__'
+    description: 'Include a success metrics YAML definition'
+    prompt: 'Include success metrics?'
     default: true
 
 conditionals:
-  - path: "prd/user-stories.md"
+  - path: 'prd/user-stories.md'
     when: IncludeUserStories
-  - path: "prd/success-metrics.yaml"
+  - path: 'prd/success-metrics.yaml'
     when: IncludeMetrics
 
 composition:

--- a/templates/prompt-library/README.md
+++ b/templates/prompt-library/README.md
@@ -12,12 +12,12 @@ Versioned prompt management system using YAML files with structured frontmatter.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | `prompts` | Kebab-case project name |
-| `Description` | string | `A versioned prompt library` | Project description |
-| `IncludeSdk` | bool | `true` | Include TypeScript SDK |
-| `IncludeTests` | bool | `true` | Include validation tests |
+| Variable       | Type   | Default                      | Description              |
+| -------------- | ------ | ---------------------------- | ------------------------ |
+| `ProjectName`  | string | `prompts`                    | Kebab-case project name  |
+| `Description`  | string | `A versioned prompt library` | Project description      |
+| `IncludeSdk`   | bool   | `true`                       | Include TypeScript SDK   |
+| `IncludeTests` | bool   | `true`                       | Include validation tests |
 
 ## Project layout
 

--- a/templates/prompt-library/template.yaml
+++ b/templates/prompt-library/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: prompt-library
-displayName: "Prompt Library"
+displayName: 'Prompt Library'
 description: >
   Scaffolds a versioned prompt management system using YAML files with
   structured frontmatter for metadata, model configuration, and typed
   variables. Includes an optional TypeScript SDK for loading, validating,
   and rendering prompts programmatically, plus a validation test suite
   that checks all prompt files against a JSON Schema.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -17,54 +17,54 @@ tags: [prompts, yaml, versioning, llm, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
-    default: "prompts"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
+    default: 'prompts'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "A versioned prompt library"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'A versioned prompt library'
 
   - name: IncludeSdk
     type: bool
-    placeholder: "__INCLUDE_SDK__"
-    description: "Include TypeScript SDK for loading, validating, and rendering prompts"
-    prompt: "Include TypeScript SDK?"
+    placeholder: '__INCLUDE_SDK__'
+    description: 'Include TypeScript SDK for loading, validating, and rendering prompts'
+    prompt: 'Include TypeScript SDK?'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include validation test suite for prompt files"
-    prompt: "Include validation tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include validation test suite for prompt files'
+    prompt: 'Include validation tests?'
     default: true
 
 conditionals:
-  - path: "sdk/src/index.ts"
+  - path: 'sdk/src/index.ts'
     when: IncludeSdk
-  - path: "sdk/src/types.ts"
+  - path: 'sdk/src/types.ts'
     when: IncludeSdk
-  - path: "sdk/package.json"
+  - path: 'sdk/package.json'
     when: IncludeSdk
-  - path: "sdk/tsconfig.json"
+  - path: 'sdk/tsconfig.json'
     when: IncludeSdk
-  - path: "tests/validate.ts"
+  - path: 'tests/validate.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, eval-harness]
@@ -72,6 +72,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the SDK and validation scripts"
+    version: '>=22'
+    purpose: 'Node.js runtime for the SDK and validation scripts'
     optional: false

--- a/templates/proposal-template/README.md
+++ b/templates/proposal-template/README.md
@@ -10,11 +10,11 @@ Scaffolds a client-facing sales proposal with executive summary, solution overvi
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `CompanyName` | string | (required) | Client company name |
-| `ProposalType` | string | `services` | Proposal type |
+| Variable       | Type   | Default    | Description             |
+| -------------- | ------ | ---------- | ----------------------- |
+| `ProjectName`  | string | (required) | Kebab-case project name |
+| `CompanyName`  | string | (required) | Client company name     |
+| `ProposalType` | string | `services` | Proposal type           |
 
 ## Project layout
 

--- a/templates/proposal-template/template.yaml
+++ b/templates/proposal-template/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: proposal-template
-displayName: "Sales Proposal"
+displayName: 'Sales Proposal'
 description: >
   Scaffolds a client-facing sales proposal with executive summary,
   solution overview, pricing structure, delivery timeline, and terms.
   Produces a professional proposal document with supporting data files
   for pricing and scheduling.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [sales]
 category: sales
@@ -16,27 +16,27 @@ tags: [proposal, sales, pricing, timeline, services]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: CompanyName
     type: string
-    placeholder: "__COMPANY_NAME__"
-    description: "Client company name for the proposal"
-    prompt: "Client company name"
+    placeholder: '__COMPANY_NAME__'
+    description: 'Client company name for the proposal'
+    prompt: 'Client company name'
     required: true
 
   - name: ProposalType
     type: string
-    placeholder: "__PROPOSAL_TYPE__"
-    description: "Type of proposal (services, product, hybrid)"
-    prompt: "Proposal type"
-    default: "services"
+    placeholder: '__PROPOSAL_TYPE__'
+    description: 'Type of proposal (services, product, hybrid)'
+    prompt: 'Proposal type'
+    default: 'services'
 
 composition:
   pairsWith: [battle-cards, brand-guidelines]

--- a/templates/qbr-template/README.md
+++ b/templates/qbr-template/README.md
@@ -11,11 +11,11 @@ Scaffolds a Quarterly Business Review package with account health dashboards, us
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ReviewCadence` | enum | `quarterly` | Review cadence: quarterly or monthly |
-| `IncludeExpansion` | bool | `true` | Include expansion tracking |
+| Variable           | Type   | Default     | Description                          |
+| ------------------ | ------ | ----------- | ------------------------------------ |
+| `ProjectName`      | string | (required)  | Kebab-case project name              |
+| `ReviewCadence`    | enum   | `quarterly` | Review cadence: quarterly or monthly |
+| `IncludeExpansion` | bool   | `true`      | Include expansion tracking           |
 
 ## Project layout
 

--- a/templates/qbr-template/template.yaml
+++ b/templates/qbr-template/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: qbr-template
-displayName: "Quarterly Business Review"
+displayName: 'Quarterly Business Review'
 description: >
   Scaffolds a QBR package with account health dashboards, usage metrics
   frameworks, expansion opportunity tracking, and risk assessments.
   Supports quarterly and monthly review cadences. Optionally includes
   expansion tracking for upsell and cross-sell pipeline management.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [customer-success]
 category: customer-success
@@ -16,31 +16,31 @@ tags: [qbr, customer-success, metrics, risk-assessment, expansion]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ReviewCadence
     type: enum
-    placeholder: "__REVIEW_CADENCE__"
-    description: "Review meeting cadence"
-    prompt: "Review cadence"
-    default: "quarterly"
-    options: ["quarterly", "monthly"]
+    placeholder: '__REVIEW_CADENCE__'
+    description: 'Review meeting cadence'
+    prompt: 'Review cadence'
+    default: 'quarterly'
+    options: ['quarterly', 'monthly']
 
   - name: IncludeExpansion
     type: bool
-    placeholder: "__INCLUDE_EXPANSION__"
-    description: "Include expansion opportunity tracking"
-    prompt: "Include expansion tracking?"
+    placeholder: '__INCLUDE_EXPANSION__'
+    description: 'Include expansion opportunity tracking'
+    prompt: 'Include expansion tracking?'
     default: true
 
 conditionals:
-  - path: "qbr/expansion-tracking.yaml"
+  - path: 'qbr/expansion-tracking.yaml'
     when: IncludeExpansion
 
 composition:

--- a/templates/rag-pipeline/README.md
+++ b/templates/rag-pipeline/README.md
@@ -13,15 +13,15 @@ Scaffolds a Retrieval-Augmented Generation (RAG) pipeline in TypeScript. All com
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | "A retrieval-augmented generation pipeline" | Project description |
-| `VectorStore` | string | `chroma` | chroma, pgvector, qdrant, or pinecone |
-| `EmbeddingProvider` | string | `openai` | openai or cohere |
-| `LlmProvider` | string | `anthropic` | anthropic or openai |
-| `ChunkStrategy` | string | `recursive` | fixed, recursive, or semantic |
-| `IncludeTests` | bool | `true` | Include vitest test suite |
+| Variable            | Type   | Default                                     | Description                           |
+| ------------------- | ------ | ------------------------------------------- | ------------------------------------- |
+| `ProjectName`       | string | _(required)_                                | Kebab-case project name               |
+| `Description`       | string | "A retrieval-augmented generation pipeline" | Project description                   |
+| `VectorStore`       | string | `chroma`                                    | chroma, pgvector, qdrant, or pinecone |
+| `EmbeddingProvider` | string | `openai`                                    | openai or cohere                      |
+| `LlmProvider`       | string | `anthropic`                                 | anthropic or openai                   |
+| `ChunkStrategy`     | string | `recursive`                                 | fixed, recursive, or semantic         |
+| `IncludeTests`      | bool   | `true`                                      | Include vitest test suite             |
 
 ## Project layout
 

--- a/templates/rag-pipeline/template.yaml
+++ b/templates/rag-pipeline/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: rag-pipeline
-displayName: "RAG Pipeline"
+displayName: 'RAG Pipeline'
 description: >
   Scaffolds a Retrieval-Augmented Generation pipeline in TypeScript.
   Implements document ingestion, configurable chunking strategies,
@@ -13,7 +13,7 @@ description: >
   Supports multiple vector stores (pgvector, Chroma, Qdrant, Pinecone),
   alternate embedding providers (OpenAI, Cohere), and alternate LLM
   providers (Anthropic, OpenAI).
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: ai-systems
@@ -22,70 +22,70 @@ tags: [typescript, rag, embeddings, vector-search, llm, retrieval, ai]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory names"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory names'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "A retrieval-augmented generation pipeline"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'A retrieval-augmented generation pipeline'
 
   - name: VectorStore
     type: string
-    placeholder: "__VECTOR_STORE__"
-    description: "Vector database backend for storing and querying embeddings (e.g. chroma, pgvector, qdrant, pinecone)"
-    prompt: "Vector store"
-    default: "chroma"
+    placeholder: '__VECTOR_STORE__'
+    description: 'Vector database backend for storing and querying embeddings (e.g. chroma, pgvector, qdrant, pinecone)'
+    prompt: 'Vector store'
+    default: 'chroma'
 
   - name: EmbeddingProvider
     type: string
-    placeholder: "__EMBEDDING_PROVIDER__"
-    description: "Provider for text embeddings — bedrock (Titan v2, default), openai, or cohere"
-    prompt: "Embedding provider"
-    default: "bedrock"
+    placeholder: '__EMBEDDING_PROVIDER__'
+    description: 'Provider for text embeddings — bedrock (Titan v2, default), openai, or cohere'
+    prompt: 'Embedding provider'
+    default: 'bedrock'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "LLM provider for answer generation — bedrock (default), anthropic, or openai"
-    prompt: "LLM provider"
-    default: "bedrock"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'LLM provider for answer generation — bedrock (default), anthropic, or openai'
+    prompt: 'LLM provider'
+    default: 'bedrock'
 
   - name: ChunkStrategy
     type: string
-    placeholder: "__CHUNK_STRATEGY__"
-    description: "Text chunking strategy for splitting documents"
-    prompt: "Chunking strategy"
-    default: "recursive"
+    placeholder: '__CHUNK_STRATEGY__'
+    description: 'Text chunking strategy for splitting documents'
+    prompt: 'Chunking strategy'
+    default: 'recursive'
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include vitest test suite with chunking, retrieval, and registry tests"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include vitest test suite with chunking, retrieval, and registry tests'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/__tests__/chunking.test.ts"
+  - path: 'src/__tests__/chunking.test.ts'
     when: IncludeTests
-  - path: "src/__tests__/retrieval.test.ts"
+  - path: 'src/__tests__/retrieval.test.ts'
     when: IncludeTests
-  - path: "src/__tests__/registry.test.ts"
+  - path: 'src/__tests__/registry.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [agentic-loop, eval-harness, go-service]
@@ -93,6 +93,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=24"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=24'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/release-checklist/README.md
+++ b/templates/release-checklist/README.md
@@ -12,11 +12,11 @@ Scaffolds a structured release checklist covering pre-release validation, deploy
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ReleaseType` | enum | `minor` | Release type: major, minor, or patch |
-| `IncludeRollback` | bool | `true` | Include rollback plan |
+| Variable          | Type   | Default    | Description                          |
+| ----------------- | ------ | ---------- | ------------------------------------ |
+| `ProjectName`     | string | (required) | Kebab-case project name              |
+| `ReleaseType`     | enum   | `minor`    | Release type: major, minor, or patch |
+| `IncludeRollback` | bool   | `true`     | Include rollback plan                |
 
 ## Project layout
 

--- a/templates/release-checklist/template.yaml
+++ b/templates/release-checklist/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: release-checklist
-displayName: "Release Checklist"
+displayName: 'Release Checklist'
 description: >
   Scaffolds a structured release checklist covering pre-release validation,
   deployment verification, rollback criteria, and a sign-off matrix.
   Produces actionable Markdown checklists and a YAML sign-off matrix
   with role-based approval tracking. Designed to standardize the release
   process across teams and ensure consistent quality gates.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [qa]
 category: qa
@@ -17,31 +17,31 @@ tags: [testing, qa, release, checklist, deployment]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in document titles and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in document titles and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ReleaseType
     type: enum
-    placeholder: "__RELEASE_TYPE__"
-    description: "Semantic version release type"
-    prompt: "Release type"
-    default: "minor"
-    options: ["major", "minor", "patch"]
+    placeholder: '__RELEASE_TYPE__'
+    description: 'Semantic version release type'
+    prompt: 'Release type'
+    default: 'minor'
+    options: ['major', 'minor', 'patch']
 
   - name: IncludeRollback
     type: bool
-    placeholder: "__INCLUDE_ROLLBACK__"
-    description: "Include a rollback plan document"
-    prompt: "Include rollback plan?"
+    placeholder: '__INCLUDE_ROLLBACK__'
+    description: 'Include a rollback plan document'
+    prompt: 'Include rollback plan?'
     default: true
 
 conditionals:
-  - path: "release/rollback-plan.md"
+  - path: 'release/rollback-plan.md'
     when: IncludeRollback
 
 composition:

--- a/templates/research-framework/README.md
+++ b/templates/research-framework/README.md
@@ -11,11 +11,11 @@ Scaffolds a product research framework with hypothesis canvas, interview guides,
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ResearchType` | string | `generative` | Research methodology type |
-| `IncludeCompetitive` | bool | `true` | Include competitive analysis |
+| Variable             | Type   | Default      | Description                  |
+| -------------------- | ------ | ------------ | ---------------------------- |
+| `ProjectName`        | string | (required)   | Kebab-case project name      |
+| `ResearchType`       | string | `generative` | Research methodology type    |
+| `IncludeCompetitive` | bool   | `true`       | Include competitive analysis |
 
 ## Project layout
 

--- a/templates/research-framework/template.yaml
+++ b/templates/research-framework/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: research-framework
-displayName: "Research Framework"
+displayName: 'Research Framework'
 description: >
   Scaffolds a product research framework with hypothesis canvas,
   interview guides, and synthesis templates. Supports generative and
   evaluative research workflows. Optionally includes a structured
   competitive analysis. Designed to feed insights directly into PRDs
   and product strategy.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [product]
 category: product
@@ -17,30 +17,30 @@ tags: [research, interviews, competitive-analysis, hypothesis, synthesis]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ResearchType
     type: string
-    placeholder: "__RESEARCH_TYPE__"
-    description: "Primary research methodology (generative, evaluative, mixed)"
-    prompt: "Research type"
-    default: "generative"
+    placeholder: '__RESEARCH_TYPE__'
+    description: 'Primary research methodology (generative, evaluative, mixed)'
+    prompt: 'Research type'
+    default: 'generative'
 
   - name: IncludeCompetitive
     type: bool
-    placeholder: "__INCLUDE_COMPETITIVE__"
-    description: "Include a competitive analysis YAML template"
-    prompt: "Include competitive analysis?"
+    placeholder: '__INCLUDE_COMPETITIVE__'
+    description: 'Include a competitive analysis YAML template'
+    prompt: 'Include competitive analysis?'
     default: true
 
 conditionals:
-  - path: "research/competitive-analysis.yaml"
+  - path: 'research/competitive-analysis.yaml'
     when: IncludeCompetitive
 
 composition:

--- a/templates/runbook/README.md
+++ b/templates/runbook/README.md
@@ -12,12 +12,12 @@ Scaffolds an operations runbook with service overview, dependency map, operation
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `ServiceName` | string | (required) | Human-readable service name |
-| `IncludeIncidentResponse` | bool | `true` | Include incident response playbook |
-| `OnCallTool` | string | `pagerduty` | On-call management tool |
+| Variable                  | Type   | Default     | Description                        |
+| ------------------------- | ------ | ----------- | ---------------------------------- |
+| `ProjectName`             | string | (required)  | Kebab-case project name            |
+| `ServiceName`             | string | (required)  | Human-readable service name        |
+| `IncludeIncidentResponse` | bool   | `true`      | Include incident response playbook |
+| `OnCallTool`              | string | `pagerduty` | On-call management tool            |
 
 ## Project layout
 

--- a/templates/runbook/template.yaml
+++ b/templates/runbook/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: nanohype/v1
 
 name: runbook
-displayName: "Operations Runbook"
+displayName: 'Operations Runbook'
 description: >
   Scaffolds an operations runbook with service overview, dependency map,
   operational procedures, and escalation paths. Optionally includes an
   incident response playbook. Designed for on-call engineers and SRE
   teams managing production services.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [operations]
 category: operations
@@ -16,37 +16,37 @@ tags: [runbook, operations, incident-response, escalation, sre]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name used as the document directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name used as the document directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ServiceName
     type: string
-    placeholder: "__SERVICE_NAME__"
-    description: "Human-readable service name for document titles"
-    prompt: "Service name"
+    placeholder: '__SERVICE_NAME__'
+    description: 'Human-readable service name for document titles'
+    prompt: 'Service name'
     required: true
 
   - name: IncludeIncidentResponse
     type: bool
-    placeholder: "__INCLUDE_INCIDENT_RESPONSE__"
-    description: "Include an incident response playbook"
-    prompt: "Include incident response?"
+    placeholder: '__INCLUDE_INCIDENT_RESPONSE__'
+    description: 'Include an incident response playbook'
+    prompt: 'Include incident response?'
     default: true
 
   - name: OnCallTool
     type: string
-    placeholder: "__ON_CALL_TOOL__"
-    description: "On-call management tool (pagerduty, opsgenie, grafana-oncall)"
-    prompt: "On-call tool"
-    default: "pagerduty"
+    placeholder: '__ON_CALL_TOOL__'
+    description: 'On-call management tool (pagerduty, opsgenie, grafana-oncall)'
+    prompt: 'On-call tool'
+    default: 'pagerduty'
 
 conditionals:
-  - path: "runbook/incident-response.md"
+  - path: 'runbook/incident-response.md'
     when: IncludeIncidentResponse
 
 composition:

--- a/templates/slack-bot/README.md
+++ b/templates/slack-bot/README.md
@@ -13,13 +13,13 @@ TypeScript Slack bot with @slack/bolt, AI-powered responses, and a pluggable LLM
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | _(required)_ | Kebab-case project name |
-| `Description` | string | `"A Slack bot with AI"` | Short project description |
-| `LlmProvider` | string | `"anthropic"` | `anthropic` or `openai` |
-| `IncludeSlashCommands` | bool | `true` | Include `/ask` slash command |
-| `IncludeTests` | bool | `true` | Include test files |
+| Variable               | Type   | Default                 | Description                  |
+| ---------------------- | ------ | ----------------------- | ---------------------------- |
+| `ProjectName`          | string | _(required)_            | Kebab-case project name      |
+| `Description`          | string | `"A Slack bot with AI"` | Short project description    |
+| `LlmProvider`          | string | `"anthropic"`           | `anthropic` or `openai`      |
+| `IncludeSlashCommands` | bool   | `true`                  | Include `/ask` slash command |
+| `IncludeTests`         | bool   | `true`                  | Include test files           |
 
 ## Project layout
 

--- a/templates/slack-bot/template.yaml
+++ b/templates/slack-bot/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: slack-bot
-displayName: "Slack Bot"
+displayName: 'Slack Bot'
 description: >
   Scaffolds a TypeScript Slack bot using @slack/bolt with Socket Mode for
   local development and HTTP for production. Includes AI-powered message
@@ -9,7 +9,7 @@ description: >
   LLM provider registry (AWS Bedrock by default — Converse with prompt
   caching, on IRSA, no keys — plus Anthropic and OpenAI alternates), and
   thread-aware conversation context for multi-turn AI responses.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -18,54 +18,54 @@ tags: [typescript, slack, bot, ai, chatbot]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "A Slack bot with AI"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'A Slack bot with AI'
 
   - name: LlmProvider
     type: string
-    placeholder: "__LLM_PROVIDER__"
-    description: "Default LLM provider — bedrock (AWS Bedrock, IRSA, prompt-cached), anthropic, or openai"
-    prompt: "LLM provider"
-    default: "bedrock"
+    placeholder: '__LLM_PROVIDER__'
+    description: 'Default LLM provider — bedrock (AWS Bedrock, IRSA, prompt-cached), anthropic, or openai'
+    prompt: 'LLM provider'
+    default: 'bedrock'
 
   - name: IncludeSlashCommands
     type: bool
-    placeholder: "__INCLUDE_SLASH_COMMANDS__"
-    description: "Include the /ask slash command"
-    prompt: "Include slash commands?"
+    placeholder: '__INCLUDE_SLASH_COMMANDS__'
+    description: 'Include the /ask slash command'
+    prompt: 'Include slash commands?'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test files with vitest"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test files with vitest'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/commands/ask.ts"
+  - path: 'src/commands/ask.ts'
     when: IncludeSlashCommands
-  - path: "src/__tests__/message.test.ts"
+  - path: 'src/__tests__/message.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [module-queue-ts, module-database-ts, agentic-loop]
@@ -73,6 +73,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=24"
-    purpose: "Node.js runtime for the Slack bot"
+    version: '>=24'
+    purpose: 'Node.js runtime for the Slack bot'
     optional: false

--- a/templates/spring-boot-service/README.md
+++ b/templates/spring-boot-service/README.md
@@ -18,16 +18,16 @@ Scaffolds a Java [Spring Boot 4](https://spring.io/projects/spring-boot) HTTP se
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `GroupId` | string | `com.example` | Maven groupId (reverse-DNS, dot-separated) |
-| `ArtifactId` | string | `<ProjectName>` | Maven artifactId (kebab-case) |
-| `Description` | string | `A Spring Boot HTTP service` | Short project description |
-| `JavaPackage` | string | `<GroupId>.app` | Root Java package, dot form (e.g. `com.example.app`) |
-| `PackageDir` | string | `com/example/app` | Root Java package, slash form — must pair with `JavaPackage` |
-| `Database` | string | `postgres` | Database driver: `postgres`, `mysql`, or `h2` |
-| `IncludeDocker` | bool | `true` | Include Dockerfile and docker-compose.yml |
+| Variable        | Type   | Default                      | Description                                                  |
+| --------------- | ------ | ---------------------------- | ------------------------------------------------------------ |
+| `ProjectName`   | string | (required)                   | Kebab-case project name                                      |
+| `GroupId`       | string | `com.example`                | Maven groupId (reverse-DNS, dot-separated)                   |
+| `ArtifactId`    | string | `<ProjectName>`              | Maven artifactId (kebab-case)                                |
+| `Description`   | string | `A Spring Boot HTTP service` | Short project description                                    |
+| `JavaPackage`   | string | `<GroupId>.app`              | Root Java package, dot form (e.g. `com.example.app`)         |
+| `PackageDir`    | string | `com/example/app`            | Root Java package, slash form — must pair with `JavaPackage` |
+| `Database`      | string | `postgres`                   | Database driver: `postgres`, `mysql`, or `h2`                |
+| `IncludeDocker` | bool   | `true`                       | Include Dockerfile and docker-compose.yml                    |
 
 ### On the two package variables
 

--- a/templates/spring-boot-service/template.yaml
+++ b/templates/spring-boot-service/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: spring-boot-service
-displayName: "Spring Boot HTTP Service"
+displayName: 'Spring Boot HTTP Service'
 description: >
   Scaffolds a Java Spring Boot 4 HTTP service with Spring Web MVC, Spring Boot
   Actuator for health and metrics, Spring Data JPA + Flyway migrations, Micrometer
@@ -10,7 +10,7 @@ description: >
   load test scaffolding, Testcontainers integration tests, and optional Docker
   support. Auth-neutral — stack `module-spring-security` alongside when you need
   authentication.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -19,96 +19,96 @@ tags: [java, spring-boot, jvm, api, service, rest]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as repo/directory name"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as repo/directory name'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: GroupId
     type: string
-    placeholder: "__GROUP_ID__"
-    description: "Maven groupId (reverse-DNS, dot-separated, lowercase)"
-    prompt: "Maven groupId"
-    default: "com.example"
+    placeholder: '__GROUP_ID__'
+    description: 'Maven groupId (reverse-DNS, dot-separated, lowercase)'
+    prompt: 'Maven groupId'
+    default: 'com.example'
     required: true
     validation:
       pattern: "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
-      message: "Must be a valid Maven groupId (e.g. com.example.acme)"
+      message: 'Must be a valid Maven groupId (e.g. com.example.acme)'
 
   - name: ArtifactId
     type: string
-    placeholder: "__ARTIFACT_ID__"
-    description: "Maven artifactId (kebab-case)"
-    prompt: "Maven artifactId"
-    default: "${ProjectName}"
+    placeholder: '__ARTIFACT_ID__'
+    description: 'Maven artifactId (kebab-case)'
+    prompt: 'Maven artifactId'
+    default: '${ProjectName}'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for README and pom.xml"
-    prompt: "Project description"
-    default: "A Spring Boot HTTP service"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for README and pom.xml'
+    prompt: 'Project description'
+    default: 'A Spring Boot HTTP service'
 
   - name: JavaPackage
     type: string
-    placeholder: "__JAVA_PKG__"
-    description: "Root Java package (dot form, used in source declarations)"
-    prompt: "Root Java package (dot form)"
-    default: "${GroupId}.app"
+    placeholder: '__JAVA_PKG__'
+    description: 'Root Java package (dot form, used in source declarations)'
+    prompt: 'Root Java package (dot form)'
+    default: '${GroupId}.app'
     required: true
     validation:
       pattern: "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
-      message: "Must be a valid Java package (e.g. com.example.app)"
+      message: 'Must be a valid Java package (e.g. com.example.app)'
 
   - name: PackageDir
     type: string
-    placeholder: "__PKG_DIR__"
+    placeholder: '__PKG_DIR__'
     description: >
       Root Java package as a directory path (slash form, used for the source tree
       layout). Must be the slash-form of JavaPackage — e.g. if JavaPackage is
       'com.example.app' then PackageDir is 'com/example/app'.
-    prompt: "Root Java package (slash form)"
-    default: "com/example/app"
+    prompt: 'Root Java package (slash form)'
+    default: 'com/example/app'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9_]*(/[a-z][a-z0-9_]*)*$"
-      message: "Must be lowercase segments separated by slashes (e.g. com/example/app)"
+      pattern: '^[a-z][a-z0-9_]*(/[a-z][a-z0-9_]*)*$'
+      message: 'Must be lowercase segments separated by slashes (e.g. com/example/app)'
 
   - name: Database
     type: string
-    placeholder: "__DATABASE__"
+    placeholder: '__DATABASE__'
     description: >
       Default database driver. Known values: postgres, mysql, h2. Additional
       drivers can be added by editing pom.xml and application.yaml.
-    prompt: "Database driver"
-    default: "postgres"
+    prompt: 'Database driver'
+    default: 'postgres'
 
   - name: IncludeDocker
     type: bool
-    placeholder: "__INCLUDE_DOCKER__"
-    description: "Include Dockerfile and docker-compose.yml"
-    prompt: "Include Docker support?"
+    placeholder: '__INCLUDE_DOCKER__'
+    description: 'Include Dockerfile and docker-compose.yml'
+    prompt: 'Include Docker support?'
     default: true
 
 conditionals:
-  - path: "Dockerfile"
+  - path: 'Dockerfile'
     when: IncludeDocker
-  - path: "docker-compose.yml"
+  - path: 'docker-compose.yml'
     when: IncludeDocker
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Resolve Maven dependencies"
-      run: "mvn -q -DskipTests dependency:resolve"
-      workdir: "."
+      description: 'Resolve Maven dependencies'
+      run: 'mvn -q -DskipTests dependency:resolve'
+      workdir: '.'
 
 composition:
   pairsWith: [k8s-deploy, monitoring-stack, infra-gcp, infra-aws, module-spring-security]
@@ -116,10 +116,10 @@ composition:
 
 prerequisites:
   - name: java
-    version: ">=25"
-    purpose: "JDK 25 (latest LTS) for compiling and running the Spring Boot service"
+    version: '>=25'
+    purpose: 'JDK 25 (latest LTS) for compiling and running the Spring Boot service'
     optional: false
   - name: mvn
-    version: ">=3.8"
-    purpose: "Maven build tool for dependency resolution and packaging"
+    version: '>=3.8'
+    purpose: 'Maven build tool for dependency resolution and packaging'
     optional: false

--- a/templates/tenant-chart-base/README.md
+++ b/templates/tenant-chart-base/README.md
@@ -38,7 +38,7 @@ dependencies:
 Finally, replace each lifted template with a one-line wrapper, e.g. `chart/templates/serviceaccount.yaml`:
 
 ```yaml
-{{ include "tenant-chart-base.serviceaccount" . }}
+{ { include "tenant-chart-base.serviceaccount" . } }
 ```
 
 Because the library is vendored (present in `charts/`), `helm template` / `helm lint` work offline — no `helm dependency build` needed.

--- a/templates/tenant-chart-base/template.yaml
+++ b/templates/tenant-chart-base/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: tenant-chart-base
-displayName: "Tenant Chart Base (Helm library)"
+displayName: 'Tenant Chart Base (Helm library)'
 description: >
   A Helm library chart (type: library) that defines the named templates every
   nanohype Platform-tenant chart shares — the ServiceAccount (IRSA), NetworkPolicy
@@ -13,7 +13,7 @@ description: >
   and `.Release` resolve to the consuming app. Workload topology (Deployments,
   CronJobs, Services) and the per-tenant ExternalSecret stay in the consumer — those
   are the legitimate per-app divergences. The catalog's first library chart.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: infrastructure
@@ -32,8 +32,8 @@ composition:
 
 prerequisites:
   - name: helm
-    version: ">=3.0"
-    purpose: "Render + lint a consumer chart that depends on this library"
+    version: '>=3.0'
+    purpose: 'Render + lint a consumer chart that depends on this library'
     optional: false
 
 hooks: {}

--- a/templates/test-automation/README.md
+++ b/templates/test-automation/README.md
@@ -13,12 +13,12 @@ Scaffolds a test automation framework using Playwright for browser testing with 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `Framework` | string | `playwright` | Test framework |
-| `Language` | string | `typescript` | Programming language |
-| `IncludeCi` | bool | `true` | Include GitHub Actions workflow |
+| Variable      | Type   | Default      | Description                     |
+| ------------- | ------ | ------------ | ------------------------------- |
+| `ProjectName` | string | (required)   | Kebab-case project name         |
+| `Framework`   | string | `playwright` | Test framework                  |
+| `Language`    | string | `typescript` | Programming language            |
+| `IncludeCi`   | bool   | `true`       | Include GitHub Actions workflow |
 
 ## Project layout
 

--- a/templates/test-automation/template.yaml
+++ b/templates/test-automation/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: test-automation
-displayName: "Test Automation"
+displayName: 'Test Automation'
 description: >
   Scaffolds a test automation framework using Playwright for browser
   testing. Includes a page object model, test fixtures, data factories,
   example specs, and CI configuration. Produces a runnable test suite
   with structured reporting, parallel execution support, and a clean
   separation between test infrastructure and test logic.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [qa, engineering]
 category: qa
@@ -17,45 +17,45 @@ tags: [testing, qa, automation, playwright, typescript]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in package.json and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in package.json and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Framework
     type: string
-    placeholder: "__FRAMEWORK__"
-    description: "Test framework to use (e.g., playwright, cypress, selenium)"
-    prompt: "Test framework"
-    default: "playwright"
+    placeholder: '__FRAMEWORK__'
+    description: 'Test framework to use (e.g., playwright, cypress, selenium)'
+    prompt: 'Test framework'
+    default: 'playwright'
 
   - name: Language
     type: string
-    placeholder: "__LANGUAGE__"
-    description: "Programming language for test code"
-    prompt: "Language"
-    default: "typescript"
+    placeholder: '__LANGUAGE__'
+    description: 'Programming language for test code'
+    prompt: 'Language'
+    default: 'typescript'
 
   - name: IncludeCi
     type: bool
-    placeholder: "__INCLUDE_CI__"
-    description: "Include GitHub Actions CI workflow for automated test runs"
-    prompt: "Include CI workflow?"
+    placeholder: '__INCLUDE_CI__'
+    description: 'Include GitHub Actions CI workflow for automated test runs'
+    prompt: 'Include CI workflow?'
     default: true
 
 conditionals:
-  - path: ".github/workflows/test.yml"
+  - path: '.github/workflows/test.yml'
     when: IncludeCi
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [test-plan, acceptance-criteria, ts-service, next-app, go-service]
@@ -63,6 +63,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for TypeScript execution"
+    version: '>=22'
+    purpose: 'Node.js runtime for TypeScript execution'
     optional: false

--- a/templates/test-plan/README.md
+++ b/templates/test-plan/README.md
@@ -11,11 +11,11 @@ Scaffolds a comprehensive test plan document covering scope, approach, environme
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | (required) | Kebab-case project name |
-| `TestType` | string | `functional` | Primary testing type |
-| `IncludeRiskMatrix` | bool | `true` | Include risk assessment matrix |
+| Variable            | Type   | Default      | Description                    |
+| ------------------- | ------ | ------------ | ------------------------------ |
+| `ProjectName`       | string | (required)   | Kebab-case project name        |
+| `TestType`          | string | `functional` | Primary testing type           |
+| `IncludeRiskMatrix` | bool   | `true`       | Include risk assessment matrix |
 
 ## Project layout
 

--- a/templates/test-plan/template.yaml
+++ b/templates/test-plan/template.yaml
@@ -1,14 +1,14 @@
 apiVersion: nanohype/v1
 
 name: test-plan
-displayName: "Test Plan"
+displayName: 'Test Plan'
 description: >
   Scaffolds a comprehensive test plan document covering scope, approach,
   environments, test matrix, risk assessment, and entry/exit criteria.
   Produces a structured Markdown plan with a companion YAML test matrix
   and an optional risk matrix. Designed as the QA planning artifact that
   pairs with acceptance criteria and test automation templates.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [qa]
 category: qa
@@ -17,30 +17,30 @@ tags: [testing, qa, test-plan, risk, planning]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used in document titles and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used in document titles and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: TestType
     type: string
-    placeholder: "__TEST_TYPE__"
-    description: "Primary testing type covered by this plan"
-    prompt: "Test type"
-    default: "functional"
+    placeholder: '__TEST_TYPE__'
+    description: 'Primary testing type covered by this plan'
+    prompt: 'Test type'
+    default: 'functional'
 
   - name: IncludeRiskMatrix
     type: bool
-    placeholder: "__INCLUDE_RISK_MATRIX__"
-    description: "Include a risk assessment matrix document"
-    prompt: "Include risk matrix?"
+    placeholder: '__INCLUDE_RISK_MATRIX__'
+    description: 'Include a risk assessment matrix document'
+    prompt: 'Include risk matrix?'
     default: true
 
 conditionals:
-  - path: "plan/risk-matrix.md"
+  - path: 'plan/risk-matrix.md'
     when: IncludeRiskMatrix
 
 composition:

--- a/templates/ts-service/README.md
+++ b/templates/ts-service/README.md
@@ -13,12 +13,12 @@ TypeScript HTTP service with the Hono framework and OpenTelemetry instrumentatio
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `Description` | string | `A TypeScript HTTP service` | Project description |
-| `Framework` | string | `hono` | HTTP framework |
-| `IncludeDocker` | bool | `true` | Include Dockerfile and docker-compose |
+| Variable        | Type   | Default                     | Description                           |
+| --------------- | ------ | --------------------------- | ------------------------------------- |
+| `ProjectName`   | string | —                           | Kebab-case project name               |
+| `Description`   | string | `A TypeScript HTTP service` | Project description                   |
+| `Framework`     | string | `hono`                      | HTTP framework                        |
+| `IncludeDocker` | bool   | `true`                      | Include Dockerfile and docker-compose |
 
 ## Project layout
 

--- a/templates/ts-service/template.yaml
+++ b/templates/ts-service/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: ts-service
-displayName: "TypeScript HTTP Service"
+displayName: 'TypeScript HTTP Service'
 description: >
   Scaffolds a production-ready TypeScript HTTP service using the Hono
   framework. Ships with structured request logging, error handling, Zod
@@ -10,7 +10,7 @@ description: >
   template is auth-neutral and persistence-neutral — stack
   `module-auth-ts` alongside when you need authentication, and
   `module-database-ts` when you need a database layer.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -19,47 +19,47 @@ tags: [typescript, hono, api, service, rest]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "A TypeScript HTTP service"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'A TypeScript HTTP service'
 
   - name: Framework
     type: string
-    placeholder: "__FRAMEWORK__"
-    description: "HTTP framework (hono is default; extensible to express, fastify)"
-    prompt: "HTTP framework"
-    default: "hono"
+    placeholder: '__FRAMEWORK__'
+    description: 'HTTP framework (hono is default; extensible to express, fastify)'
+    prompt: 'HTTP framework'
+    default: 'hono'
 
   - name: IncludeDocker
     type: bool
-    placeholder: "__INCLUDE_DOCKER__"
-    description: "Include Dockerfile and docker-compose.yml"
-    prompt: "Include Docker files?"
+    placeholder: '__INCLUDE_DOCKER__'
+    description: 'Include Dockerfile and docker-compose.yml'
+    prompt: 'Include Docker files?'
     default: true
 
 conditionals:
-  - path: "Dockerfile"
+  - path: 'Dockerfile'
     when: IncludeDocker
-  - path: "docker-compose.yml"
+  - path: 'docker-compose.yml'
     when: IncludeDocker
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [infra-aws, infra-fly, module-auth-ts, module-database-ts]
@@ -67,6 +67,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the HTTP service"
+    version: '>=22'
+    purpose: 'Node.js runtime for the HTTP service'
     optional: false

--- a/templates/vscode-ext/README.md
+++ b/templates/vscode-ext/README.md
@@ -12,15 +12,15 @@ VS Code extension with optional React webview panel and AI provider integration.
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | — | Kebab-case project name |
-| `ExtensionName` | string | — | Display name in VS Code |
-| `Publisher` | string | — | VS Code marketplace publisher ID |
-| `Description` | string | `A VS Code extension` | Extension description |
-| `ActivationEvent` | string | `onStartupFinished` | When the extension activates |
-| `IncludeWebview` | bool | `true` | Include React webview panel |
-| `IncludeAi` | bool | `true` | Include AI provider integration |
+| Variable          | Type   | Default               | Description                      |
+| ----------------- | ------ | --------------------- | -------------------------------- |
+| `ProjectName`     | string | —                     | Kebab-case project name          |
+| `ExtensionName`   | string | —                     | Display name in VS Code          |
+| `Publisher`       | string | —                     | VS Code marketplace publisher ID |
+| `Description`     | string | `A VS Code extension` | Extension description            |
+| `ActivationEvent` | string | `onStartupFinished`   | When the extension activates     |
+| `IncludeWebview`  | bool   | `true`                | Include React webview panel      |
+| `IncludeAi`       | bool   | `true`                | Include AI provider integration  |
 
 ## Project layout
 

--- a/templates/vscode-ext/template.yaml
+++ b/templates/vscode-ext/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: vscode-ext
-displayName: "VS Code Extension (TypeScript + esbuild)"
+displayName: 'VS Code Extension (TypeScript + esbuild)'
 description: >
   Scaffolds a VS Code extension with TypeScript and esbuild bundling.
   Optionally includes a React-based webview panel that communicates with
@@ -9,7 +9,7 @@ description: >
   Anthropic and OpenAI providers using the shared registry pattern.
   Uses esbuild for fast builds and supports the standard VS Code
   extension development workflow.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -18,89 +18,89 @@ tags: [vscode, extension, typescript, ai, editor]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
-    default: "my-vscode-extension"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
+    default: 'my-vscode-extension'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: ExtensionName
     type: string
-    placeholder: "__EXTENSION_NAME__"
-    description: "Human-readable extension name displayed in VS Code"
-    prompt: "Extension display name"
-    default: "My Extension"
+    placeholder: '__EXTENSION_NAME__'
+    description: 'Human-readable extension name displayed in VS Code'
+    prompt: 'Extension display name'
+    default: 'My Extension'
     required: true
 
   - name: Publisher
     type: string
-    placeholder: "__PUBLISHER__"
-    description: "VS Code marketplace publisher ID"
-    prompt: "Publisher ID"
+    placeholder: '__PUBLISHER__'
+    description: 'VS Code marketplace publisher ID'
+    prompt: 'Publisher ID'
     required: true
     validation:
-      pattern: "^[a-zA-Z][a-zA-Z0-9-]*$"
-      message: "Must start with a letter and contain only letters, numbers, and hyphens"
+      pattern: '^[a-zA-Z][a-zA-Z0-9-]*$'
+      message: 'Must start with a letter and contain only letters, numbers, and hyphens'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short extension description for package.json and README"
-    prompt: "Extension description"
-    default: "A VS Code extension"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short extension description for package.json and README'
+    prompt: 'Extension description'
+    default: 'A VS Code extension'
 
   - name: ActivationEvent
     type: string
-    placeholder: "__ACTIVATION_EVENT__"
-    description: "VS Code activation event trigger"
-    prompt: "Activation event"
-    default: "onStartupFinished"
+    placeholder: '__ACTIVATION_EVENT__'
+    description: 'VS Code activation event trigger'
+    prompt: 'Activation event'
+    default: 'onStartupFinished'
 
   - name: IncludeWebview
     type: bool
-    placeholder: "__INCLUDE_WEBVIEW__"
-    description: "Include a React-based webview panel"
-    prompt: "Include webview panel?"
+    placeholder: '__INCLUDE_WEBVIEW__'
+    description: 'Include a React-based webview panel'
+    prompt: 'Include webview panel?'
     default: true
 
   - name: IncludeAi
     type: bool
-    placeholder: "__INCLUDE_AI__"
-    description: "Include AI integration with Anthropic and OpenAI providers"
-    prompt: "Include AI integration?"
+    placeholder: '__INCLUDE_AI__'
+    description: 'Include AI integration with Anthropic and OpenAI providers'
+    prompt: 'Include AI integration?'
     default: true
 
 conditionals:
-  - path: "src/webview/panel.ts"
+  - path: 'src/webview/panel.ts'
     when: IncludeWebview
-  - path: "src/webview/app/index.html"
+  - path: 'src/webview/app/index.html'
     when: IncludeWebview
-  - path: "src/webview/app/index.tsx"
+  - path: 'src/webview/app/index.tsx'
     when: IncludeWebview
-  - path: "src/webview/app/App.tsx"
+  - path: 'src/webview/app/App.tsx'
     when: IncludeWebview
-  - path: "src/ai/providers/types.ts"
+  - path: 'src/ai/providers/types.ts'
     when: IncludeAi
-  - path: "src/ai/providers/registry.ts"
+  - path: 'src/ai/providers/registry.ts'
     when: IncludeAi
-  - path: "src/ai/providers/anthropic.ts"
+  - path: 'src/ai/providers/anthropic.ts'
     when: IncludeAi
-  - path: "src/ai/providers/openai.ts"
+  - path: 'src/ai/providers/openai.ts'
     when: IncludeAi
-  - path: "src/ai/providers/index.ts"
+  - path: 'src/ai/providers/index.ts'
     when: IncludeAi
-  - path: "src/ai/client.ts"
+  - path: 'src/ai/client.ts'
     when: IncludeAi
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [mcp-server-ts, prompt-library]
@@ -108,9 +108,9 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for building and bundling the extension"
+    version: '>=22'
+    purpose: 'Node.js runtime for building and bundling the extension'
     optional: false
   - name: vsce
-    purpose: "VS Code Extension CLI for packaging and publishing"
+    purpose: 'VS Code Extension CLI for packaging and publishing'
     optional: true

--- a/templates/worker-service/README.md
+++ b/templates/worker-service/README.md
@@ -15,13 +15,13 @@ Background processor with scheduled cron jobs and queue consumption. Includes a 
 
 ## Variables
 
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `ProjectName` | string | -- | Kebab-case project name |
-| `Description` | string | `Background worker with cron and queue processing` | Project description |
-| `QueueProvider` | string | `memory` | Default queue provider (memory/bullmq/sqs or custom) |
-| `IncludeCron` | bool | `true` | Include cron scheduler |
-| `IncludeTests` | bool | `true` | Include test suite |
+| Variable        | Type   | Default                                            | Description                                          |
+| --------------- | ------ | -------------------------------------------------- | ---------------------------------------------------- |
+| `ProjectName`   | string | --                                                 | Kebab-case project name                              |
+| `Description`   | string | `Background worker with cron and queue processing` | Project description                                  |
+| `QueueProvider` | string | `memory`                                           | Default queue provider (memory/bullmq/sqs or custom) |
+| `IncludeCron`   | bool   | `true`                                             | Include cron scheduler                               |
+| `IncludeTests`  | bool   | `true`                                             | Include test suite                                   |
 
 ## Project layout
 

--- a/templates/worker-service/template.yaml
+++ b/templates/worker-service/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: nanohype/v1
 
 name: worker-service
-displayName: "TypeScript Worker Service"
+displayName: 'TypeScript Worker Service'
 description: >
   Background processor with scheduled cron jobs and queue consumption.
   Features a lightweight cron scheduler with standard 5-field expression
@@ -9,7 +9,7 @@ description: >
   circuit breaker for resilience, OpenTelemetry metrics, and a minimal
   Hono health server for Kubernetes probes. Graceful shutdown drains
   both cron and queue work before exit.
-version: "0.1.0"
+version: '0.1.0'
 license: Apache-2.0
 persona: [engineering]
 category: applications
@@ -18,62 +18,62 @@ tags: [typescript, worker, cron, queue, background, jobs]
 variables:
   - name: ProjectName
     type: string
-    placeholder: "__PROJECT_NAME__"
-    description: "Kebab-case project name, used as package name and directory"
-    prompt: "Project name"
+    placeholder: '__PROJECT_NAME__'
+    description: 'Kebab-case project name, used as package name and directory'
+    prompt: 'Project name'
     required: true
     validation:
-      pattern: "^[a-z][a-z0-9-]*$"
-      message: "Must be lowercase kebab-case starting with a letter"
+      pattern: '^[a-z][a-z0-9-]*$'
+      message: 'Must be lowercase kebab-case starting with a letter'
 
   - name: Description
     type: string
-    placeholder: "__DESCRIPTION__"
-    description: "Short project description for package.json and README"
-    prompt: "Project description"
-    default: "Background worker with cron and queue processing"
+    placeholder: '__DESCRIPTION__'
+    description: 'Short project description for package.json and README'
+    prompt: 'Project description'
+    default: 'Background worker with cron and queue processing'
 
   - name: QueueProvider
     type: string
-    placeholder: "__QUEUE_PROVIDER__"
-    description: "Default queue provider (memory, bullmq, sqs, or a custom name)"
-    prompt: "Queue provider"
-    default: "memory"
+    placeholder: '__QUEUE_PROVIDER__'
+    description: 'Default queue provider (memory, bullmq, sqs, or a custom name)'
+    prompt: 'Queue provider'
+    default: 'memory'
 
   - name: IncludeCron
     type: bool
-    placeholder: "__INCLUDE_CRON__"
-    description: "Include cron scheduler with example scheduled jobs"
-    prompt: "Include cron scheduler?"
+    placeholder: '__INCLUDE_CRON__'
+    description: 'Include cron scheduler with example scheduled jobs'
+    prompt: 'Include cron scheduler?'
     default: true
 
   - name: IncludeTests
     type: bool
-    placeholder: "__INCLUDE_TESTS__"
-    description: "Include test suite with vitest"
-    prompt: "Include tests?"
+    placeholder: '__INCLUDE_TESTS__'
+    description: 'Include test suite with vitest'
+    prompt: 'Include tests?'
     default: true
 
 conditionals:
-  - path: "src/worker/scheduler/cron.ts"
+  - path: 'src/worker/scheduler/cron.ts'
     when: IncludeCron
-  - path: "src/worker/scheduler/types.ts"
+  - path: 'src/worker/scheduler/types.ts'
     when: IncludeCron
-  - path: "src/worker/scheduler/jobs/example.ts"
+  - path: 'src/worker/scheduler/jobs/example.ts'
     when: IncludeCron
-  - path: "src/worker/__tests__/scheduler.test.ts"
+  - path: 'src/worker/__tests__/scheduler.test.ts'
     when: IncludeTests
-  - path: "src/worker/__tests__/consumer.test.ts"
+  - path: 'src/worker/__tests__/consumer.test.ts'
     when: IncludeTests
-  - path: "src/worker/__tests__/health.test.ts"
+  - path: 'src/worker/__tests__/health.test.ts'
     when: IncludeTests
 
 hooks:
   post:
     - name: install-dependencies
-      description: "Install npm dependencies"
-      run: "npm install"
-      workdir: "."
+      description: 'Install npm dependencies'
+      run: 'npm install'
+      workdir: '.'
 
 composition:
   pairsWith: [module-queue-ts, infra-aws, infra-fly, k8s-deploy]
@@ -81,6 +81,6 @@ composition:
 
 prerequisites:
   - name: node
-    version: ">=22"
-    purpose: "Node.js runtime for the worker service"
+    version: '>=22'
+    purpose: 'Node.js runtime for the worker service'
     optional: false


### PR DESCRIPTION
See commit message. Root .prettierrc (semi, single quotes, 100) + ignore for skeletons/catalog.json; 282 files; all validation suites green. NOTE: touches library/runtime/src — tenant repos re-vendor after this merges.