### PR TITLE
Add metrics + logger runtime modules, breaker onClose, canonical prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "printWidth": 100
-}

--- a/library/config/prettierrc.json
+++ b/library/config/prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/library/runtime/package-lock.json
+++ b/library/runtime/package-lock.json
@@ -9,12 +9,17 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/sdk-metrics": "^2.8.0",
         "@types/node": "^24.13.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=24"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -75,6 +80,76 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz",
+      "integrity": "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {

--- a/library/runtime/package.json
+++ b/library/runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@nanohype/runtime",
   "version": "0.1.0",
   "private": true,
-  "description": "Zero-dependency TypeScript runtime primitives — the vendorable source of truth for circuit breaking, resilience, provider registries, WorkOS Directory access, and PII redaction",
+  "description": "TypeScript runtime primitives — the vendorable source of truth for circuit breaking, resilience, provider registries, WorkOS Directory access, PII redaction, metrics, and logging. Zero runtime dependencies beyond the @opentelemetry/api peer the observability modules assume (present in every tenant by the platform contract)",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -13,7 +13,12 @@
   "engines": {
     "node": ">=24"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.1"
+  },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-metrics": "^2.8.0",
     "@types/node": "^24.13.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/library/runtime/src/circuit-breaker.test.ts
+++ b/library/runtime/src/circuit-breaker.test.ts
@@ -175,4 +175,68 @@ describe('circuit breaker', () => {
     await expect(cb.exec(fail)).rejects.toThrow('boom');
     expect(cb.state()).toBe('open');
   });
