### PR TITLE
fix: add missing .prettierrc to electron-app + module-llm-observability

### DIFF
--- a/library/config/biome.base.json
+++ b/library/config/biome.base.json
@@ -9,7 +9,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended"
+      "preset": "recommended",
+      "style": {
+        "noNonNullAssertion": "off"
+      }
     }
   },
   "javascript": {

--- a/library/config/biome.base.json
+++ b/library/config/biome.base.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/templates/electron-app/skeleton/.prettierrc
+++ b/templates/electron-app/skeleton/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/templates/electron-app/skeleton/eslint.config.js
+++ b/templates/electron-app/skeleton/eslint.config.js
@@ -12,5 +12,5 @@ export default tseslint.config(
     // Node build/config scripts (esbuild.config.mjs, vite/vitest config).
     files: ["**/*.mjs", "**/*.config.{js,ts}"],
     languageOptions: { globals: globals.node },
-  },
+  }
 );

--- a/templates/electron-app/skeleton/src/__tests__/ipc.test.ts
+++ b/templates/electron-app/skeleton/src/__tests__/ipc.test.ts
@@ -50,9 +50,7 @@ describe("provider registry", () => {
     registerProvider("anthropic", () => stubProvider());
     registerProvider("openai", () => stubProvider());
 
-    expect(() => getProvider("cohere")).toThrowError(
-      /Unknown AI provider: "cohere"/,
-    );
+    expect(() => getProvider("cohere")).toThrowError(/Unknown AI provider: "cohere"/);
     expect(() => getProvider("cohere")).toThrowError(/Available:/);
   });
 

--- a/templates/electron-app/skeleton/src/main/bootstrap.ts
+++ b/templates/electron-app/skeleton/src/main/bootstrap.ts
@@ -24,7 +24,7 @@ export function validateBootstrap(): void {
         `\n  Unresolved placeholder in ${label}: ${value}\n\n` +
           "  This project was scaffolded from a nanohype template but\n" +
           "  some variables were not replaced. Re-run the scaffolding\n" +
-          "  tool or replace placeholders manually.\n",
+          "  tool or replace placeholders manually.\n"
       );
       process.exit(1);
     }

