### PR TITLE
fix: clear flagged transitive lockfile versions and unblock test signal

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -11,6 +11,28 @@ permissions:
   contents: read
 
 jobs:
+  # Supply-chain gate. Replaces `npm audit`, whose npm advisory endpoints are
+  # unreliable; osv-scanner checks the committed lockfiles against the OSV
+  # database and exits non-zero on a known vulnerability. Pinned to an exact
+  # version (its behaviour can shift in a patch).
+  #
+  # Runs as its own job so a new advisory still blocks the merge but never
+  # short-circuits the typecheck/lint/build/test signal below.
+  audit:
+    name: audit (osv-scanner)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: audit (osv-scanner)
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        with:
+          scan-args: |-
+            --no-resolve
+            --recursive
+            ./
+
   build-and-test:
     name: Build and test MCP server
     runs-on: ubuntu-latest
@@ -45,18 +67,6 @@ jobs:
       - name: Install dependencies
         working-directory: mcp-server
         run: npm ci
-
-      # Supply-chain gate. Replaces `npm audit`, whose npm advisory endpoints are
-      # unreliable; osv-scanner checks the committed lockfiles against the OSV
-      # database and exits non-zero on a known vulnerability. Pinned to an exact
-      # version (its behaviour can shift in a patch).
-      - name: audit (osv-scanner)
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
-        with:
-          scan-args: |-
-            --no-resolve
-            --recursive
-            ./
 
       - name: Typecheck
         working-directory: mcp-server

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -11,6 +11,28 @@ permissions:
   contents: read
 
 jobs:
+  # Supply-chain gate. Replaces `npm audit`, whose npm advisory endpoints are
+  # unreliable; osv-scanner checks the committed lockfiles against the OSV
+  # database and exits non-zero on a known vulnerability. Pinned to an exact
+  # version (its behaviour can shift in a patch).
+  #
+  # Runs as its own job so a new advisory still blocks the merge but never
+  # short-circuits the typecheck/lint/build/test signal below.
+  audit:
+    name: audit (osv-scanner)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: audit (osv-scanner)
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        with:
+          scan-args: |-
+            --no-resolve
+            --recursive
+            ./
+
   build-and-test:
     name: Build and test SDK
     runs-on: ubuntu-latest
@@ -39,18 +61,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      # Supply-chain gate. Replaces `npm audit`, whose npm advisory endpoints are
-      # unreliable; osv-scanner checks the committed lockfiles against the OSV
-      # database and exits non-zero on a known vulnerability. Pinned to an exact
-      # version (its behaviour can shift in a patch).
-      - name: audit (osv-scanner)
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
-        with:
-          scan-args: |-
-            --no-resolve
-            --recursive
-            ./
 
       - name: Typecheck
         run: npm run typecheck

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -317,12 +317,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -977,21 +977,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1352,9 +1365,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1532,9 +1545,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -42,5 +42,11 @@
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "^5.7.0",
     "vitest": "^4.1.6"
+  },
+  "overrides": {
+    "@hono/node-server": "^2.0.5",
+    "body-parser": "^2.3.0",
+    "fast-uri": "^3.1.3",
+    "hono": "^4.12.27"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
   },
   "overrides": {
     "fast-json-patch": "^3.1.1",
+    "fast-uri": "^3.1.3",
+    "linkify-it": "^5.0.2",
     "markdownlint-cli2": {
       "js-yaml": "^4.2.0",
       "markdown-it": "^14.2.0"

--- a/schemas/standards.schema.json
+++ b/schemas/standards.schema.json
@@ -329,7 +329,14 @@
         "properties": {
           "content": {
             "type": "object",
-            "required": ["environments", "domains", "cluster_identity", "transforms", "limits", "rules"],
+            "required": [
+              "environments",
+              "domains",
+              "cluster_identity",
+              "transforms",
+              "limits",
+              "rules"
+            ],
             "properties": {
               "environments": { "type": "array", "minItems": 1, "items": { "type": "string" } },
               "domains": {


### PR DESCRIPTION
## What was failing

The `audit (osv-scanner)` gate reported eight advisories across six packages, turning the **SDK**, **MCP Server**, and **Validate Templates** workflows red on `main`.

| Package | Was | Now | Advisory |
| --- | --- | --- | --- |
| `@hono/node-server` | 1.19.14 | 2.0.11 | GHSA-frvp-7c67-39w9 (5.9) |
| `hono` | 4.12.26 | 4.12.31 | GHSA-hvrm-45r6-mjfj, GHSA-w62v-xxxg-mg59, GHSA-xgm2-5f3f-mvvc |
| `body-parser` | 2.2.2 | 2.3.0 | GHSA-v422-hmwv-36x6 (3.7) |
| `fast-uri` | 3.1.2 | 3.1.4 | GHSA-4c8g-83qw-93j6 (7.5) |
| `linkify-it` (dev) | 5.0.1 | 5.0.2 | GHSA-v245-v573-v5vm (7.5) |

Every flagged package is transitive via `@modelcontextprotocol/sdk@1.29.0`, which is already the latest published release. No upstream version to move to, so the versions are forced with npm `overrides`. Nothing is suppressed — no ignore file, no severity threshold, no `continue-on-error`.

## The major bump

`@hono/node-server` 1.19.14 → 2.0.11 is the only major. Its two breaking changes:

1. **Node 18 dropped** — moot, this package requires Node >=24.
2. **`@hono/node-server/vercel` subpath removed** — the MCP SDK never imports it.

The SDK's only use is `getRequestListener` from the package root, and its type signature is identical across both versions. Verified by loading `@modelcontextprotocol/sdk/server/streamableHttp.js` (the sole consumer) and constructing the transport against the overridden tree.

The MCP server itself uses the stdio transport and never reaches the HTTP path, so this is an unused code path in practice — but it still gets pinned, because the scanner reads the committed lockfile, not the import graph.

## Second defect — audit ordering (#155)

`sdk.yml` and `mcp-server.yml` ran the scanner as a **step inside** their build-and-test jobs. A scanner failure short-circuited the job, so Typecheck, Lint, Build, and Test never ran — any advisory against a transitive dep silently erased all functional CI signal for both packages.

The scanner is now its own job in both workflows, matching what `validate-templates.yml`, `library.yml`, and `template-doctor.yml` already do. It still fails independently and still blocks the merge; it no longer masks whether the tests pass.

## Verification

Ran the pinned scanner image locally against the updated lockfiles — `No issues found`, exit 0.

Full local gate suite, all exit 0:

- root: `lint`, `validate:catalog`, `validate:standards`, `verify:catalog`, `verify:library`, `lint:docs`
- `sdk/`: `typecheck`, `lint`, `build`, `test:coverage` (135 tests)
- `mcp-server/`: `typecheck`, `lint`, `build`, `test:coverage` (50 tests)
- schema sync diff

Also smoke-tested the built MCP server over stdio — it initializes and serves `tools/list` correctly.

## Note

Root `biome check` had a pre-existing formatting drift in `schemas/standards.schema.json`, unrelated to these advisories. That command is not wired into any workflow, which is why it went unnoticed. Reflowed to the formatter's output; no schema semantics change.