+
+  it('fires onClose once when a half-open probe succeeds', async () => {
+    const clock = makeClock();
+    const onClose = vi.fn();
+    const cb = createCircuitBreaker({
+      ...baseConfig,
+      failureThreshold: 1,
+      now: clock.now,
+      onClose,
+    });
+
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    expect(onClose).not.toHaveBeenCalled();
+
+    clock.tick(30_000);
+    await expect(cb.exec(ok)).resolves.toBe('ok');
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith('test');
+
+    // Further successes while closed don't re-fire it.
+    await expect(cb.exec(ok)).resolves.toBe('ok');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onClose on reset() of a tripped breaker, but not of a closed one', async () => {
+    const clock = makeClock();
+    const onClose = vi.fn();
+    const cb = createCircuitBreaker({
+      ...baseConfig,
+      failureThreshold: 1,
+      now: clock.now,
+      onClose,
+    });
+
+    cb.reset(); // already closed — no transition
+    expect(onClose).not.toHaveBeenCalled();
+
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    cb.reset();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('pairs onOpen and onClose across a full trip/recover cycle', async () => {
+    const clock = makeClock();
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const cb = createCircuitBreaker({
+      ...baseConfig,
+      failureThreshold: 1,
+      now: clock.now,
+      onOpen,
+      onClose,
+    });
+
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    clock.tick(30_000);
+    await expect(cb.exec(ok)).resolves.toBe('ok');
+    await expect(cb.exec(fail)).rejects.toThrow('boom');
+    clock.tick(30_000);
+    await expect(cb.exec(ok)).resolves.toBe('ok');
+
+    expect(onOpen).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
 });

--- a/library/runtime/src/circuit-breaker.ts
+++ b/library/runtime/src/circuit-breaker.ts
@@ -23,11 +23,15 @@
  *
  * `onOpen` fires once per closed→open transition (not on every rejection
  * while already open), so a counter wired here matches the number of
- * trips, not the blast radius. `reset()` is an operator override that
- * force-closes and clears failure history.
+ * trips, not the blast radius. `onClose` is its mirror — once per
+ * open/half_open→closed transition (a successful half-open probe or an
+ * operator `reset()` of a tripped breaker) — so a paired gauge can be
+ * raised on trip and lowered on recovery without the caller tracking
+ * state itself. `reset()` is an operator override that force-closes and
+ * clears failure history.
  *
  * Zero dependencies. Observability is the caller's concern — wire
- * `onOpen` into whatever metrics surface the consumer has.
+ * `onOpen`/`onClose` into whatever metrics surface the consumer has.
  */
 
 export type CircuitState = 'closed' | 'open' | 'half_open';
@@ -59,6 +63,12 @@ export interface CircuitBreakerConfig {
   now?: () => number;
   /** Emitted once per closed→open transition. */
   onOpen?: (name: string) => void;
+  /**
+   * Emitted once per open/half_open→closed transition: a successful
+   * half-open probe, or `reset()` on a breaker that isn't closed. Never
+   * fired by `reset()` on an already-closed breaker.
+   */
+  onClose?: (name: string) => void;
 }
 
 export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker {
@@ -95,9 +105,11 @@ export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker 
     state: () => state,
 
     reset(): void {
+      const wasClosed = state === 'closed';
       state = 'closed';
       failures = [];
       halfOpenInFlight = false;
+      if (!wasClosed) cfg.onClose?.(cfg.name);
     },
 
     async exec<T>(fn: () => Promise<T>): Promise<T> {
@@ -122,6 +134,7 @@ export function createCircuitBreaker(cfg: CircuitBreakerConfig): CircuitBreaker 
           state = 'closed';
           failures = [];
           halfOpenInFlight = false;
+          cfg.onClose?.(cfg.name);
           return result;
         } catch (err) {
           halfOpenInFlight = false;

--- a/library/runtime/src/logger.test.ts
+++ b/library/runtime/src/logger.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createLogger, errorMessage } from './logger.js';
+
+function captureStreams() {
+  const err: string[] = [];
+  const out: string[] = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+    err.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    out.push(String(chunk));
+    return true;
+  });
+  const parse = (lines: string[]) => lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+  return { err, out, parse };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createLogger', () => {
+  it('writes one JSON line with level, timestamp, and message', () => {
+    const { err, parse } = captureStreams();
+    createLogger().info('started');
+
+    const [entry] = parse(err);
+    expect(entry).toMatchObject({ level: 'info', message: 'started' });
+    expect(typeof entry?.timestamp).toBe('string');
+  });
+
+  it('merges context-first fields into the line', () => {
+    const { err, parse } = captureStreams();
+    createLogger().warn({ incident_id: 'inc-1', attempt: 2 }, 'retrying');
+
+    const [entry] = parse(err);
+    expect(entry).toMatchObject({
+      level: 'warn',
+      message: 'retrying',
+      incident_id: 'inc-1',
+      attempt: 2,
+    });
+  });
+
+  it('filters below the configured level and honors setLevel', () => {
+    const { err } = captureStreams();
+    const log = createLogger({ level: 'warn' });
+    log.info('dropped');
+    log.warn('kept');
+    log.setLevel('debug');
+    log.debug('kept after setLevel');
+
+    expect(err).toHaveLength(2);
+  });
+
+  it('stamps child bindings on every line, and children nest', () => {
+    const { err, parse } = captureStreams();
+    const log = createLogger({ bindings: { service: 'svc' } });
+    const child = log.child({ incident_id: 'inc-9' });
+    child.child({ step: 'assemble' }).info('go');
+
+    const [entry] = parse(err);
+    expect(entry).toMatchObject({ service: 'svc', incident_id: 'inc-9', step: 'assemble' });
+  });
+
+  it('lets per-call context override bindings', () => {
+    const { err, parse } = captureStreams();
+    createLogger({ bindings: { source: 'default' } }).info({ source: 'override' }, 'x');
+
+    const [entry] = parse(err);
+    expect(entry?.source).toBe('override');
+  });
+
+  it('sends everything to stderr by default, keeping stdout clean', () => {
+    const { err, out } = captureStreams();
+    const log = createLogger();
+    log.info('a');
+    log.error('b');
+
+    expect(err).toHaveLength(2);
+    expect(out).toHaveLength(0);
+  });
+
+  it('splits info/debug to stdout and warn/error to stderr in split mode', () => {
+    const { err, out } = captureStreams();
+    const log = createLogger({ level: 'debug', stream: 'split' });
+    log.debug('d');
+    log.info('i');
+    log.warn('w');
+    log.error('e');
+
+    expect(out).toHaveLength(2);
+    expect(err).toHaveLength(2);
+  });
+
+  it('omits trace fields when no OTel span is active', () => {
+    const { err, parse } = captureStreams();
+    createLogger().info('no span');
+
+    const [entry] = parse(err);
+    expect(entry).not.toHaveProperty('trace_id');
+    expect(entry).not.toHaveProperty('span_id');
+  });
+});
+
+describe('errorMessage', () => {
+  it('unwraps Error instances and stringifies everything else', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+    expect(errorMessage('plain')).toBe('plain');
+    expect(errorMessage(42)).toBe('42');
+  });
+});