--- a/templates/electron-app/skeleton/src/main/config.ts
+++ b/templates/electron-app/skeleton/src/main/config.ts
@@ -9,25 +9,15 @@ import { z } from "zod";
 //
 
 const configSchema = z.object({
-  LLM_PROVIDER: z
-    .string()
-    .default("__LLM_PROVIDER__"),
+  LLM_PROVIDER: z.string().default("__LLM_PROVIDER__"),
 
-  ANTHROPIC_API_KEY: z
-    .string()
-    .optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
 
-  OPENAI_API_KEY: z
-    .string()
-    .optional(),
+  OPENAI_API_KEY: z.string().optional(),
 
-  LOG_LEVEL: z
-    .enum(["debug", "info", "warn", "error"])
-    .default("info"),
+  LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info"),
 
-  NODE_ENV: z
-    .enum(["development", "production", "test"])
-    .default("development"),
+  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/templates/electron-app/skeleton/src/main/ipc-handlers.ts
+++ b/templates/electron-app/skeleton/src/main/ipc-handlers.ts
@@ -16,37 +16,28 @@ interface SendMessagePayload {
 }
 
 export function registerIpcHandlers(ipcMain: IpcMain): void {
-  ipcMain.handle(
-    "ai:send-message",
-    async (_event, payload: SendMessagePayload) => {
-      const providerName =
-        payload.provider ?? process.env.LLM_PROVIDER ?? "__LLM_PROVIDER__";
+  ipcMain.handle("ai:send-message", async (_event, payload: SendMessagePayload) => {
+    const providerName = payload.provider ?? process.env.LLM_PROVIDER ?? "__LLM_PROVIDER__";
 
-      const apiKey = resolveApiKey(providerName);
-      if (!apiKey) {
-        return {
-          content: "",
-          error: `No API key found for provider "${providerName}". Set the corresponding environment variable.`,
-        };
-      }
+    const apiKey = resolveApiKey(providerName);
+    if (!apiKey) {
+      return {
+        content: "",
+        error: `No API key found for provider "${providerName}". Set the corresponding environment variable.`,
+      };
+    }
 
-      try {
-        const provider = getProvider(providerName);
-        const content = await provider.sendMessage(
-          payload.messages,
-          apiKey,
-          payload.model,
-        );
-        return { content };
-      } catch (err) {
-        return {
-          content: "",
-          error:
-            err instanceof Error ? err.message : "Failed to get AI response",
-        };
-      }
-    },
-  );
+    try {
+      const provider = getProvider(providerName);
+      const content = await provider.sendMessage(payload.messages, apiKey, payload.model);
+      return { content };
+    } catch (err) {
+      return {
+        content: "",
+        error: err instanceof Error ? err.message : "Failed to get AI response",
+      };
+    }
+  });
 }
 
 /**

--- a/templates/electron-app/skeleton/src/main/preload.ts
+++ b/templates/electron-app/skeleton/src/main/preload.ts
@@ -11,7 +11,7 @@ export interface ElectronAPI {
   sendMessage: (
     messages: Array<{ role: string; content: string }>,
     provider?: string,
-    model?: string,
+    model?: string
   ) => Promise<{ content: string; error?: string }>;
 }
 
@@ -19,6 +19,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
   sendMessage: (
     messages: Array<{ role: string; content: string }>,
     provider?: string,
-    model?: string,
+    model?: string
   ) => ipcRenderer.invoke("ai:send-message", { messages, provider, model }),
 } satisfies ElectronAPI);

--- a/templates/electron-app/skeleton/src/main/providers/anthropic.ts
+++ b/templates/electron-app/skeleton/src/main/providers/anthropic.ts
@@ -5,11 +5,7 @@ import { registerProvider } from "./registry.js";
 class AnthropicProvider implements AiProvider {
   readonly defaultModel = "claude-sonnet-4-20250514";
 
-  async sendMessage(
-    messages: ChatMessage[],
-    apiKey: string,
-    model?: string,
-  ): Promise<string> {
+  async sendMessage(messages: ChatMessage[], apiKey: string, model?: string): Promise<string> {
     const client = new Anthropic({ apiKey });
 
     const response = await client.messages.create({

--- a/templates/electron-app/skeleton/src/main/providers/openai.ts
+++ b/templates/electron-app/skeleton/src/main/providers/openai.ts
@@ -5,11 +5,7 @@ import { registerProvider } from "./registry.js";
 class OpenAIProvider implements AiProvider {
   readonly defaultModel = "gpt-4o";
 
-  async sendMessage(
-    messages: ChatMessage[],
-    apiKey: string,
-    model?: string,
-  ): Promise<string> {
+  async sendMessage(messages: ChatMessage[], apiKey: string, model?: string): Promise<string> {
     const client = new OpenAI({ apiKey });
 
     const response = await client.chat.completions.create({

--- a/templates/electron-app/skeleton/src/renderer/App.tsx
+++ b/templates/electron-app/skeleton/src/renderer/App.tsx
@@ -58,7 +58,7 @@ export function App() {
         setIsLoading(false);
       }
     },
-    [messages],
+    [messages]
   );
 
   return (
@@ -71,18 +71,20 @@ export function App() {
       }}
     >
       <header
-        style={{
-          padding: "10px 16px",
-          borderBottom: "1px solid var(--border)",
-          fontWeight: 600,
-          fontSize: "13px",
-          letterSpacing: "-0.015em",
-          color: "var(--foreground)",
-          background: "var(--card)",
-          // -webkit-app-region makes the custom title bar draggable; not in
-          // @types/react's CSSProperties, so cast.
-          WebkitAppRegion: "drag",
-        } as CSSProperties}
+        style={
+          {
+            padding: "10px 16px",
+            borderBottom: "1px solid var(--border)",
+            fontWeight: 600,
+            fontSize: "13px",
+            letterSpacing: "-0.015em",
+            color: "var(--foreground)",
+            background: "var(--card)",
+            // -webkit-app-region makes the custom title bar draggable; not in
+            // @types/react's CSSProperties, so cast.
+            WebkitAppRegion: "drag",
+          } as CSSProperties
+        }
       >
         __PROJECT_NAME__
       </header>
@@ -98,7 +100,7 @@ declare global {
       sendMessage: (
         messages: Array<{ role: string; content: string }>,
         provider?: string,
-        model?: string,
+        model?: string
       ) => Promise<{ content: string; error?: string }>;
     };
   }

--- a/templates/electron-app/skeleton/src/renderer/components/Chat.tsx
+++ b/templates/electron-app/skeleton/src/renderer/components/Chat.tsx
@@ -102,12 +102,8 @@ export function Chat({ messages, onSend, isLoading }: ChatProps) {
             fontSize: "13px",
             transition: "border-color 0.15s var(--ease-out)",
           }}
-          onFocus={(e) =>
-            (e.currentTarget.style.borderColor = "var(--accent)")
-          }
-          onBlur={(e) =>
-            (e.currentTarget.style.borderColor = "var(--input-border)")
-          }
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--input-border)")}
         />
         <button
           type="submit"
@@ -116,31 +112,22 @@ export function Chat({ messages, onSend, isLoading }: ChatProps) {
             padding: "8px 16px",
             borderRadius: "6px",
             border: "none",
-            background:
-              isLoading || !input.trim()
-                ? "var(--muted)"
-                : "var(--accent)",
-            color:
-              isLoading || !input.trim()
-                ? "var(--dim)"
-                : "var(--accent-foreground)",
+            background: isLoading || !input.trim() ? "var(--muted)" : "var(--accent)",
+            color: isLoading || !input.trim() ? "var(--dim)" : "var(--accent-foreground)",
             fontSize: "13px",
             cursor: isLoading || !input.trim() ? "default" : "pointer",
             fontWeight: 600,
-            transition:
-              "filter 0.15s var(--ease-out), transform 0.1s var(--ease-spring)",
+            transition: "filter 0.15s var(--ease-out), transform 0.1s var(--ease-spring)",
           }}
           onMouseEnter={(e) => {
-            if (!isLoading && input.trim())
-              e.currentTarget.style.filter = "brightness(1.15)";
+            if (!isLoading && input.trim()) e.currentTarget.style.filter = "brightness(1.15)";
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.filter = "brightness(1)";
             e.currentTarget.style.transform = "scale(1)";
           }}
           onMouseDown={(e) => {
-            if (!isLoading && input.trim())
-              e.currentTarget.style.transform = "scale(0.96)";
+            if (!isLoading && input.trim()) e.currentTarget.style.transform = "scale(0.96)";
           }}
           onMouseUp={(e) => {
             e.currentTarget.style.transform = "scale(1)";

--- a/templates/electron-app/skeleton/src/renderer/components/Message.tsx
+++ b/templates/electron-app/skeleton/src/renderer/components/Message.tsx
@@ -33,9 +33,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
           maxWidth: "85%",
           padding: "8px 12px",
           borderRadius: "6px",
-          background: isUser
-            ? "color-mix(in srgb, var(--accent) 10%, transparent)"
-            : "var(--card)",
+          background: isUser ? "color-mix(in srgb, var(--accent) 10%, transparent)" : "var(--card)",
           color: "var(--foreground)",
           fontSize: "13px",
           lineHeight: "1.5",
@@ -72,9 +70,7 @@ function renderContent(content: string) {
 
   while ((match = codeBlockRegex.exec(content)) !== null) {
     if (match.index > lastIndex) {
-      parts.push(
-        ...renderParagraphs(content.slice(lastIndex, match.index), parts.length),
-      );
+      parts.push(...renderParagraphs(content.slice(lastIndex, match.index), parts.length));
     }
     parts.push(
       <pre
@@ -93,7 +89,7 @@ function renderContent(content: string) {
         }}
       >
         <code>{match[1]}</code>
-      </pre>,
+      </pre>
     );
     lastIndex = match.index + match[0].length;
   }

--- a/templates/module-llm-observability/skeleton/.prettierrc
+++ b/templates/module-llm-observability/skeleton/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/templates/module-llm-observability/skeleton/eslint.config.js
+++ b/templates/module-llm-observability/skeleton/eslint.config.js
@@ -27,5 +27,5 @@ export default tseslint.config(
   },
   {
     ignores: ["dist/", "node_modules/"],
-  },
+  }
 );

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
@@ -63,7 +63,9 @@ describe("cost calculator", () => {
     const calculator = createCostCalculator();
 
     calculator.record(makeSpan({ model: "claude-sonnet-4-6", inputTokens: 100, outputTokens: 50 }));
-    calculator.record(makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 200, outputTokens: 100 }));
+    calculator.record(
+      makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 200, outputTokens: 100 })
+    );
 
     const summary = calculator.query();
     expect(summary.totalRequests).toBe(2);
@@ -93,8 +95,12 @@ describe("cost calculator", () => {
   it("breaks down cost by model", () => {
     const calculator = createCostCalculator();
 
-    calculator.record(makeSpan({ model: "claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500 }));
-    calculator.record(makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 1000, outputTokens: 500 }));
+    calculator.record(
+      makeSpan({ model: "claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500 })
+    );
+    calculator.record(
+      makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 1000, outputTokens: 500 })
+    );
 
     const summary = calculator.query();
     expect(summary.byModel["claude-sonnet-4-6"]).toBeGreaterThan(0);

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/registry.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/registry.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  registerExporter,
-  getExporter,
-  listExporters,
-} from "../exporters/registry.js";
+import { registerExporter, getExporter, listExporters } from "../exporters/registry.js";
 import type { LlmExporter } from "../exporters/types.js";
 
 // ── Exporter Registry Tests ────────────────────────────────────────
@@ -32,9 +28,7 @@ describe("LLM exporter registry", () => {
   });
 
   it("throws when retrieving an unregistered exporter", () => {
-    expect(() => getExporter("nonexistent-exporter")).toThrow(
-      /Unknown LLM exporter/,
-    );
+    expect(() => getExporter("nonexistent-exporter")).toThrow(/Unknown LLM exporter/);
   });
 
   it("lists all registered exporter names", () => {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
@@ -19,9 +19,7 @@ describe("LLM tracer", () => {
   it("wraps an async LLM call and captures a span", async () => {
     const tracer = createLlmTracer({ serviceName: "test-service" });
 
-    const { response, span } = await tracer.trace(
-      async () => makeResponse(),
-    );
+    const { response, span } = await tracer.trace(async () => makeResponse());
 
     expect(response.text).toBe("Hello, world!");
     expect(span.model).toBe("claude-sonnet-4-6");
@@ -78,10 +76,10 @@ describe("LLM tracer", () => {
       defaultTags: { environment: "test", team: "platform" },
     });
 
-    const { span } = await tracer.trace(
-      async () => makeResponse(),
-      { user: "alice", team: "overridden" },
-    );
+    const { span } = await tracer.trace(async () => makeResponse(), {
+      user: "alice",
+      team: "overridden",
+    });
 
     expect(span.tags["environment"]).toBe("test");
     expect(span.tags["user"]).toBe("alice");
@@ -105,7 +103,7 @@ describe("LLM tracer", () => {
     const tracer = createLlmTracer({ serviceName: "test-service" });
 
     const { span } = await tracer.trace(async () =>
-      makeResponse({ model: "gpt-4o", provider: "openai", inputTokens: 200, outputTokens: 100 }),
+      makeResponse({ model: "gpt-4o", provider: "openai", inputTokens: 200, outputTokens: 100 })
     );
 
     expect(span.model).toBe("gpt-4o");

--- a/templates/module-llm-observability/skeleton/src/llm-observability/bootstrap.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/bootstrap.ts
@@ -24,7 +24,7 @@ export function validateBootstrap(): void {
         `\n  Unresolved placeholder in ${label}: ${value}\n\n` +
           "  This project was scaffolded from a nanohype template but\n" +
           "  some variables were not replaced. Re-run the scaffolding\n" +
-          "  tool or replace placeholders manually.\n",
+          "  tool or replace placeholders manually.\n"
       );
       process.exit(1);
     }

--- a/templates/module-llm-observability/skeleton/src/llm-observability/cost/anomaly.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/cost/anomaly.ts
@@ -30,7 +30,7 @@ export interface AnomalyResult {
 export function detectAnomalies(
   entries: CostEntry[],
   windowSize: number = 20,
-  threshold: number = 2.0,
+  threshold: number = 2.0
 ): AnomalyResult[] {
   const anomalies: AnomalyResult[] = [];
 

--- a/templates/module-llm-observability/skeleton/src/llm-observability/cost/calculator.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/cost/calculator.ts
@@ -54,7 +54,7 @@ export function createCostCalculator() {
     if (filters.tags) {
       const requiredTags = filters.tags;
       filtered = filtered.filter((e) =>
-        Object.entries(requiredTags).every(([k, v]) => e.tags[k] === v),
+        Object.entries(requiredTags).every(([k, v]) => e.tags[k] === v)
       );
     }
     if (filters.since) {

--- a/templates/module-llm-observability/skeleton/src/llm-observability/cost/pricing.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/cost/pricing.ts
@@ -39,11 +39,7 @@ export function getModelPricing(model: string): ModelPricing {
 /**
  * Calculate cost for a request given token counts and model.
  */
-export function calculateCost(
-  model: string,
-  inputTokens: number,
-  outputTokens: number,
-): number {
+export function calculateCost(model: string, inputTokens: number, outputTokens: number): number {
   const pricing = getModelPricing(model);
   return (inputTokens * pricing.input) / 1_000_000 + (outputTokens * pricing.output) / 1_000_000;
 }

--- a/templates/module-llm-observability/skeleton/src/llm-observability/exporters/console.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/exporters/console.ts
@@ -17,17 +17,17 @@ function createConsoleExporter(): LlmExporter {
       const cost = span.cost > 0 ? ` $${span.cost.toFixed(6)}` : "";
       console.log(
         `[LLM] ${status} ${span.provider}/${span.model} ` +
-        `${span.durationMs}ms ` +
-        `in=${span.inputTokens} out=${span.outputTokens}${cost}` +
-        (span.error ? ` err="${span.error}"` : ""),
+          `${span.durationMs}ms ` +
+          `in=${span.inputTokens} out=${span.outputTokens}${cost}` +
+          (span.error ? ` err="${span.error}"` : "")
       );
     },
 
     exportCost(entry: CostEntry): void {
       console.log(
         `[LLM:COST] ${entry.provider}/${entry.model} ` +
-        `$${entry.cost.toFixed(6)} ` +
-        `in=${entry.inputTokens} out=${entry.outputTokens}`,
+          `$${entry.cost.toFixed(6)} ` +
+          `in=${entry.inputTokens} out=${entry.outputTokens}`
       );
     },
 

--- a/templates/module-llm-observability/skeleton/src/llm-observability/exporters/registry.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/exporters/registry.ts
@@ -14,10 +14,7 @@ const factories = new Map<string, () => LlmExporter>();
  * Register an exporter factory under the given name.
  * Called at module load time by each exporter module.
  */
-export function registerExporter(
-  name: string,
-  factory: () => LlmExporter,
-): void {
+export function registerExporter(name: string, factory: () => LlmExporter): void {
   factories.set(name, factory);
 }
 
@@ -29,9 +26,7 @@ export function getExporter(name: string): LlmExporter {
   const factory = factories.get(name);
   if (!factory) {
     const available = [...factories.keys()].join(", ") || "(none)";
-    throw new Error(
-      `Unknown LLM exporter "${name}". Registered exporters: ${available}`,
-    );
+    throw new Error(`Unknown LLM exporter "${name}". Registered exporters: ${available}`);
   }
   return factory();
 }

--- a/templates/module-llm-observability/skeleton/src/llm-observability/index.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/index.ts
@@ -19,8 +19,10 @@ import type { LlmExporter } from "./exporters/types.js";
 import type { QualityStats, QualityWindow } from "./quality/types.js";
 
 // Conditional cost imports — tree-shaken when cost/ directory is excluded
-let createCostCalculator: (() => ReturnType<typeof import("./cost/calculator.js").createCostCalculator>) | undefined;
-let calculateCostFn: ((model: string, inputTokens: number, outputTokens: number) => number) | undefined;
+let createCostCalculator:
+  (() => ReturnType<typeof import("./cost/calculator.js").createCostCalculator>) | undefined;
+let calculateCostFn:
+  ((model: string, inputTokens: number, outputTokens: number) => number) | undefined;
 
 try {
   const costModule = await import("./cost/calculator.js");
@@ -39,7 +41,9 @@ export interface LlmObserver {
   /** Get quality statistics over a sliding window. */
   getQualityStats(window?: QualityWindow): QualityStats;
   /** Get cost entries (empty if cost tracking is disabled). */
-  getCosts(filters?: import("./cost/types.js").CostFilters): import("./cost/types.js").CostSummary | null;
+  getCosts(
+    filters?: import("./cost/types.js").CostFilters
+  ): import("./cost/types.js").CostSummary | null;
   /** Flush exporters and shut down. */
   close(): Promise<void>;
 }
@@ -90,7 +94,7 @@ export function createLlmObserver(config: ObserverConfig): LlmObserver {
 
   async function traceFn(
     fn: () => Promise<LlmResponse>,
-    tags: Record<string, string> = {},
+    tags: Record<string, string> = {}
   ): Promise<LlmResponse> {
     let response: LlmResponse;
     let span: LlmSpan;
@@ -102,12 +106,7 @@ export function createLlmObserver(config: ObserverConfig): LlmObserver {
       // fabricated empty response.
       if (err instanceof TracedError) {
         exporter.exportSpan(err.span);
-        llmMetrics.recordTrace(
-          err.span.model,
-          err.span.provider,
-          err.span.durationMs,
-          false,
-        );
+        llmMetrics.recordTrace(err.span.model, err.span.provider, err.span.durationMs, false);
         throw err.cause;
       }
       throw err;
@@ -142,7 +141,9 @@ export function createLlmObserver(config: ObserverConfig): LlmObserver {
     return qualityMonitor.getStats(window);
   }
 
-  function getCosts(filters?: import("./cost/types.js").CostFilters): import("./cost/types.js").CostSummary | null {
+  function getCosts(
+    filters?: import("./cost/types.js").CostFilters
+  ): import("./cost/types.js").CostSummary | null {
     if (!costCalculator) return null;
     return costCalculator.query(filters);
   }
@@ -163,6 +164,13 @@ export { getExporter, listExporters, registerExporter } from "./exporters/index.
 export { logger } from "./logger.js";
 export { createLlmMetrics } from "./metrics.js";
 export type { LlmExporter } from "./exporters/types.js";
-export type { ObserverConfig, LlmSpan, LlmResponse, LlmEvent, CostEntry, QualityScore } from "./types.js";
+export type {
+  ObserverConfig,
+  LlmSpan,
+  LlmResponse,
+  LlmEvent,
+  CostEntry,
+  QualityScore,
+} from "./types.js";
 export type { TracerOptions, SpanContext } from "./tracer/types.js";
 export type { QualityStats, QualityWindow } from "./quality/types.js";

--- a/templates/module-llm-observability/skeleton/src/llm-observability/logger.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/logger.ts
@@ -62,15 +62,11 @@ function emit(level: LogLevel, message: string, fields?: Record<string, unknown>
  *   logger.info("span captured", { model: "claude-sonnet-4-6", durationMs: 340 });
  */
 export const logger = {
-  debug: (message: string, fields?: Record<string, unknown>) =>
-    emit("debug", message, fields),
+  debug: (message: string, fields?: Record<string, unknown>) => emit("debug", message, fields),
 
-  info: (message: string, fields?: Record<string, unknown>) =>
-    emit("info", message, fields),
+  info: (message: string, fields?: Record<string, unknown>) => emit("info", message, fields),
 
-  warn: (message: string, fields?: Record<string, unknown>) =>
-    emit("warn", message, fields),
+  warn: (message: string, fields?: Record<string, unknown>) => emit("warn", message, fields),
 
-  error: (message: string, fields?: Record<string, unknown>) =>
-    emit("error", message, fields),
+  error: (message: string, fields?: Record<string, unknown>) => emit("error", message, fields),
 };

--- a/templates/module-llm-observability/skeleton/src/llm-observability/tracer/index.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/tracer/index.ts
@@ -21,7 +21,7 @@ export type { TracerOptions, SpanContext } from "./types.js";
 export class TracedError extends Error {
   constructor(
     public readonly span: LlmSpan,
-    public readonly cause: unknown,
+    public readonly cause: unknown
   ) {
     super(cause instanceof Error ? cause.message : String(cause));
     this.name = "TracedError";
@@ -47,7 +47,7 @@ export function createLlmTracer(options: TracerOptions) {
    */
   async function trace(
     fn: () => Promise<LlmResponse>,
-    tags: Record<string, string> = {},
+    tags: Record<string, string> = {}
   ): Promise<{ response: LlmResponse; span: LlmSpan }> {
     const id = randomUUID();
     const startedAt = new Date(now());


### PR DESCRIPTION
## Summary
Closes #143. Two of the three named templates (`electron-app`, `module-llm-observability`) were missing the catalog-standard `.prettierrc`; `module-semantic-cache` already had one, verified before starting rather than assumed. Added the missing configs and reformatted both skeletons' source files to match.

## Test plan
- [x] `./scripts/validate.sh templates/electron-app` — pass
- [x] `./scripts/validate.sh templates/module-llm-observability` — pass