### PR TITLE
fix(templates): stop scaffolding ingress against a controller that may not exist

### DIFF
--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -82,7 +82,7 @@ Compose with any of the application templates that produce a container-shipped s
 Designed to work with these repos already in place on the target cluster:
 
 - `nanohype/landing-zone` — provisions the EKS cluster, ArgoCD, base IAM, KMS keys, and the per-app `<app>-platform` component (IRSA role + Secrets Manager entries)
-- `nanohype/eks-gitops` — supplies cluster addons (cert-manager, external-secrets, ingress-nginx, observability, Kyverno policies) and the ApplicationSet that picks up `gitops/applicationset-entry.yaml`
+- `nanohype/eks-gitops` — supplies cluster addons (cert-manager, external-secrets, external-dns, the AWS Load Balancer Controller, Cilium, observability, Kyverno policies) and the ApplicationSet that picks up `gitops/applicationset-entry.yaml`. The load balancer controller is the cluster's only ingress implementation: it creates an `alb` IngressClass and does not mark it the cluster default, so any Ingress you add has to request `alb` by name, and its TLS terminates on the ALB against an ACM certificate rather than a Kubernetes Secret
 - `nanohype/eks-agent-platform` — runs the operator that reconciles your `platform.yaml`
 
 If any of these are missing on the target cluster, the rendered app's `platform.yaml` won't reconcile and the ApplicationSet entry won't have a parent to register against.

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -64,12 +64,25 @@ probes:
 networkPolicy:
   enabled: true
   ingress:
-    # Allow traffic from same namespace + the cluster ingress controller.
+    # Same namespace, plus the load balancer in front of any Ingress this app
+    # adds.
+    #
+    # The load balancer is not a pod, so that second source cannot be a
+    # namespaceSelector. nanohype EKS clusters serve the `alb` class from the
+    # AWS Load Balancer Controller, and with `target-type: ip` the connection
+    # arrives from an ALB network interface in the cluster VPC — the source is a
+    # VPC address belonging to no namespace, so a namespaceSelector on an
+    # ingress-controller namespace drops it. 10.0.0.0/8 is the range the
+    # landing-zone network component allocates VPC CIDRs from; narrow it to the
+    # public subnet CIDRs per-env where the blast radius matters.
+    #
+    # On a cluster whose ingress controller does run as pods (ingress-nginx,
+    # Traefik), replace the ipBlock with a namespaceSelector on that
+    # controller's namespace instead.
     - from:
         - podSelector: {}
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: ingress-nginx
+        - ipBlock:
+            cidr: 10.0.0.0/8
       ports:
         - protocol: TCP
           port: __PORT__

--- a/templates/k8s-deploy/README.md
+++ b/templates/k8s-deploy/README.md
@@ -11,7 +11,7 @@ Generic Kubernetes deployment with raw manifests and an optional Helm chart. Wor
 - Liveness and readiness probes on configurable health endpoints
 - Resource requests and limits for CPU and memory
 - RollingUpdate strategy with zero-downtime deploys
-- Optional Ingress with TLS termination (nginx ingress controller)
+- Optional Ingress, controller-agnostic — no class and no annotations are set, so the cluster's default IngressClass claims it; the values file carries ready-to-paste blocks for the AWS Load Balancer Controller and for ingress-nginx, including how TLS differs between them
 - Optional HorizontalPodAutoscaler with CPU and memory scaling
 - Optional Helm chart producing the same resources, fully parameterized
 - Optional GitHub Actions workflow for build, push, and deploy
@@ -38,7 +38,7 @@ Generic Kubernetes deployment with raw manifests and an optional Helm chart. Wor
     configmap.yaml          # Application configuration
     deployment.yaml         # Deployment + ServiceAccount
     service.yaml            # ClusterIP Service
-    ingress.yaml            # (optional) Ingress with TLS
+    ingress.yaml            # (optional) Ingress — set the class + annotations for your controller
     hpa.yaml                # (optional) HorizontalPodAutoscaler
   chart/                    # (optional) Helm chart
     Chart.yaml              # Chart metadata

