### PR TITLE
Template skeletons: coverage floors + fake-clock TTL tests

### DIFF
--- a/templates/a2a-agent/skeleton/package.json
+++ b/templates/a2a-agent/skeleton/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/a2a-agent/skeleton/vitest.config.ts
+++ b/templates/a2a-agent/skeleton/vitest.config.ts
@@ -3,5 +3,36 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the protocol server, transport/skill registries, the example
+      // skill, and the circuit breaker. Live transports (http/websocket), the
+      // protocol client, discovery, SDK providers, and wiring (agent, bootstrap,
+      // logger, barrels, type-only modules) are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/agent.ts",
+        "src/bootstrap.ts",
+        "src/logger.ts",
+        "src/discovery/**",
+        "src/protocol/client.ts",
+        "src/protocol/transport/http.ts",
+        "src/protocol/transport/websocket.ts",
+        "src/providers/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 78,
+      },
+    },
   },
 });

--- a/templates/agent-orchestrator/skeleton/package.json
+++ b/templates/agent-orchestrator/skeleton/package.json
@@ -18,7 +18,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/agent-orchestrator/skeleton/vitest.config.ts
+++ b/templates/agent-orchestrator/skeleton/vitest.config.ts
@@ -3,5 +3,34 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the orchestrator core, agents, context, routing, the mock
+      // provider, and the circuit breaker. SDK-backed providers
+      // (anthropic/openai) and wiring (bootstrap, config, logger, metrics,
+      // barrels, type-only modules) are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/orchestrator/bootstrap.ts",
+        "src/orchestrator/config.ts",
+        "src/orchestrator/logger.ts",
+        "src/orchestrator/metrics.ts",
+        "src/orchestrator/providers/anthropic.ts",
+        "src/orchestrator/providers/openai.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 73,
+        functions: 85,
+        statements: 73,
+        branches: 79,
+      },
+    },
   },
 });

--- a/templates/agentic-loop/skeleton/package.json
+++ b/templates/agentic-loop/skeleton/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/agentic-loop/skeleton/vitest.config.ts
+++ b/templates/agentic-loop/skeleton/vitest.config.ts
@@ -3,5 +3,38 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the tool/provider registries, the example tool, and the circuit
+      // breaker. The agent loop, memory, eval, and token helpers plus SDK
+      // providers and wiring are exercised end-to-end, not unit-covered —
+      // ratchet them in as unit suites land.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/agent.ts",
+        "src/bootstrap.ts",
+        "src/logger.ts",
+        "src/metrics.ts",
+        "src/tokens.ts",
+        "src/eval/**",
+        "src/memory/**",
+        "src/providers/anthropic.ts",
+        "src/providers/openai.ts",
+        "src/providers/mock.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/chrome-ext/skeleton/package.json
+++ b/templates/chrome-ext/skeleton/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -25,6 +26,7 @@
     "@types/chrome": "^0.0.287",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "typescript": "^5.8.0",

--- a/templates/chrome-ext/skeleton/vitest.config.ts
+++ b/templates/chrome-ext/skeleton/vitest.config.ts
@@ -5,5 +5,38 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the provider registry — the only pure in-process logic. Everything
+      // else needs a browser runtime (background/content/UI, chrome-API-backed
+      // messaging/storage) or a live SDK.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/background/**",
+        "src/content/**",
+        "src/options/**",
+        "src/sidepanel/**",
+        "src/lib/ai.ts",
+        "src/lib/logger.ts",
+        "src/lib/messaging.ts",
+        "src/lib/storage.ts",
+        "src/lib/providers/anthropic.ts",
+        "src/lib/providers/openai.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/ci-eval/skeleton/package.json
+++ b/templates/ci-eval/skeleton/package.json
@@ -13,12 +13,13 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
-    "openai": "^4.85.0",
     "js-yaml": "^4.1.0",
+    "openai": "^4.85.0",
     "yaml": "^2.7.0",
     "zod": "^3.24.0"
   },
@@ -26,6 +27,7 @@
     "@eslint/js": "^9.17.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.17.0",
     "prettier": "^3.4.0",
     "tsx": "^4.19.0",

--- a/templates/ci-eval/skeleton/vitest.config.ts
+++ b/templates/ci-eval/skeleton/vitest.config.ts
@@ -4,5 +4,32 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the baseline store, reporter, runner, assertions, and provider
+      // registry. SDK providers and wiring (bootstrap, config, logger, barrels,
+      // type-only modules) are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/ci-eval/bootstrap.ts",
+        "src/ci-eval/config.ts",
+        "src/ci-eval/logger.ts",
+        "src/ci-eval/providers/anthropic.ts",
+        "src/ci-eval/providers/openai.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 55,
+        functions: 72,
+        statements: 55,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/discord-bot/skeleton/package.json
+++ b/templates/discord-bot/skeleton/package.json
@@ -13,18 +13,20 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "discord.js": "^14.16.0",
     "@anthropic-ai/sdk": "^0.91.1",
+    "discord.js": "^14.16.0",
+    "dotenv": "^16.4.0",
     "openai": "^4.85.0",
-    "zod": "^3.24.0",
-    "dotenv": "^16.4.0"
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/discord-bot/skeleton/vitest.config.ts
+++ b/templates/discord-bot/skeleton/vitest.config.ts
@@ -5,5 +5,35 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the provider registry and circuit breaker. Discord handlers
+      // (commands/events), SDK providers, and wiring are exercised against the
+      // live SDK, not unit-covered.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/config.ts",
+        "src/logger.ts",
+        "src/commands/**",
+        "src/events/**",
+        "src/providers/anthropic.ts",
+        "src/providers/openai.ts",
+        "src/providers/mock.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 83,
+        statements: 85,
+        branches: 78,
+      },
+    },
   },
 });