--- a/library/runtime/src/logger.ts
+++ b/library/runtime/src/logger.ts
@@ -1,0 +1,115 @@
+/**
+ * Structured JSON-lines logger for tenant services.
+ *
+ * One line per call: `{level, timestamp, message, trace_id?, span_id?,
+ * ...bindings, ...context}`. When an OTel span is active, `trace_id` +
+ * `span_id` are stamped automatically so Grafana's Tempo ↔ Loki
+ * correlation jump works one-click; without a span (tests, CLI) the
+ * fields are simply absent.
+ *
+ * Call shape is context-first (pino-style): `log.info({ incident_id },
+ * 'assembled war room')` or bare `log.info('started')`. `child(bindings)`
+ * returns a logger that stamps the bindings on every line — the idiom for
+ * threading a correlation id through a request.
+ *
+ * Stream policy is a config choice, not a hardcode:
+ * - `stderr` (default) — everything to stderr, keeping stdout clean for
+ *   CLI/display output.
+ * - `split` — info/debug to stdout, warn/error to stderr.
+ *
+ * This is deliberately not a pino replacement. Services whose framework
+ * integration is pino-shaped (Fastify's bundled logger,
+ * `@opentelemetry/instrumentation-pino`) should keep pino; this module is
+ * for services that would otherwise hand-roll exactly this file.
+ */
+
+import { trace } from '@opentelemetry/api';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVELS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+export interface LoggerConfig {
+  /** Minimum level. Defaults to `LOG_LEVEL` env when valid, else `info`. */
+  level?: LogLevel;
+  /** Where lines go. Default `stderr`. */
+  stream?: 'stderr' | 'split';
+  /** Fields stamped on every line (service name, static context). */
+  bindings?: Record<string, unknown>;
+}
+
+export interface Logger {
+  debug(context: Record<string, unknown> | string, message?: string): void;
+  info(context: Record<string, unknown> | string, message?: string): void;
+  warn(context: Record<string, unknown> | string, message?: string): void;
+  error(context: Record<string, unknown> | string, message?: string): void;
+  /** A logger stamping `bindings` on every line, sharing this logger's config. */
+  child(bindings: Record<string, unknown>): Logger;
+  /** Raise/lower the minimum level at runtime (affects children too). */
+  setLevel(level: LogLevel): void;
+}
+
+function envLevel(): LogLevel {
+  const level = process.env['LOG_LEVEL'] as LogLevel | undefined;
+  return level && LEVELS[level] !== undefined ? level : 'info';
+}
+
+function traceFields(): { trace_id?: string; span_id?: string } {
+  const span = trace.getActiveSpan();
+  if (!span) return {};
+  const ctx = span.spanContext();
+  if (!ctx.traceId || ctx.traceId === '00000000000000000000000000000000') return {};
+  return { trace_id: ctx.traceId, span_id: ctx.spanId };
+}
+
+export function createLogger(cfg: LoggerConfig = {}): Logger {
+  // Shared, mutable level state: setLevel on any child adjusts the whole
+  // logger tree, matching how a LOG_LEVEL change is expected to behave.
+  const state = { level: cfg.level ?? envLevel() };
+  const stream = cfg.stream ?? 'stderr';
+
+  function write(
+    level: LogLevel,
+    bindings: Record<string, unknown>,
+    context: Record<string, unknown> | string,
+    message?: string,
+  ): void {
+    if (LEVELS[level] < LEVELS[state.level]) return;
+
+    const contextFields = typeof context === 'string' ? {} : context;
+    const entry = {
+      level,
+      timestamp: new Date().toISOString(),
+      message: typeof context === 'string' ? context : (message ?? ''),
+      ...traceFields(),
+      ...bindings,
+      ...contextFields,
+    };
+
+    const line = JSON.stringify(entry) + '\n';
+    if (stream === 'split' && (level === 'debug' || level === 'info')) {
+      process.stdout.write(line);
+    } else {
+      process.stderr.write(line);
+    }
+  }
+
+  function make(bindings: Record<string, unknown>): Logger {
+    return {
+      debug: (context, message) => write('debug', bindings, context, message),
+      info: (context, message) => write('info', bindings, context, message),
+      warn: (context, message) => write('warn', bindings, context, message),
+      error: (context, message) => write('error', bindings, context, message),
+      child: (childBindings) => make({ ...bindings, ...childBindings }),
+      setLevel: (level) => {
+        state.level = level;
+      },
+    };
+  }
+
+  return make(cfg.bindings ?? {});
+}
+
+/** Normalize an unknown thrown value to a string message for log fields. */
+export const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);