--- a/templates/k8s-deploy/skeleton/chart/values.yaml
+++ b/templates/k8s-deploy/skeleton/chart/values.yaml
@@ -42,21 +42,56 @@ readinessProbe:
   timeoutSeconds: 3
   failureThreshold: 2
 
+# This template targets a generic cluster, so it names no ingress controller.
+# An empty className renders an Ingress with no `ingressClassName`, which the
+# cluster's default IngressClass claims. If your cluster has no default class —
+# nanohype EKS clusters do not; see below — the Ingress is created and then
+# ignored by every controller, so name the class explicitly.
+#
+# Annotations are controller-specific and there is no portable set, so the
+# default is empty. Fill in the block for whichever controller serves the class:
+#
+#   AWS Load Balancer Controller (nanohype EKS clusters, `eks-gitops`
+#   addons/networking/aws-load-balancer-controller — it creates an `alb`
+#   IngressClass and does NOT mark it the cluster default):
+#
+#     className: alb
+#     annotations:
+#       alb.ingress.kubernetes.io/scheme: internet-facing   # or internal
+#       alb.ingress.kubernetes.io/target-type: ip           # pods are VPC IPs
+#       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+#       alb.ingress.kubernetes.io/ssl-redirect: "443"
+#       alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:...
+#     tls: []
+#
+#   TLS on an ALB terminates against an ACM certificate named by that
+#   annotation, or one the controller matches to the rule host. It cannot read
+#   a Kubernetes TLS Secret, so `tls` stays empty.
+#
+#   ingress-nginx:
+#
+#     className: nginx
+#     annotations:
+#       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+#       nginx.ingress.kubernetes.io/proxy-body-size: 10m
+#     tls:
+#       - secretName: __PROJECT_NAME__-tls
+#         hosts:
+#           - __PROJECT_NAME__.example.com
+#
+#   A Secret-reading controller (ingress-nginx, Traefik, Contour) needs the
+#   `tls` list plus something that populates the Secret — cert-manager with an
+#   Issuer or ClusterIssuer you have created, or a Secret you manage yourself.
 ingress:
   enabled: true
-  className: nginx
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+  className: ""
+  annotations: {}
   hosts:
     - host: __PROJECT_NAME__.example.com
       paths:
         - path: /
           pathType: Prefix
-  tls:
-    - secretName: __PROJECT_NAME__-tls
-      hosts:
-        - __PROJECT_NAME__.example.com
+  tls: []
 
 autoscaling:
   enabled: true

--- a/templates/k8s-deploy/skeleton/k8s/ingress.yaml
+++ b/templates/k8s-deploy/skeleton/k8s/ingress.yaml
@@ -6,11 +6,27 @@ metadata:
   labels:
     app.kubernetes.io/name: __PROJECT_NAME__
     app.kubernetes.io/part-of: __PROJECT_NAME__
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+  # Annotations are controller-specific and there is no portable set, so none
+  # are set here. Add the block for whichever controller serves your class:
+  #
+  #   AWS Load Balancer Controller (what nanohype EKS clusters run):
+  #     alb.ingress.kubernetes.io/scheme: internet-facing
+  #     alb.ingress.kubernetes.io/target-type: ip
+  #     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+  #     alb.ingress.kubernetes.io/ssl-redirect: "443"
+  #     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:...
+  #
+  #   ingress-nginx:
+  #     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  #     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
 spec:
-  ingressClassName: nginx
+  # No `ingressClassName`: this template targets a generic cluster and names no
+  # controller, so the cluster's default IngressClass claims this object. Set it
+  # explicitly on a cluster with no default class — nanohype EKS clusters serve
+  # `alb` via the AWS Load Balancer Controller and do not mark it the default,
+  # so an unnamed Ingress there is created and then ignored by everything.
+  #
+  #   ingressClassName: alb
   rules:
     - host: __PROJECT_NAME__.example.com
       http:
@@ -22,7 +38,14 @@ spec:
                 name: __PROJECT_NAME__
                 port:
                   name: http