--- a/templates/electron-app/skeleton/package.json
+++ b/templates/electron-app/skeleton/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -29,6 +30,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "concurrently": "^9.1.0",
     "electron": "^42.0.0",
     "esbuild": "^0.24.0",

--- a/templates/electron-app/skeleton/vitest.config.ts
+++ b/templates/electron-app/skeleton/vitest.config.ts
@@ -11,5 +11,34 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.{test,spec}.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the provider registry — the only pure in-process logic.
+      // Main-process wiring (ipc, preload, config), the renderer UI, and SDK
+      // providers need Electron or live SDKs.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/main/bootstrap.ts",
+        "src/main/config.ts",
+        "src/main/ipc-handlers.ts",
+        "src/main/preload.ts",
+        "src/main/providers/anthropic.ts",
+        "src/main/providers/openai.ts",
+        "src/renderer/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/eval-harness/skeleton/package.json
+++ b/templates/eval-harness/skeleton/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.17.0",
     "prettier": "^3.4.0",
     "tsx": "^4.19.0",

--- a/templates/eval-harness/skeleton/vitest.config.ts
+++ b/templates/eval-harness/skeleton/vitest.config.ts
@@ -4,5 +4,32 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the assertion library, case helpers, and suite builder. The
+      // runner, providers, reporters, and resilience layer are exercised
+      // end-to-end against live providers.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/runner.ts",
+        "src/providers/**",
+        "src/reporters/**",
+        "src/resilience/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 72,
+        functions: 69,
+        statements: 72,
+        branches: 77,
+      },
+    },
   },
 });

--- a/templates/fine-tune-pipeline/skeleton/package.json
+++ b/templates/fine-tune-pipeline/skeleton/package.json
@@ -12,16 +12,18 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "dotenv": "^16.4.0",
     "openai": "^4.85.0",
-    "zod": "^3.24.0",
-    "dotenv": "^16.4.0"
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.17.0",
     "prettier": "^3.4.0",
     "tsx": "^4.19.0",

--- a/templates/fine-tune-pipeline/skeleton/vitest.config.ts
+++ b/templates/fine-tune-pipeline/skeleton/vitest.config.ts
@@ -4,5 +4,34 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the dataset split/validate logic. IO-bound prepare, eval
+      // comparison, SDK-backed training, the resilience layer, and wiring are
+      // integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/config.ts",
+        "src/logger.ts",
+        "src/dataset/prepare.ts",
+        "src/eval/**",
+        "src/training/**",
+        "src/resilience/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/guardrails/skeleton/package.json
+++ b/templates/guardrails/skeleton/package.json
@@ -23,11 +23,13 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "typescript": "^5.8.0",

--- a/templates/guardrails/skeleton/vitest.config.ts
+++ b/templates/guardrails/skeleton/vitest.config.ts
@@ -3,5 +3,28 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the filter pipeline and the filters themselves. Wiring (bootstrap,
+      // logger, barrels, type-only modules) carries no logic to gate.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/logger.ts",
+        "src/guardrails/bootstrap.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 80,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/llm-wiki/skeleton/package.json
+++ b/templates/llm-wiki/skeleton/package.json
@@ -21,7 +21,8 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "cli": "tsx src/cli/index.ts"
+    "cli": "tsx src/cli/index.ts",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/llm-wiki/skeleton/vitest.config.ts
+++ b/templates/llm-wiki/skeleton/vitest.config.ts
@@ -3,5 +3,39 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate operations, schema parsing, wiki search/link-graph/page logic,
+      // the registries, and the circuit breaker. The HTTP API, CLI, IO-backed
+      // sources/storage (local/git), SDK providers, mocks, and the index
+      // manager are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/config.ts",
+        "src/api/**",
+        "src/cli/**",
+        "src/llm/anthropic.ts",
+        "src/llm/mock.ts",
+        "src/sources/local.ts",
+        "src/sources/mock.ts",
+        "src/storage/git.ts",
+        "src/storage/mock.ts",
+        "src/tenant/auth.ts",
+        "src/wiki/index-manager.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 73,
+      },
+    },
   },
 });

--- a/templates/mcp-server-ts/skeleton/package.json
+++ b/templates/mcp-server-ts/skeleton/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
@@ -24,6 +25,7 @@
     "@eslint/js": "^9.20.0",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/mcp-server-ts/skeleton/vitest.config.ts
+++ b/templates/mcp-server-ts/skeleton/vitest.config.ts
@@ -5,5 +5,30 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the server assembly and the example tool/resource handlers.
+      // Transports (stdio/streamable-http) and wiring are exercised by MCP
+      // clients, not unit coverage.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/logger.ts",
+        "src/transports/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 69,
+        functions: 85,
+        statements: 69,
+        branches: 83,
+      },
+    },
   },
 });

--- a/templates/module-analytics-ts/skeleton/package.json
+++ b/templates/module-analytics-ts/skeleton/package.json
@@ -20,7 +20,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-analytics-ts/skeleton/vitest.config.ts
+++ b/templates/module-analytics-ts/skeleton/vitest.config.ts
@@ -3,5 +3,35 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the event buffer, middleware, mock provider, registry, and circuit
+      // breaker. SDK-backed providers (amplitude/mixpanel/posthog/segment) and
+      // wiring are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/analytics/bootstrap.ts",
+        "src/analytics/config.ts",
+        "src/analytics/logger.ts",
+        "src/analytics/metrics.ts",
+        "src/analytics/providers/amplitude.ts",
+        "src/analytics/providers/mixpanel.ts",
+        "src/analytics/providers/posthog.ts",
+        "src/analytics/providers/segment.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 80,
+      },
+    },
   },
 });