--- a/library/runtime/src/metrics.test.ts
+++ b/library/runtime/src/metrics.test.ts
@@ -1,0 +1,152 @@
+import { metrics as otelMetrics } from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createMetrics } from './metrics.js';
+
+/**
+ * A real (in-memory) meter provider so the tests assert the actual series
+ * shape — instrument names are a public contract queried by dashboards and
+ * PrometheusRules, so "it didn't throw" is not enough.
+ */
+let exporter: InMemoryMetricExporter;
+let reader: PeriodicExportingMetricReader;
+let provider: MeterProvider;
+
+beforeEach(() => {
+  exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+  reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 });
+  provider = new MeterProvider({ readers: [reader] });
+  otelMetrics.setGlobalMeterProvider(provider);
+});
+
+afterEach(async () => {
+  await provider.shutdown();
+  otelMetrics.disable();
+});
+
+async function collectedInstruments(): Promise<Map<string, unknown>> {
+  await reader.forceFlush();
+  const byName = new Map<string, unknown>();
+  for (const rm of exporter.getMetrics()) {
+    for (const scope of rm.scopeMetrics) {
+      for (const metric of scope.metrics) {
+        byName.set(metric.descriptor.name, metric);
+      }
+    }
+  }
+  return byName;
+}
+
+const cfg = { meterName: 'test-service', namespace: 'test_service' };
+
+describe('createMetrics', () => {
+  it('namespaces every instrument as <namespace>.<name>', async () => {
+    const m = createMetrics(cfg);
+    m.counter('crawl.failures');
+    m.timing('assembly_duration_ms', 42);
+
+    const instruments = await collectedInstruments();
+    expect([...instruments.keys()].sort()).toEqual([
+      'test_service.assembly_duration_ms',
+      'test_service.crawl.failures',
+    ]);
+  });
+
+  it('accumulates counter values with attributes', async () => {
+    const m = createMetrics(cfg);
+    m.counter('tokens', 10, { kind: 'input' });
+    m.counter('tokens', 5, { kind: 'input' });
+    m.counter('tokens', 7, { kind: 'output' });
+
+    const instruments = await collectedInstruments();
+    const metric = instruments.get('test_service.tokens') as {
+      dataPoints: { attributes: Record<string, string>; value: number }[];
+    };
+    const byKind = Object.fromEntries(metric.dataPoints.map((d) => [d.attributes.kind, d.value]));
+    expect(byKind).toEqual({ input: 15, output: 7 });
+  });
+
+  it('records timings as ms histograms', async () => {
+    const m = createMetrics(cfg);
+    m.timing('latency', 100);
+    m.timing('latency', 300);
+
+    const instruments = await collectedInstruments();
+    const metric = instruments.get('test_service.latency') as {
+      descriptor: { unit: string };
+      dataPoints: { value: { count: number; sum: number } }[];
+    };
+    expect(metric.descriptor.unit).toBe('ms');
+    expect(metric.dataPoints[0]?.value.count).toBe(2);
+    expect(metric.dataPoints[0]?.value.sum).toBe(400);
+  });
+
+  it('applies explicit bucket boundaries to distributions', async () => {
+    const m = createMetrics(cfg);
+    const boundaries = [0, 0.5, 1];
+    m.distribution('change_score', 0.3, undefined, { boundaries });
+    m.distribution('change_score', 0.9, undefined, { boundaries });
+
+    const instruments = await collectedInstruments();
+    const metric = instruments.get('test_service.change_score') as {
+      descriptor: { unit: string };
+      dataPoints: { value: { buckets: { boundaries: number[]; counts: number[] } } }[];
+    };
+    expect(metric.descriptor.unit).toBe('1');
+    expect(metric.dataPoints[0]?.value.buckets.boundaries).toEqual(boundaries);
+    // Buckets: (-inf,0], (0,0.5], (0.5,1], (1,+inf) — 0.3 and 0.9 land in the middle two.
+    expect(metric.dataPoints[0]?.value.buckets.counts).toEqual([0, 1, 1, 0]);
+  });
+
+  it('carries unit and description through instrument options', async () => {
+    const m = createMetrics(cfg);
+    m.counter('email.sent', 1, undefined, { unit: 'emails', description: 'Newsletter sends' });
+
+    const instruments = await collectedInstruments();
+    const metric = instruments.get('test_service.email.sent') as {
+      descriptor: { unit: string; description: string };
+    };
+    expect(metric.descriptor.unit).toBe('emails');
+    expect(metric.descriptor.description).toBe('Newsletter sends');
+  });
+
+  it('observes the latest value per attribute set on an observable gauge', async () => {
+    const m = createMetrics(cfg);
+    m.setObservable('circuit_breaker.open', 1, { target: 'slack' });
+    m.setObservable('circuit_breaker.open', 1, { target: 'linear' });
+    m.setObservable('circuit_breaker.open', 0, { target: 'slack' });
+
+    const instruments = await collectedInstruments();
+    const metric = instruments.get('test_service.circuit_breaker.open') as {
+      dataPoints: { attributes: Record<string, string>; value: number }[];
+    };
+    const byTarget = Object.fromEntries(
+      metric.dataPoints.map((d) => [d.attributes.target, d.value]),
+    );
+    expect(byTarget).toEqual({ slack: 0, linear: 1 });
+  });
+
+  it('caches instruments per name', () => {
+    const m = createMetrics(cfg);
+    expect(m.counterInstrument('hits')).toBe(m.counterInstrument('hits'));
+    expect(m.histogramInstrument('latency')).toBe(m.histogramInstrument('latency'));
+  });
+
+  it('degrades to a no-op without a registered meter provider', async () => {
+    await provider.shutdown();
+    otelMetrics.disable();
+    const m = createMetrics(cfg);
+    expect(() => {
+      m.counter('anything');
+      m.timing('anything', 1);
+      m.distribution('anything', 0.5);
+      m.setObservable('anything', 1);
+    }).not.toThrow();
+  });
+});

