### PR TITLE
Currency: TypeScript 6, js-yaml 5, Node 24 floor across published packages

### DIFF
--- a/mcp-server/__tests__/resources.test.ts
+++ b/mcp-server/__tests__/resources.test.ts
@@ -53,7 +53,7 @@ describe('readResource', () => {
     const result = await readResource(source, 'nanohype://standards');
     const parsed = JSON.parse(result.contents[0].text);
     expect(parsed['language-toolchain'].kind).toBe('nanohype/standards/language-toolchain');
-    expect(parsed['quality-rubric-dimensions'].content.dimensions).toHaveLength(9);
+    expect(parsed['quality-rubric-dimensions'].content.dimensions).toHaveLength(10);
   });
 
   it('resolves nanohype://standards/{name} to one standard', async () => {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -25,7 +25,7 @@
         "vitest": "^4.1.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "../sdk": {
@@ -33,23 +33,22 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^5.2.1"
       },
       "bin": {
         "nanohype": "dist/bin/nanohype.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.8.0",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.4.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.3",
         "vitest": "^4.1.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -19,7 +19,7 @@
     "tsconfig.json"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "build": "tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "eslint": "^10.6.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^5.2.1",
         "markdownlint-cli2": "^0.22.1",
         "prettier": "^3.9.4",
         "typescript-eslint": "^8.62.1"
@@ -1295,9 +1295,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "dev": true,
       "funding": [
         {
@@ -1314,7 +1314,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {
@@ -1522,6 +1522,29 @@
       },
       "peerDependencies": {
         "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mdurl": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "eslint": "^10.6.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^5.2.1",
     "markdownlint-cli2": "^0.22.1",
     "prettier": "^3.9.4",
     "typescript-eslint": "^8.62.1"

--- a/scripts/generate-catalog.mjs
+++ b/scripts/generate-catalog.mjs
@@ -16,7 +16,7 @@
 import { readFile, readdir, writeFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');

--- a/scripts/validate-schema.mjs
+++ b/scripts/validate-schema.mjs
@@ -15,7 +15,7 @@ import { extname } from 'node:path';
 
 import _Ajv2020 from 'ajv/dist/2020.js';
 import _addFormats from 'ajv-formats';
-import jsYaml from 'js-yaml';
+import * as jsYaml from 'js-yaml';
 
 const Ajv2020 = _Ajv2020.default ?? _Ajv2020;
 const addFormats = _addFormats.default ?? _addFormats;

--- a/sdk/__tests__/standards.test.ts
+++ b/sdk/__tests__/standards.test.ts
@@ -44,10 +44,10 @@ describe('loadStandard', () => {
     expect(s.content.regions_preferred).toContain('us-west-2');
   });
 
-  it('loads quality-rubric-dimensions with nine named dimensions', async () => {
+  it('loads quality-rubric-dimensions with ten named dimensions', async () => {
     const s = await loadStandard(source, 'quality-rubric-dimensions');
     if (s.kind !== 'nanohype/standards/quality-rubric-dimensions') throw new Error('kind narrow');
-    expect(s.content.dimensions).toHaveLength(9);
+    expect(s.content.dimensions).toHaveLength(10);
     const ids = s.content.dimensions.map((d) => d.id);
     for (const required of [
       'architecture',
@@ -59,6 +59,7 @@ describe('loadStandard', () => {
       'code_quality',
       'documentation',
       'consistency',
+      'ai_systems',
     ]) {
       expect(ids).toContain(required);
     }

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -9,23 +9,22 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^5.2.1"
       },
       "bin": {
         "nanohype": "dist/bin/nanohype.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.8.0",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.4.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.3",
         "vitest": "^4.1.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -702,13 +701,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1685,9 +1677,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "funding": [
         {
           "type": "github",
@@ -1703,7 +1695,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {
@@ -2477,9 +2469,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -20,7 +20,7 @@
     "tsconfig.json"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "build": "tsc",
@@ -35,15 +35,14 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^5.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.8.0",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.3",
     "vitest": "^4.1.6"
   }

--- a/sdk/src/sources/github.ts
+++ b/sdk/src/sources/github.ts
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import type {
   Catalog,
   CatalogEntry,

--- a/sdk/src/sources/local.ts
+++ b/sdk/src/sources/local.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { dirname, join, relative, resolve, sep } from 'node:path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import type {
   Catalog,
   CatalogEntry,

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -11,7 +11,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["__tests__", "dist"]


### PR DESCRIPTION
Resolves dependency and toolchain drift in the published packages so they track the org baseline. All version floors resolved from the registry at edit time.

## Changes

### `@nanohype/sdk`
- `typescript` `^5.7.0` → `^6.0.3` (latest 6.x)
- `js-yaml` `^4.1.1` → `^5.2.1` (latest)
- `engines.node` `">=20"` → `">=24"`
- js-yaml 5 is ESM-only with no default export → three `import yaml from 'js-yaml'` converted to `import * as yaml from 'js-yaml'` (call sites unchanged). js-yaml 5 bundles its own types, so the redundant `@types/js-yaml` devDependency is dropped.
- TS6 skips auto-including `@types/node` when its `typesVersions` caps below the compiler version (25.8.0 caps at `<=5.7`), so `tsconfig.json` gains `"types": ["node"]` — the compiler's own recommended fix. `@types/node` left at `^25.8.0` (only one major behind; not required, build green).

### `@nanohype/mcp`
- `engines.node` `">=20"` → `">=24"`

### Root workspace
- `js-yaml` devDependency `^4.2.0` → `^5.2.1`. The `markdownlint-cli2` override keeps its own js-yaml at `^4.x` (that toolchain still needs v4).
- `scripts/generate-catalog.mjs` and `scripts/validate-schema.mjs` converted to namespace js-yaml imports (v5 API).

### Test fixups (pre-existing drift, unrelated to deps)
The quality rubric ships **ten** dimensions but two assertions still expected nine. Corrected to ten + added the missing `ai_systems` id: `sdk/__tests__/standards.test.ts`, `mcp-server/__tests__/resources.test.ts`.

## Verification
- sdk: `npm run build` clean, `npm test` 134/134 pass
- mcp-server: `npm run build` clean, `npm test` 50/50 pass
- root: `validate:standards`, `validate:catalog`, `verify:catalog` all pass; `catalog.json` unchanged

## Note
`sdk/src/bin/nanohype.ts` is gitignored (`.gitignore` `bin/` pattern catches `src/bin/`), so its js-yaml import fix is applied locally but not tracked/committed. Pre-existing repo quirk, flagged for follow-up.

https://claude.ai/code/session_01U3YWJMYZU8RiPPoBv6ZTme