--- a/templates/module-auth-ts/skeleton/package.json
+++ b/templates/module-auth-ts/skeleton/package.json
@@ -27,17 +27,19 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "jose": "^6.0.0",
     "@clerk/backend": "^1.0.0",
+    "@supabase/supabase-js": "^2.0.0",
     "auth0": "^4.0.0",
-    "@supabase/supabase-js": "^2.0.0"
+    "jose": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "typescript": "^5.8.0",

--- a/templates/module-auth-ts/skeleton/vitest.config.ts
+++ b/templates/module-auth-ts/skeleton/vitest.config.ts
@@ -3,5 +3,34 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the guards, JWT provider, registry, and circuit breaker.
+      // SDK-backed providers (auth0/clerk/supabase), the apikey/mock providers,
+      // and framework middleware are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/auth/bootstrap.ts",
+        "src/auth/middleware.ts",
+        "src/auth/providers/apikey.ts",
+        "src/auth/providers/auth0.ts",
+        "src/auth/providers/clerk.ts",
+        "src/auth/providers/supabase.ts",
+        "src/auth/providers/mock.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 72,
+        functions: 82,
+        statements: 72,
+        branches: 75,
+      },
+    },
   },
 });

--- a/templates/module-billing-ts/skeleton/package.json
+++ b/templates/module-billing-ts/skeleton/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-billing-ts/skeleton/vitest.config.ts
+++ b/templates/module-billing-ts/skeleton/vitest.config.ts
@@ -3,5 +3,33 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate invoicing, metering, the webhook handler, registry, and circuit
+      // breaker. The Stripe provider, the mock, and wiring are
+      // integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/billing/bootstrap.ts",
+        "src/billing/config.ts",
+        "src/billing/logger.ts",
+        "src/billing/metrics.ts",
+        "src/billing/providers/stripe.ts",
+        "src/billing/providers/mock.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 76,
+      },
+    },
   },
 });

--- a/templates/module-cache-ts/skeleton/package.json
+++ b/templates/module-cache-ts/skeleton/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-cache-ts/skeleton/vitest.config.ts
+++ b/templates/module-cache-ts/skeleton/vitest.config.ts
@@ -3,5 +3,31 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the memory provider and registry. Redis/memcached providers talk
+      // to live stores; wiring and type-only modules carry no logic to gate.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/cache/bootstrap.ts",
+        "src/cache/metrics.ts",
+        "src/cache/providers/memcached.ts",
+        "src/cache/providers/redis.ts",
+        "src/types/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/module-database-ts/skeleton/package.json
+++ b/templates/module-database-ts/skeleton/package.json
@@ -23,20 +23,22 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "drizzle-orm": "^0.45.2",
-    "pg": "^8.13.0",
-    "better-sqlite3": "^11.0.0",
     "@libsql/client": "^0.15.0",
-    "dotenv": "^16.4.0"
+    "better-sqlite3": "^11.0.0",
+    "dotenv": "^16.4.0",
+    "drizzle-orm": "^0.45.2",
+    "pg": "^8.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "drizzle-kit": "^0.30.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",

--- a/templates/module-database-ts/skeleton/vitest.config.ts
+++ b/templates/module-database-ts/skeleton/vitest.config.ts
@@ -3,5 +3,33 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the client facade and driver registry. Live-database drivers
+      // (postgres/sqlite/turso), migrations, the schema, and wiring are
+      // integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/db/bootstrap.ts",
+        "src/db/migrate.ts",
+        "src/db/schema.ts",
+        "src/db/drivers/postgres.ts",
+        "src/db/drivers/sqlite.ts",
+        "src/db/drivers/turso.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 64,
+      },
+    },
   },
 });

--- a/templates/module-feature-flags-ts/skeleton/package.json
+++ b/templates/module-feature-flags-ts/skeleton/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-feature-flags-ts/skeleton/vitest.config.ts
+++ b/templates/module-feature-flags-ts/skeleton/vitest.config.ts
@@ -3,5 +3,35 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the evaluator, tracker, store registry, and circuit breaker. The
+      // stores (memory/json-file/redis/mock) and wiring are
+      // integration-exercised — ratchet them in as unit suites land.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/feature-flags/bootstrap.ts",
+        "src/feature-flags/config.ts",
+        "src/feature-flags/logger.ts",
+        "src/feature-flags/metrics.ts",
+        "src/feature-flags/stores/json-file.ts",
+        "src/feature-flags/stores/memory.ts",
+        "src/feature-flags/stores/mock.ts",
+        "src/feature-flags/stores/redis.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 75,
+      },
+    },
   },
 });

--- a/templates/module-knowledge-base-ts/skeleton/package.json
+++ b/templates/module-knowledge-base-ts/skeleton/package.json
@@ -27,7 +27,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "typescript": "^5.8.0",

--- a/templates/module-knowledge-base-ts/skeleton/vitest.config.ts
+++ b/templates/module-knowledge-base-ts/skeleton/vitest.config.ts
@@ -3,5 +3,35 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the ingest adapter, mock provider, registry, and circuit breaker.
+      // SDK-backed providers (notion/confluence/coda/google-docs) and wiring
+      // are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/knowledge-base/bootstrap.ts",
+        "src/knowledge-base/config.ts",
+        "src/knowledge-base/logger.ts",
+        "src/knowledge-base/metrics.ts",
+        "src/knowledge-base/providers/coda.ts",
+        "src/knowledge-base/providers/confluence.ts",
+        "src/knowledge-base/providers/google-docs.ts",
+        "src/knowledge-base/providers/notion.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 76,
+      },
+    },
   },
 });