--- a/library/runtime/src/metrics.ts
+++ b/library/runtime/src/metrics.ts
@@ -1,0 +1,152 @@
+/**
+ * OTel metrics surface for tenant services.
+ *
+ * Every consumer needs the same core: instruments created lazily (so the
+ * meter provider — installed by the auto-instrumentations preload — has a
+ * chance to register first), cached per name, and self-prefixed with the
+ * service namespace so the Prometheus series are deterministic. An
+ * instrument named `crawl.failures` under namespace
+ * `competitive_intelligence` arrives in AMP/Mimir as
+ * `competitive_intelligence_crawl_failures_total` purely from the
+ * instrument name (OTLP→Prometheus lowercases dots/dashes to underscores
+ * and adds the type suffix), with no collector-side namespace rewrite.
+ *
+ * `createMetrics` returns that core once; apps keep their own thin,
+ * named-wrapper modules over it. Instrument names are a public contract —
+ * dashboards and PrometheusRules query the resulting series — so wrappers
+ * must preserve their existing names when adopting this module.
+ *
+ * When no meter provider is registered (tests, CI, `OTEL_SDK_DISABLED`),
+ * the OTel API degrades to a no-op. Nothing here throws without a
+ * backend, so call sites stay unconditional.
+ */
+
+import {
+  metrics as otelMetrics,
+  type Attributes,
+  type Counter,
+  type Histogram,
+  type ObservableGauge,
+  type ObservableResult,
+} from '@opentelemetry/api';
+
+export interface InstrumentOptions {
+  /** OTel unit string (`ms`, `tokens`, `1`, …). Applied on first creation. */
+  unit?: string;
+  /** Human description shown by metric browsers. Applied on first creation. */
+  description?: string;
+  /**
+   * Explicit histogram bucket edges. Required for 0–1 ratios, which
+   * otherwise inherit OTel's default ms-scale buckets ([0,5,…]) and
+   * collapse every value into the first bucket. Applied on first creation.
+   */
+  boundaries?: number[];
+}
+
+export interface Metrics {
+  /** Add to a monotonic counter. */
+  counter(name: string, value?: number, attributes?: Attributes, opts?: InstrumentOptions): void;
+  /** Record a duration in milliseconds (histogram, unit `ms`). */
+  timing(name: string, ms: number, attributes?: Attributes): void;
+  /** Record a unitless value into a histogram (unit `1` unless overridden). */
+  distribution(
+    name: string,
+    value: number,
+    attributes?: Attributes,
+    opts?: InstrumentOptions,
+  ): void;
+  /**
+   * Set the current value of an observable gauge for one attribute set.
+   * The gauge reports every recorded attribute set on each scrape — the
+   * shape breaker-state (1/0 by `target`) and similar current-state
+   * signals need.
+   */
+  setObservable(name: string, value: number, attributes?: Attributes): void;
+  /** The cached raw counter instrument, for call sites that record directly. */
+  counterInstrument(name: string, opts?: InstrumentOptions): Counter;
+  /** The cached raw histogram instrument, for call sites that record directly. */
+  histogramInstrument(name: string, opts?: InstrumentOptions): Histogram;
+}
+
+export interface MetricsConfig {
+  /** OTel meter name — conventionally the service handle (`incident-response`). */
+  meterName: string;
+  /**
+   * Series prefix, prepended as `<namespace>.<name>` on every instrument
+   * (`incident_response`). Underscored form of the service handle.
+   */
+  namespace: string;
+}
+
+export function createMetrics(cfg: MetricsConfig): Metrics {
+  const qualify = (name: string): string => `${cfg.namespace}.${name}`;
+  const meter = () => otelMetrics.getMeter(cfg.meterName);
+
+  const counters = new Map<string, Counter>();
+  const histograms = new Map<string, Histogram>();
+  const observables = new Map<string, Map<string, { value: number; attributes: Attributes }>>();
+  const observableGauges = new Map<string, ObservableGauge>();
+
+  function counterInstrument(name: string, opts?: InstrumentOptions): Counter {
+    let c = counters.get(name);
+    if (!c) {
+      c = meter().createCounter(qualify(name), {
+        ...(opts?.unit !== undefined && { unit: opts.unit }),
+        ...(opts?.description !== undefined && { description: opts.description }),
+      });
+      counters.set(name, c);
+    }
+    return c;
+  }
+
+  function histogramInstrument(name: string, opts?: InstrumentOptions): Histogram {
+    let h = histograms.get(name);
+    if (!h) {
+      h = meter().createHistogram(qualify(name), {
+        ...(opts?.unit !== undefined && { unit: opts.unit }),
+        ...(opts?.description !== undefined && { description: opts.description }),
+        ...(opts?.boundaries !== undefined && {
+          advice: { explicitBucketBoundaries: opts.boundaries },
+        }),
+      });
+      histograms.set(name, h);
+    }
+    return h;
+  }
+
+  return {
+    counter(name, value = 1, attributes, opts): void {
+      counterInstrument(name, opts).add(value, attributes);
+    },
+
+    timing(name, ms, attributes): void {
+      histogramInstrument(name, { unit: 'ms' }).record(ms, attributes);
+    },
+
+    distribution(name, value, attributes, opts): void {
+      histogramInstrument(name, { unit: '1', ...opts }).record(value, attributes);
+    },
+
+    setObservable(name, value, attributes = {}): void {
+      let entries = observables.get(name);
+      if (!entries) {
+        entries = new Map();
+        observables.set(name, entries);
+      }
+      entries.set(JSON.stringify(attributes), { value, attributes });
+
+      if (!observableGauges.has(name)) {
+        const gauge = meter().createObservableGauge(qualify(name));
+        gauge.addCallback((result: ObservableResult) => {
+          for (const { value: v, attributes: attrs } of observables.get(name)?.values() ?? []) {
+            result.observe(v, attrs);
+          }
+        });
+        observableGauges.set(name, gauge);
+      }
+    },
+
+    counterInstrument,
+    histogramInstrument,
+  };
+}