-  tls:
-    - hosts:
-        - __PROJECT_NAME__.example.com
-      secretName: __PROJECT_NAME__-tls
+  # TLS depends on the controller. An ALB terminates against an ACM certificate
+  # supplied by the certificate-arn annotation above, or one it matches to the
+  # rule host; it cannot read a Kubernetes Secret, so it needs no `tls` block.
+  # A Secret-reading controller — ingress-nginx, Traefik, Contour — needs one,
+  # plus something that populates the Secret: cert-manager with an Issuer or
+  # ClusterIssuer you have created, or a Secret you manage yourself.
+  #
+  #   tls:
+  #     - hosts:
+  #         - __PROJECT_NAME__.example.com
+  #       secretName: __PROJECT_NAME__-tls


### PR DESCRIPTION
Two skeletons hardcoded ingress-nginx. `k8s-deploy` set `className: nginx` with two `nginx.ingress.kubernetes.io/*` annotations and a `tls` block naming a Secret; `k8s-app-tenant` admitted ingress traffic through a namespaceSelector matching an `ingress-nginx` namespace. Both render an object no controller claims on a cluster without ingress-nginx, and the NetworkPolicy one fails even where a controller does exist.

## The class default decision

`k8s-deploy` now sets `className: ""` and `annotations: {}` rather than defaulting to `alb`, with the working block for each controller documented inline. An empty class renders an Ingress with no `ingressClassName`, which the cluster's default IngressClass claims.

Naming no controller, rather than naming this org's:

- `k8s-deploy` is the generic-cluster template — its own README says to use it "when targeting a generic cluster without those operators". Defaulting to `alb` would make a template that promises portable output emit AWS-specific annotations by default: the same defect in the other direction.
- It would also buy nothing. `k8s-app-tenant` — the template that *does* target those clusters — ships no Ingress at all, deliberately: ingress varies by workload topology, so the base chart leaves it to the app. No tenant scaffolds its Ingress from `k8s-deploy`.

The cost of an empty default is a silent no-op on a cluster with no default IngressClass, so the values comment says so directly and gives the class to name.

## k8s-deploy

`skeleton/chart/values.yaml` and `skeleton/k8s/ingress.yaml` carry the same commented guidance: the AWS Load Balancer Controller block (`alb`, scheme, `target-type: ip`, listen-ports, ssl-redirect, certificate-arn) and the ingress-nginx block, each with its TLS story. An ALB terminates against an ACM certificate and cannot read a Kubernetes Secret, so it takes no `tls` block; a Secret-reading controller needs the `tls` list plus something that fills the Secret. `tls` now defaults to empty instead of naming a Secret nothing creates.

## k8s-app-tenant

`skeleton/chart/values.yaml` replaces the ingress-controller namespaceSelector with `ipBlock: 10.0.0.0/8`, matching what the tenant charts run. A load balancer is not a pod: with `target-type: ip` the connection arrives from a load balancer network interface in the cluster VPC, so the source is a VPC address belonging to no namespace and a namespaceSelector drops it even where a controller is running. The comment says to narrow to per-env public subnet CIDRs, and how to swap back to a namespaceSelector where the controller runs as pods.

## Documentation

- `k8s-app-tenant/README.md` — the addon list named ingress-nginx among what eks-gitops supplies. It supplies the AWS Load Balancer Controller and Cilium; the line now says so, plus that `alb` must be requested by name and its TLS comes from ACM.
- `k8s-deploy/README.md` — the feature list described TLS via "nginx ingress controller"; now describes the controller-agnostic default.

## Verification

Both templates scaffolded through the SDK renderer and rendered: `helm lint` clean, `helm template` clean with ingress on and off and across all three per-env values files, `kubeconform` valid on every rendered resource plus the raw manifests, and zero nginx references in rendered output. `validate.sh` passes for every template; schema, standards, manifest, and catalog validation pass; the catalog regenerates byte-identical.

Left as-is: `infra-druid` (creates its own self-signed cert-manager Issuer, assumes no ClusterIssuer), `monitoring-stack` (ships its own Prometheus; the Alertmanager line is a suggestion for that self-contained bundle), and the kube-prometheus-stack references (already scoped to the local kx workspace where it runs).