--- a/templates/module-llm-gateway/skeleton/src/gateway/__tests__/caching.test.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/__tests__/caching.test.ts
@@ -44,8 +44,9 @@ describe("hash caching strategy", () => {
   });
 
   it("expires entries after TTL", async () => {
-    const { getCachingStrategy } = await import("../caching/registry.js");
-    const strategy = getCachingStrategy("hash");
+    const { createHashStrategy } = await import("../caching/hash.js");
+    let clock = 0;
+    const strategy = createHashStrategy({ now: () => clock });
 
     const shortTtlContext = { ...defaultContext, ttl: 50 };
     await strategy.set("expire-key", mockResponse, shortTtlContext);
@@ -53,8 +54,8 @@ describe("hash caching strategy", () => {
     // Should exist immediately
     expect(await strategy.get("expire-key", shortTtlContext)).toBeDefined();
 
-    // Wait for TTL to pass
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    // Tick the injected clock past the TTL — no real waiting
+    clock = 60;
 
     // Should be expired
     expect(await strategy.get("expire-key", shortTtlContext)).toBeUndefined();
@@ -74,20 +75,20 @@ describe("hash caching strategy", () => {
 
 describe("sliding-ttl caching strategy", () => {
   it("extends TTL on cache hit", async () => {
-    const { getCachingStrategy } = await import("../caching/registry.js");
-    await import("../caching/sliding-ttl.js");
-    const strategy = getCachingStrategy("sliding-ttl");
+    const { createSlidingTtlStrategy } = await import("../caching/sliding-ttl.js");
+    let clock = 0;
+    const strategy = createSlidingTtlStrategy({ now: () => clock });
 
     const context = { ...defaultContext, ttl: 100 };
     await strategy.set("sliding-key", mockResponse, context);
 
-    // Hit the cache repeatedly to extend TTL
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    // Hit the cache at 60ms to extend the TTL
+    clock = 60;
     const result1 = await strategy.get("sliding-key", context);
     expect(result1).toBeDefined();
 
     // Another 60ms — would have expired without sliding, but TTL was extended
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    clock = 120;
     const result2 = await strategy.get("sliding-key", context);
     expect(result2).toBeDefined();
   });

--- a/templates/module-llm-gateway/skeleton/src/gateway/caching/hash.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/caching/hash.ts
@@ -1,5 +1,10 @@
 import type { GatewayResponse } from "../types.js";
-import type { CachingStrategy, CacheContext, CachedResponse } from "./types.js";
+import type {
+  CachingStrategy,
+  CachingStrategyOptions,
+  CacheContext,
+  CachedResponse,
+} from "./types.js";
 import { registerCachingStrategy } from "./registry.js";
 
 // Re-export so existing imports from "./hash.js" keep working
@@ -22,7 +27,8 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-export function createHashStrategy(): CachingStrategy {
+export function createHashStrategy(options: CachingStrategyOptions = {}): CachingStrategy {
+  const now = options.now ?? Date.now;
   const store = new Map<string, CacheEntry>();
 
   return {
@@ -32,7 +38,7 @@ export function createHashStrategy(): CachingStrategy {
       const entry = store.get(key);
       if (!entry) return undefined;
 
-      if (Date.now() >= entry.expiresAt) {
+      if (now() >= entry.expiresAt) {
         store.delete(key);
         return undefined;
       }
@@ -44,12 +50,12 @@ export function createHashStrategy(): CachingStrategy {
       const ttl = context.ttl ?? DEFAULT_TTL_MS;
       const cached: CachedResponse = {
         response: { ...response, cached: true },
-        cachedAt: new Date().toISOString(),
+        cachedAt: new Date(now()).toISOString(),
       };
       // Re-inserting moves the key to the end of the insertion order, so a
       // refreshed entry isn't treated as the oldest on the next eviction.
       store.delete(key);
-      store.set(key, { cached, expiresAt: Date.now() + ttl });
+      store.set(key, { cached, expiresAt: now() + ttl });
 
       // Bound the store: evict the oldest-inserted entry once over the cap.
       while (store.size > MAX_ENTRIES) {

--- a/templates/module-llm-gateway/skeleton/src/gateway/caching/sliding-ttl.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/caching/sliding-ttl.ts
@@ -1,5 +1,10 @@
 import type { GatewayResponse } from "../types.js";
-import type { CachingStrategy, CacheContext, CachedResponse } from "./types.js";
+import type {
+  CachingStrategy,
+  CachingStrategyOptions,
+  CacheContext,
+  CachedResponse,
+} from "./types.js";
 import { registerCachingStrategy } from "./registry.js";
 
 // Re-export so existing imports from "./sliding-ttl.js" keep working
@@ -24,7 +29,8 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-export function createSlidingTtlStrategy(): CachingStrategy {
+export function createSlidingTtlStrategy(options: CachingStrategyOptions = {}): CachingStrategy {
+  const now = options.now ?? Date.now;
   const store = new Map<string, CacheEntry>();
 
   return {
@@ -34,13 +40,13 @@ export function createSlidingTtlStrategy(): CachingStrategy {
       const entry = store.get(key);
       if (!entry) return undefined;
 
-      if (Date.now() >= entry.expiresAt) {
+      if (now() >= entry.expiresAt) {
         store.delete(key);
         return undefined;
       }
 
       // Extend TTL on hit and mark as most-recently used by re-inserting.
-      entry.expiresAt = Date.now() + entry.ttlMs;
+      entry.expiresAt = now() + entry.ttlMs;
       store.delete(key);
       store.set(key, entry);
       return entry.cached;
@@ -50,10 +56,10 @@ export function createSlidingTtlStrategy(): CachingStrategy {
       const ttl = context.ttl ?? DEFAULT_TTL_MS;
       const cached: CachedResponse = {
         response: { ...response, cached: true },
-        cachedAt: new Date().toISOString(),
+        cachedAt: new Date(now()).toISOString(),
       };
       store.delete(key);
-      store.set(key, { cached, ttlMs: ttl, expiresAt: Date.now() + ttl });
+      store.set(key, { cached, ttlMs: ttl, expiresAt: now() + ttl });
 
       // Bound the store: evict the least-recently-used entry over the cap.
       while (store.size > MAX_ENTRIES) {

--- a/templates/module-llm-gateway/skeleton/src/gateway/caching/types.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/caching/types.ts
@@ -30,6 +30,12 @@ export interface CachedResponse {
   cachedAt: string;
 }
 
+/** Construction options shared by the built-in caching strategies. */
+export interface CachingStrategyOptions {
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
 export interface CachingStrategy {
   /** Unique strategy name (e.g. "hash", "sliding-ttl", "none"). */
   readonly name: string;

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
@@ -37,15 +37,18 @@ describe("LLM tracer", () => {
   });
 
   it("records duration accurately", async () => {
-    const tracer = createLlmTracer({ serviceName: "test-service" });
+    let clock = 1_000;
+    const tracer = createLlmTracer({
+      serviceName: "test-service",
+      now: () => clock,
+    });
 
     const { span } = await tracer.trace(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      clock += 50; // the traced call advances the injected clock by 50ms
       return makeResponse();
     });
 
-    expect(span.durationMs).toBeGreaterThanOrEqual(40);
-    expect(span.durationMs).toBeLessThan(200);
+    expect(span.durationMs).toBe(50);
   });
 
   it("throws a TracedError carrying the error span — never a fake response", async () => {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/tracer/index.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/tracer/index.ts
@@ -34,6 +34,7 @@ export class TracedError extends Error {
  */
 export function createLlmTracer(options: TracerOptions) {
   const defaultTags = options.defaultTags ?? {};
+  const now = options.now ?? Date.now;
 
   /**
    * Trace an async function that returns an LlmResponse.
@@ -49,12 +50,12 @@ export function createLlmTracer(options: TracerOptions) {
     tags: Record<string, string> = {},
   ): Promise<{ response: LlmResponse; span: LlmSpan }> {
     const id = randomUUID();
-    const startedAt = new Date();
+    const startedAt = new Date(now());
     const mergedTags = { ...defaultTags, ...tags };
 
     try {
       const response = await fn();
-      const endedAt = new Date();
+      const endedAt = new Date(now());
       const durationMs = endedAt.getTime() - startedAt.getTime();
 
       const span: LlmSpan = {
@@ -73,7 +74,7 @@ export function createLlmTracer(options: TracerOptions) {
 
       return { response, span };
     } catch (error) {
-      const endedAt = new Date();
+      const endedAt = new Date(now());
       const durationMs = endedAt.getTime() - startedAt.getTime();
 
       const span: LlmSpan = {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/tracer/types.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/tracer/types.ts
@@ -8,6 +8,8 @@ export interface TracerOptions {
   defaultTags?: Record<string, string>;
   /** Whether to record cost on each span. Default: true. */
   recordCost?: boolean;
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
 }
 
 /** Context captured during a traced LLM call. */

--- a/templates/module-media-ts/skeleton/package.json
+++ b/templates/module-media-ts/skeleton/package.json
@@ -19,7 +19,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-media-ts/skeleton/vitest.config.ts
+++ b/templates/module-media-ts/skeleton/vitest.config.ts
@@ -3,5 +3,34 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the transform builder/presets, mock provider, registry, and
+      // circuit breaker. SDK-backed providers (cloudinary/imgix/uploadcare) and
+      // wiring are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/media/bootstrap.ts",
+        "src/media/config.ts",
+        "src/media/logger.ts",
+        "src/media/metrics.ts",
+        "src/media/providers/cloudinary.ts",
+        "src/media/providers/imgix.ts",
+        "src/media/providers/uploadcare.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/module-notifications-ts/skeleton/package.json
+++ b/templates/module-notifications-ts/skeleton/package.json
@@ -17,11 +17,12 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "resend": "^4.0.0",
     "@sendgrid/mail": "^8.1.0",
+    "resend": "^4.0.0",
     "twilio": "^5.0.0",
     "web-push": "^3.6.0",
     "zod": "^3.24.0"
@@ -30,6 +31,7 @@
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
     "@types/web-push": "^3.6.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-notifications-ts/skeleton/vitest.config.ts
+++ b/templates/module-notifications-ts/skeleton/vitest.config.ts
@@ -3,5 +3,31 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the template renderer, channel registry, and circuit breaker.
+      // SDK-backed channels (email/push/sms) and wiring are
+      // integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/notifications/bootstrap.ts",
+        "src/notifications/channels/email/**",
+        "src/notifications/channels/push/**",
+        "src/notifications/channels/sms/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 83,
+      },
+    },
   },
 });

--- a/templates/module-observability-ts/skeleton/package.json
+++ b/templates/module-observability-ts/skeleton/package.json
@@ -20,22 +20,24 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+    "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/sdk-metrics": "^2.8.0",
     "@opentelemetry/sdk-node": "^0.219.0",
     "@opentelemetry/sdk-trace-node": "^2.8.0",
-    "@opentelemetry/sdk-metrics": "^2.8.0",
-    "@opentelemetry/resources": "^2.8.0",
-    "@opentelemetry/semantic-conventions": "^1.41.1",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0"
+    "@opentelemetry/semantic-conventions": "^1.41.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@opentelemetry/context-async-hooks": "^2.8.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-observability-ts/skeleton/vitest.config.ts
+++ b/templates/module-observability-ts/skeleton/vitest.config.ts
@@ -3,5 +3,32 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the logger and exporter registry. The OTel-backed tracer/metrics
+      // and exporters (console/datadog/otlp) are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/telemetry/bootstrap.ts",
+        "src/telemetry/metrics.ts",
+        "src/telemetry/tracer.ts",
+        "src/telemetry/exporters/console.ts",
+        "src/telemetry/exporters/datadog.ts",
+        "src/telemetry/exporters/otlp.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/module-project-mgmt-ts/skeleton/package.json
+++ b/templates/module-project-mgmt-ts/skeleton/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-project-mgmt-ts/skeleton/vitest.config.ts
+++ b/templates/module-project-mgmt-ts/skeleton/vitest.config.ts
@@ -3,5 +3,35 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the mock provider, registry, and circuit breaker. SDK-backed
+      // providers (jira/linear/asana/shortcut) and wiring are
+      // integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/project-mgmt/bootstrap.ts",
+        "src/project-mgmt/config.ts",
+        "src/project-mgmt/logger.ts",
+        "src/project-mgmt/metrics.ts",
+        "src/project-mgmt/providers/asana.ts",
+        "src/project-mgmt/providers/jira.ts",
+        "src/project-mgmt/providers/linear.ts",
+        "src/project-mgmt/providers/shortcut.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 84,
+      },
+    },
   },
 });

--- a/templates/module-queue-ts/skeleton/package.json
+++ b/templates/module-queue-ts/skeleton/package.json
@@ -17,17 +17,19 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@aws-sdk/client-sqs": "^3.750.0",
     "@opentelemetry/api": "^1.9.0",
     "bullmq": "^5.0.0",
-    "@aws-sdk/client-sqs": "^3.750.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-queue-ts/skeleton/vitest.config.ts
+++ b/templates/module-queue-ts/skeleton/vitest.config.ts
@@ -3,5 +3,32 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the queue facade, job helpers, memory provider, and registry.
+      // Live-backend providers (bullmq/sqs), the worker loop, and wiring are
+      // integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/queue/bootstrap.ts",
+        "src/queue/metrics.ts",
+        "src/queue/worker.ts",
+        "src/queue/providers/bullmq.ts",
+        "src/queue/providers/sqs.ts",
+        "src/queue/providers/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 73,
+        functions: 63,
+        statements: 73,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/module-rate-limit-ts/skeleton/package.json
+++ b/templates/module-rate-limit-ts/skeleton/package.json
@@ -19,7 +19,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "ioredis": "^5.4.0",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-rate-limit-ts/skeleton/src/rate-limit/__tests__/memory-store.test.ts
+++ b/templates/module-rate-limit-ts/skeleton/src/rate-limit/__tests__/memory-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // Import the memory store module to trigger self-registration
 import "../stores/memory.js";
@@ -99,16 +99,21 @@ describe("in-memory rate limit store", () => {
   });
 
   it("expires keys after TTL", async () => {
-    // TTL is in milliseconds. Use a window wide enough to survive an
-    // awaited get() without racing against expiry on a slow runner.
-    await store.set("ephemeral", "value", 50);
+    // The store reads Date.now(), so fake timers make expiry deterministic
+    // — no real-clock waiting, no races on a slow runner.
+    vi.useFakeTimers();
+    try {
+      await store.set("ephemeral", "value", 50);
 
-    const immediate = await store.get("ephemeral");
-    expect(immediate).toBe("value");
+      const immediate = await store.get("ephemeral");
+      expect(immediate).toBe("value");
 
-    await new Promise((resolve) => setTimeout(resolve, 75));
+      vi.advanceTimersByTime(75);
 
-    const expired = await store.get("ephemeral");
-    expect(expired).toBeNull();
+      const expired = await store.get("ephemeral");
+      expect(expired).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/templates/module-rate-limit-ts/skeleton/vitest.config.ts
+++ b/templates/module-rate-limit-ts/skeleton/vitest.config.ts
@@ -3,5 +3,32 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the token-bucket algorithm, memory store, and the registries. The
+      // fixed/sliding-window algorithms, redis store, middleware, and wiring
+      // are integration-exercised — ratchet them in as unit suites land.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/rate-limit/bootstrap.ts",
+        "src/rate-limit/middleware.ts",
+        "src/rate-limit/algorithms/fixed-window.ts",
+        "src/rate-limit/algorithms/sliding-window.ts",
+        "src/rate-limit/stores/redis.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 83,
+      },
+    },
   },
 });

--- a/templates/module-search-ts/skeleton/package.json
+++ b/templates/module-search-ts/skeleton/package.json
@@ -18,7 +18,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-search-ts/skeleton/vitest.config.ts
+++ b/templates/module-search-ts/skeleton/vitest.config.ts
@@ -3,5 +3,34 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the hybrid combiner, mock provider, registry, and circuit breaker.
+      // SDK-backed providers (algolia/meilisearch/typesense) and wiring are
+      // integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/search/bootstrap.ts",
+        "src/search/config.ts",
+        "src/search/logger.ts",
+        "src/search/metrics.ts",
+        "src/search/providers/algolia.ts",
+        "src/search/providers/meilisearch.ts",
+        "src/search/providers/typesense.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 79,
+      },
+    },
   },
 });

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/__tests__/cache.test.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/__tests__/cache.test.ts
@@ -50,14 +50,23 @@ describe("semantic cache", () => {
   });
 
   it("respects TTL expiration", async () => {
-    // Store with a 1ms TTL
-    await cache.store("What is TypeScript?", "TypeScript is ...", 1);
+    let clock = 0;
+    const clockCache = await createSemanticCache({
+      embeddingProvider: "mock",
+      vectorBackend: "memory",
+      similarityThreshold: 0.95,
+      defaultTtlMs: 60_000,
+      now: () => clock,
+    });
 
-    // Wait for expiration
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Store with a 1ms TTL, then tick the injected clock past it
+    await clockCache.store("What is TypeScript?", "TypeScript is ...", 1);
+    clock = 10;
 
-    const hit = await cache.lookup("What is TypeScript?");
+    const hit = await clockCache.lookup("What is TypeScript?");
     expect(hit).toBeUndefined();
+
+    await clockCache.close();
   });
 
   it("invalidates a cache entry by id", async () => {
@@ -92,19 +101,19 @@ describe("semantic cache", () => {
   });
 
   it("stores entries with custom TTL that persists beyond default", async () => {
-    // Create cache with very short default TTL
+    // Create cache with a very short default TTL and an injected clock
+    let clock = 0;
     const shortCache = await createSemanticCache({
       embeddingProvider: "mock",
       vectorBackend: "memory",
       similarityThreshold: 0.95,
       defaultTtlMs: 1, // 1ms default
+      now: () => clock,
     });
 
-    // Store with explicit long TTL
+    // Store with explicit long TTL, then tick the clock past the default TTL
     await shortCache.store("persistent prompt", "persistent response", 60_000);
-
-    // Wait for default TTL to expire
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    clock = 10;
 
     // Should still be found because we used custom TTL
     const hit = await shortCache.lookup("persistent prompt");

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/index.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/index.ts
@@ -114,6 +114,7 @@ export async function createSemanticCache(
   const vectorBackendName = config.vectorBackend ?? "memory";
   const similarityThreshold = config.similarityThreshold ?? DEFAULT_SIMILARITY_THRESHOLD;
   const defaultTtlMs = config.defaultTtlMs ?? DEFAULT_TTL_MS;
+  const now = config.now ?? Date.now;
 
   const embedder = getEmbeddingProvider(embeddingProviderName);
   const vectorStore = getVectorStore(vectorBackendName);
@@ -160,7 +161,7 @@ export async function createSemanticCache(
         embedding,
         response,
         metadata: { prompt },
-        expiresAt: Date.now() + (ttlMs ?? defaultTtlMs),
+        expiresAt: now() + (ttlMs ?? defaultTtlMs),
       };
 
       await vectorStore.upsert(entry);

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/store/memory.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/store/memory.ts
@@ -17,6 +17,7 @@ class MemoryVectorCacheStore implements VectorCacheStore {
   readonly name = "memory";
   private entries = new Map<string, CacheVector>();
   private readonly maxEntries: number;
+  private now: () => number = Date.now;
 
   // Bound the cache so a stream of distinct prompts (every miss is upserted)
   // can't grow memory without limit until TTL. Default 1000; override per store.
@@ -25,7 +26,7 @@ class MemoryVectorCacheStore implements VectorCacheStore {
   }
 
   private isExpired(entry: CacheVector): boolean {
-    return Date.now() >= entry.expiresAt;
+    return this.now() >= entry.expiresAt;
   }
 
   /**
@@ -33,7 +34,7 @@ class MemoryVectorCacheStore implements VectorCacheStore {
    * to avoid unbounded memory growth.
    */
   private pruneExpired(): void {
-    const now = Date.now();
+    const now = this.now();
     for (const [id, entry] of this.entries) {
       if (now >= entry.expiresAt) {
         this.entries.delete(id);
@@ -41,8 +42,11 @@ class MemoryVectorCacheStore implements VectorCacheStore {
     }
   }
 
-  async init(_config: VectorStoreConfig): Promise<void> {
-    // No setup needed for in-memory store
+  async init(config: VectorStoreConfig): Promise<void> {
+    // Adopt the injected clock when one is provided (tests).
+    if (typeof config.now === "function") {
+      this.now = config.now as () => number;
+    }
   }
 
   async upsert(entry: CacheVector): Promise<void> {

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/types.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/types.ts
@@ -53,6 +53,9 @@ export interface SemanticCacheConfig {
   /** Default TTL in milliseconds. Default: 3_600_000 (1 hour) */
   defaultTtlMs?: number;
 
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+
   /** Provider-specific options passed through to init. */
   [key: string]: unknown;
 }

--- a/templates/module-storage-ts/skeleton/package.json
+++ b/templates/module-storage-ts/skeleton/package.json
@@ -23,7 +23,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.750.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "typescript": "^5.8.0",

--- a/templates/module-storage-ts/skeleton/vitest.config.ts
+++ b/templates/module-storage-ts/skeleton/vitest.config.ts
@@ -3,5 +3,33 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the local provider, registry, and circuit breaker. SDK-backed
+      // providers (s3/gcs/r2 and their shared helpers), the client facade, and
+      // wiring are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/storage/bootstrap.ts",
+        "src/storage/client.ts",
+        "src/storage/providers/gcs.ts",
+        "src/storage/providers/helpers.ts",
+        "src/storage/providers/r2.ts",
+        "src/storage/providers/s3.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 75,
+      },
+    },
   },
 });

--- a/templates/module-webhook-ts/skeleton/package.json
+++ b/templates/module-webhook-ts/skeleton/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "zod": "^3.24.0"
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/module-webhook-ts/skeleton/vitest.config.ts
+++ b/templates/module-webhook-ts/skeleton/vitest.config.ts
@@ -3,5 +3,29 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the sender and the signature schemes. The receiver, event log, and
+      // wiring are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/webhook/bootstrap.ts",
+        "src/webhook/event-log.ts",
+        "src/webhook/receiver.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 61,
+        statements: 85,
+        branches: 76,
+      },
+    },
   },
 });

--- a/templates/multimodal-pipeline/skeleton/package.json
+++ b/templates/multimodal-pipeline/skeleton/package.json
@@ -13,20 +13,22 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
-    "openai": "^4.85.0",
-    "zod": "^3.24.0",
     "dotenv": "^16.4.0",
     "mime-types": "^2.1.35",
-    "sharp": "^0.33.0"
+    "openai": "^4.85.0",
+    "sharp": "^0.33.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/mime-types": "^2.1.4",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/multimodal-pipeline/skeleton/vitest.config.ts
+++ b/templates/multimodal-pipeline/skeleton/vitest.config.ts
@@ -3,5 +3,34 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the pipeline, processors, mock provider, registries, and circuit
+      // breaker. SDK-backed providers (anthropic/openai/whisper), the output
+      // formatter, and wiring are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/config.ts",
+        "src/logger.ts",
+        "src/output/formatter.ts",
+        "src/providers/anthropic.ts",
+        "src/providers/openai.ts",
+        "src/providers/whisper.ts",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 52,
+        functions: 70,
+        statements: 52,
+        branches: 81,
+      },
+    },
   },
 });

--- a/templates/next-app/skeleton/package.json
+++ b/templates/next-app/skeleton/package.json
@@ -15,18 +15,19 @@
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
+    "dotenv": "^16.4.0",
+    "drizzle-orm": "^0.45.2",
     "next": "^15.3.0",
     "next-auth": "^5.0.0-beta.28",
     "openai": "^4.85.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.0",
-    "dotenv": "^16.4.0"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
@@ -35,6 +36,7 @@
     "@types/node": "^24.13.2",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "drizzle-kit": "^0.30.0",
     "eslint": "^9.20.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/templates/next-app/skeleton/vitest.config.ts
+++ b/templates/next-app/skeleton/vitest.config.ts
@@ -6,6 +6,35 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the chat API route, streaming helpers, and provider registry.
+      // React components/pages, SDK providers, auth/db config, and wiring are
+      // exercised by e2e, not unit coverage.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/logger.ts",
+        "src/app/api/readyz/**",
+        "src/lib/ai/providers/anthropic.ts",
+        "src/lib/ai/providers/openai.ts",
+        "src/lib/auth/**",
+        "src/lib/db/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 83,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/templates/vscode-ext/skeleton/package.json
+++ b/templates/vscode-ext/skeleton/package.json
@@ -37,7 +37,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "package": "vsce package",
-    "publish": "vsce publish"
+    "publish": "vsce publish",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -51,6 +52,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/vscode": "^1.96.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "esbuild": "^0.24.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",

--- a/templates/vscode-ext/skeleton/vitest.config.ts
+++ b/templates/vscode-ext/skeleton/vitest.config.ts
@@ -4,5 +4,33 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the provider registry and the example command — the pure
+      // in-process logic. The extension-host surfaces (extension, client,
+      // webview) and SDK providers need VS Code or live SDKs.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/bootstrap.ts",
+        "src/extension.ts",
+        "src/ai/client.ts",
+        "src/ai/providers/anthropic.ts",
+        "src/ai/providers/openai.ts",
+        "src/webview/**",
+        "src/**/index.ts",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/templates/worker-service/skeleton/package.json
+++ b/templates/worker-service/skeleton/package.json
@@ -12,18 +12,20 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "hono": "^4.7.0",
     "@hono/node-server": "^1.13.0",
     "@opentelemetry/api": "^1.9.0",
-    "zod": "^3.24.0",
-    "dotenv": "^16.4.0"
+    "dotenv": "^16.4.0",
+    "hono": "^4.7.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/worker-service/skeleton/vitest.config.ts
+++ b/templates/worker-service/skeleton/vitest.config.ts
@@ -5,5 +5,33 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      // Gate the consumer handler, scheduler cron logic, and circuit breaker.
+      // Example jobs, the health server, and wiring are integration-exercised.
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/worker/bootstrap.ts",
+        "src/worker/config.ts",
+        "src/worker/logger.ts",
+        "src/worker/metrics.ts",
+        "src/worker/index.ts",
+        "src/worker/consumer/jobs/**",
+        "src/worker/scheduler/jobs/**",
+        "src/worker/health/**",
+        "src/**/types.ts",
+      ],
+      // Floors sit just below measured coverage so the gate catches
+      // regressions; ratchet upward as the suite grows.
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 81,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Why

The catalog multiplies its defaults: most TS skeletons shipped threshold-less vitest configs, and four module skeletons taught sleep-based TTL tests — the flaky-wait anti-pattern the org's own quality bar flags.

## What

- 32 skeletons gain ts-service-shaped coverage blocks with per-metric floors pinned just below each skeleton's measured coverage (clamped 30–85), a `test:coverage` script, and `@vitest/coverage-v8` pinned to the skeleton's vitest specifier. Skipped: prompt-library/sdk (pre-existing Ajv draft-2020 suite failure — don't gate a red suite) and api-gateway (no vitest config).
- 4 module skeletons get injectable clocks (`now?: () => number`, the vendored-breaker idiom) and their TTL tests tick synchronously; module-rate-limit-ts (singleton store, no natural seam) uses vitest fake timers. Zero sleeps remain.

## Validation

All changed skeleton suites pass with their new floors; `format:check` and `validate:catalog` green.