--- a/library/runtime/tsconfig.json
+++ b/library/runtime/tsconfig.json
@@ -8,7 +8,8 @@
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanohype",
   "private": true,
-  "description": "Template catalog for AI-focused projects — MCP servers, agentic loops, RAG pipelines, and more",
+  "description": "Template catalog for AI-focused projects \u2014 MCP servers, agentic loops, RAG pipelines, and more",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -49,5 +49,6 @@
       "js-yaml": "^4.2.0",
       "markdown-it": "^14.2.0"
     }
-  }
+  },
+  "prettier": "./library/config/prettierrc.json"
 }


### PR DESCRIPTION
## Why

The four tenant apps each hand-roll a metrics module, a logger, and breaker instrumentation. Same jobs, four drifting copies — the per-repo-copies failure mode the one-foundation doctrine names. The shared cores move into `@nanohype/runtime`, the vendorable source of truth the tenants already sync from.

## What

- **`metrics.ts`** — `createMetrics({meterName, namespace})`: lazy, cached, namespace-qualified OTel instruments. Covers all four tenants' call shapes (counter/timing/distribution with explicit boundaries/keyed observable gauge + raw instrument accessors). Tests assert real exported series through an in-memory meter provider, since instrument names are a dashboard-queried contract.
- **`logger.ts`** — `createLogger`: context-first JSON-lines logger with OTel trace correlation, `child()` bindings, runtime `setLevel`, stderr-only or split stream policy. Explicitly not a pino replacement — pino-integrated services (Fastify, instrumentation-pino) keep pino.
- **`circuit-breaker.ts`** — `onClose` hook, the mirror of `onOpen` (once per open/half_open→closed transition), so open/closed gauges become declarative.
- **`library/config/prettierrc.json`** — canonical prettier config for vendor-sync into consumers; the repo's own root config now resolves to it via the package.json `prettier` field.

Peer note: the observability modules import `@opentelemetry/api` (declared as peer; every tenant carries it by the platform observability contract) — the package description drops the "zero-dependency" absolute accordingly.

## Adoption

Tenant PRs follow: each re-vendors via its existing sync script, keeps its app-specific surface (named wrappers / `MetricsEmitter` class / direct instrument exports) as a thin layer over the shared core with instrument names byte-identical, and aligns prettier to the canonical file.

## Validation

Library suite green (typecheck + 100 tests incl. the new modules and onClose transitions); repo `format:check` green with the canonical config resolving.