### PR TITLE
feat: make the datastore declaration the platform-tenant contract

### DIFF
--- a/docs/platform-reference.md
+++ b/docs/platform-reference.md
@@ -25,7 +25,7 @@ Each one ships an `AGENTS.md` at its root. The machine-readable list is the SDK'
 | Repo                                                                            | Role                                                                                                                                                                                                                                                                                                                                                                 | Agent entry point              |
 | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | [`nanohype/nanohype`](https://github.com/nanohype/nanohype)                     | Template catalog + SDK + the public Platform Reference itself (this file)                                                                                                                                                                                                                                                                                            | [`AGENTS.md`](../AGENTS.md)    |
-| [`nanohype/landing-zone`](https://github.com/nanohype/landing-zone)             | OpenTofu/Terragrunt monorepo. Cloud substrate: VPC, base IAM, KMS, observability, per-app `<app>-platform` components                                                                                                                                                                                                                                                | `landing-zone/AGENTS.md`       |
+| [`nanohype/landing-zone`](https://github.com/nanohype/landing-zone)             | OpenTofu/Terragrunt monorepo. Cloud substrate: VPC, base IAM, KMS, observability, and the generic `tenant-substrate` module that provisions a tenant's datastores from `Platform.spec.datastores`                                                                                                                                                                                                                                                | `landing-zone/AGENTS.md`       |
 | [`nanohype/eks-gitops`](https://github.com/nanohype/eks-gitops)                 | ArgoCD addon catalog for EKS clusters (App-of-Apps pattern)                                                                                                                                                                                                                                                                                                          | `eks-gitops/AGENTS.md`         |
 | [`nanohype/eks-agent-platform`](https://github.com/nanohype/eks-agent-platform) | k8s-native control plane. Owns the `Platform` / `AgentFleet` / `ModelGateway` / `BudgetPolicy` / `EvalSuite` CRDs                                                                                                                                                                                                                                                    | `eks-agent-platform/AGENTS.md` |
 | [`nanohype/eks-fleet`](https://github.com/nanohype/eks-fleet) | Cluster factory. Vends EKS clusters via Crossplane from a `Cluster` API | `eks-fleet/AGENTS.md` |
@@ -37,7 +37,8 @@ Each one ships an `AGENTS.md` at its root. The machine-readable list is the SDK'
 The boundary between layers:
 
 - **Slow-moving cloud infra** (VPC, base IAM, KMS keys, cost pipeline, EventBridge, WAF) → `landing-zone`
-- **Per-tenant fast-moving AWS state** (IRSA roles, KMS grants, S3 bucket policies, Bedrock model-access) → `eks-agent-platform` operator reconciles via AWS SDK
+- **Per-tenant identity + access** (the tenant IAM role, its scoped datastore-access policy generated from `spec.datastores`, KMS grants, Bedrock model-access) → `eks-agent-platform` operator reconciles via AWS SDK
+- **Per-tenant stateful substrate** (databases, buckets, queues, caches, streams) → declared in `Platform.spec.datastores`, provisioned by the generic `tenant-substrate` landing-zone module — no per-app component
 - **Cluster addons** (cert-manager, external-secrets, Kyverno, observability) → `eks-gitops`
 - **Local development** → `kx` (kind cluster mirroring eks-gitops)
 - **Application logic** → templates from `nanohype/templates/` scaffolded into an `<app>/chart/` + `<app>/platform.yaml`
@@ -85,7 +86,7 @@ Each repo in the stack has an `AGENTS.md` at its root — short, agent-facing, a
 
 1. [`nanohype/AGENTS.md`](../AGENTS.md) — templates + SDK + catalog. The starting point.
 2. `eks-agent-platform/AGENTS.md` — the CRD surface. Platform / AgentFleet / ModelGateway / BudgetPolicy / EvalSuite. How to declare a tenant.
-3. `landing-zone/AGENTS.md` — cloud substrate. The `<app>-platform` per-app component pattern. OIDC trust setup.
+3. `landing-zone/AGENTS.md` — cloud substrate. The `tenant-substrate` module driven by `Platform.spec.datastores`. Pod Identity setup.
 4. `eks-gitops/AGENTS.md` — addon catalog. ApplicationSet entry shape. Sync waves.
 5. `eks-fleet/AGENTS.md` — the `Cluster` API. How a cluster gets vended.
 6. `kx/AGENTS.md` — local kind mirror. When to use it.

--- a/standards/platform-tenant-contract.json
+++ b/standards/platform-tenant-contract.json
@@ -28,7 +28,7 @@
       },
       {
         "path": "<app>/chart/templates/serviceaccount.yaml",
-        "description": "ServiceAccount used by the pod. It carries no role-arn annotation: the landing-zone <app>-platform component creates an EKS Pod Identity association binding this ServiceAccount to its IAM role. `serviceAccount.name` must be pinned to the app name so it matches the association's `service_account`."
+        "description": "ServiceAccount used by the pod. It carries no role-arn annotation: the eks-agent-platform operator creates an EKS Pod Identity association binding the tenant ServiceAccount to the per-Platform IAM role, whose scoped datastore-access policy the operator generates from Platform.spec.datastores. `serviceAccount.name` must match the tenant-runtime ServiceAccount the association targets."
       },
       {
         "path": "<app>/chart/templates/networkpolicy.yaml",
@@ -40,7 +40,7 @@
       },
       {
         "path": "<app>/platform.yaml",
-        "description": "Platform CR (and any required BudgetPolicy CR) declaring the tenant boundary. The CR objects live in the team namespace (metadata.namespace: tenants-<team>); the eks-agent-platform operator provisions a per-Platform WORKLOAD namespace named tenants-<platform-name> — where the app's chart deploys — plus its ResourceQuota, LimitRange, default-deny NetworkPolicy, the ArgoCD AppProject named <platform-name>, and the per-Platform IRSA role. The app's ApplicationSet entry must target that per-Platform namespace + project."
+        "description": "Platform CR (and any required BudgetPolicy CR) declaring the tenant boundary AND its stateful substrate (spec.datastores). The CR objects live in the team namespace (metadata.namespace: tenants-<team>); the eks-agent-platform operator provisions a per-Platform WORKLOAD namespace named tenants-<platform-name> — where the app's chart deploys — plus its ResourceQuota, LimitRange, default-deny NetworkPolicy, the ArgoCD AppProject named <platform-name>, and the per-Platform IAM role with a datastore-access policy generated from spec.datastores. The declared datastores themselves are provisioned by the generic tenant-substrate module from that same declaration — there is no per-app substrate component. The app's ApplicationSet entry must target that per-Platform namespace + project."
       },
       {
         "path": "<app>/agentfleet.yaml (AI workloads only)",
@@ -69,8 +69,27 @@
           "soc2": true,
           "hipaa": false
         },
-        "isolation": "namespace"
+        "isolation": "namespace",
+        "datastores": [
+          {
+            "name": "<short-name>",
+            "kind": "<one of: relational | keyValue | objectStore | queue | cache | stream>",
+            "deletionPolicy": "Retain"
+          }
+        ]
       }
+    },
+    "datastore_vocabulary": {
+      "summary": "Declare the tenant's stateful stores in spec.datastores instead of hand-writing a landing-zone component. Each entry names a datastore and its kind; the generic tenant-substrate module provisions the resource and the operator generates the scoped IAM to reach it, so tenant count is unbounded. Each kind carries at most the one typed config block matching it — omit it to take the young/light defaults. keyValue requires its block (a DynamoDB table has no default partition key); stream carries none.",
+      "kinds": {
+        "relational": "Aurora PostgreSQL Serverless v2. Config: engineVersion, minACU/maxACU (string, 0.5-ACU steps), backupRetentionDays, deletionProtection.",
+        "keyValue": "DynamoDB. Config (required): partitionKey {name,type}; optional sortKey, billingMode, ttlAttribute, pointInTimeRecovery, globalSecondaryIndexes.",
+        "objectStore": "S3. Config: versioning, lifecycleExpireDays.",
+        "queue": "SQS with an optional dead-letter queue. Config: fifo, visibilityTimeoutSeconds, messageRetentionSeconds, maxReceiveCount (>0 provisions the DLQ).",
+        "cache": "ElastiCache (Valkey/Redis). Config: engine, nodeType, replicas.",
+        "stream": "MSK Serverless with IAM auth. No config block."
+      },
+      "deletion": "deletionPolicy defaults to Retain: deleting the Platform CR orphans the datastore intact (it keeps the Tenant tag recording what owned it), and the operator holds no delete permission on any datastore. The per-kind deletion_protection backstop is a second gate, defaulting closed."
     },
     "otel_resource_attrs": [
       {
@@ -95,8 +114,8 @@
       }
     ],
     "do_not": [
-      "Do NOT scaffold IAM roles inside the chart, and do NOT annotate the ServiceAccount with a role ARN. The IAM role is provisioned by the corresponding landing-zone <app>-platform component, which also creates the EKS Pod Identity association that binds the ServiceAccount to it — the chart carries no role ARN.",
-      "Do NOT add cloud-substrate tofu (VPCs, base IAM, KMS keys) inside the app. Substrate lives in `nanohype/landing-zone` as a per-app `<app>-platform` component.",
+      "Do NOT scaffold IAM roles inside the chart, and do NOT annotate the ServiceAccount with a role ARN. The eks-agent-platform operator provisions the per-Platform IAM role — with a datastore-access policy generated from spec.datastores — and creates the EKS Pod Identity association that binds the tenant ServiceAccount to it. The chart carries no role ARN.",
+      "Do NOT hand-write a per-app landing-zone component for the tenant's databases, buckets, queues, caches, or streams. Declare them in Platform.spec.datastores — the generic tenant-substrate module provisions them and the operator generates the scoped IAM. Cloud-substrate GAPS the datastore vocabulary does not cover (a shared VPC, base IAM, a KMS key, a new addon) still land in `nanohype/landing-zone` or `nanohype/eks-gitops`, never in-app tofu.",
       "Do NOT add cluster-level addons in the chart (ingress controller, cert-manager, External Secrets, observability stack). Those are gitops-repo concerns in `nanohype/eks-gitops`.",
       "Do NOT skip per-env `values-{dev,staging,production}.yaml` — every chart has three deltas even if some are empty.",
       "Do NOT hardcode AWS account IDs, region names, or KMS key ARNs in chart values. Per-env values plumb them in from landing-zone outputs at deploy time."

--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -7,14 +7,14 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
 - **Helm chart** in `chart/` with `Chart.yaml`, `values.yaml`, per-env deltas (`values-development.yaml`, `values-staging.yaml`, `values-production.yaml`), and templates for:
   - `deployment.yaml` — non-root, read-only rootfs, distinct `/healthz` + `/readyz` probes, OTel resource attrs + OTLP wiring (`:4318`, `http/protobuf`), `terminationGracePeriodSeconds` headroom
   - `service.yaml` — ClusterIP
-  - `serviceaccount.yaml` — pod ServiceAccount, name pinned to the app name; bound to its IAM role by a landing-zone EKS Pod Identity association, so no role-arn annotation and never inline IAM
+  - `serviceaccount.yaml` — pod ServiceAccount, name pinned to the app name; bound to the per-Platform IAM role by an EKS Pod Identity association the operator creates from the Platform CR, so no role-arn annotation and never inline IAM
   - `networkpolicy.yaml` — default-deny + explicit egress allow-list (DNS + `:443`, IMDS blocked)
   - `externalsecret.yaml` — _(toggle, off by default)_ AWS Secrets Manager → k8s Secret via External Secrets Operator, mounted `envFrom`
   - `prometheusrule.yaml` — _(on by default)_ SLI recording rules + multi-window multi-burn-rate error-budget alerts (the `observability-slo` standard), driven by the `slo.*` values
   - `grafana-dashboard.yaml` + `dashboards/<app>.json` — _(on by default)_ a `GrafanaDashboard` CR (grafana-operator → external Amazon Managed Grafana): self-contained SRE board — SLO/error-budget row + traffic + errors + latency p50/p95/p99 + saturation
   - `servicemonitor.yaml` — _(toggle, off by default)_ Prometheus scrape for apps that expose `/metrics` instead of pushing via OTLP
 - **ApplicationSet entry** in `gitops/applicationset-entry.yaml` ready to copy into `nanohype/eks-gitops/applicationsets/`
-- **Platform CR** in `platform.yaml` — a `Platform` (`platform.nanohype.dev/v1alpha1`) plus its required `BudgetPolicy` (`governance.nanohype.dev/v1alpha1`). The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IRSA role (scoped to `spec.identity.allowedModelFamilies`); the BudgetPolicy drives the spend kill-switch
+- **Platform CR** in `platform.yaml` — a `Platform` (`platform.nanohype.dev/v1alpha1`) plus its required `BudgetPolicy` (`governance.nanohype.dev/v1alpha1`). The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IAM role (scoped to `spec.identity.allowedModelFamilies`, plus a datastore-access policy generated from `spec.datastores`); the tenant's declared datastores are provisioned by the generic `tenant-substrate` module; the BudgetPolicy drives the spend kill-switch
 - **Skeleton README** documenting how to apply the Platform CR, register the ApplicationSet entry, and roll out new versions
 
 ## Variables
@@ -47,7 +47,7 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
     templates/
       deployment.yaml
       service.yaml
-      serviceaccount.yaml          # name pinned to app; role bound via landing-zone Pod Identity association
+      serviceaccount.yaml          # name pinned to app; role bound via the operator's Pod Identity association
       networkpolicy.yaml           # default-deny + egress allow-list
       externalsecret.yaml          # toggle: Secrets Manager → k8s Secret (off by default)
       prometheusrule.yaml          # SLO recording rules + burn-rate alerts (on by default)
@@ -81,7 +81,7 @@ Compose with any of the application templates that produce a container-shipped s
 
 Designed to work with these repos already in place on the target cluster:
 
-- `nanohype/landing-zone` — provisions the EKS cluster, ArgoCD, base IAM, KMS keys, and the per-app `<app>-platform` component (IRSA role + Secrets Manager entries)
+- `nanohype/landing-zone` — provisions the EKS cluster, ArgoCD, base IAM, KMS keys, and the generic `tenant-substrate` module that provisions a tenant's declared datastores
 - `nanohype/eks-gitops` — supplies cluster addons (cert-manager, external-secrets, external-dns, the AWS Load Balancer Controller, Cilium, observability, Kyverno policies) and the ApplicationSet that picks up `gitops/applicationset-entry.yaml`. The load balancer controller is the cluster's only ingress implementation: it creates an `alb` IngressClass and does not mark it the cluster default, so any Ingress you add has to request `alb` by name, and its TLS terminates on the ALB against an ACM certificate rather than a Kubernetes Secret
 - `nanohype/eks-agent-platform` — runs the operator that reconciles your `platform.yaml`
 
@@ -92,7 +92,7 @@ If any of these are missing on the target cluster, the rendered app's `platform.
 1. Render: `helm template chart/ -f chart/values-development.yaml` (sanity)
 2. Apply the Platform + BudgetPolicy CRs: `kubectl apply -f platform.yaml`
 3. Wait for `Platform.status.phase = Ready`
-4. Set any per-env secret paths in `values-{env}.yaml`; the pod's IAM role is bound by the landing-zone `<app>-platform` component's EKS Pod Identity association (no role ARN in the chart)
+4. Set any per-env secret paths in `values-{env}.yaml`; the pod's IAM role is bound by the operator's EKS Pod Identity association, created from the Platform CR (no role ARN in the chart)
 5. Copy `gitops/applicationset-entry.yaml` into the gitops repo as a new entry in the appropriate ApplicationSet
 6. ArgoCD picks up the entry on next sync and rolls out the chart
 7. For new image tags: update `values-{env}.yaml` `image.tag`, commit, ArgoCD reconciles

--- a/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_serviceaccount.tpl
+++ b/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_serviceaccount.tpl
@@ -1,8 +1,8 @@
 {{/*
 ServiceAccount for the tenant's pods. Its AWS identity is bound out of band by
 an EKS Pod Identity association (namespace + ServiceAccount -> IAM role) created
-by landing-zone's <app>-platform component, so the pod assumes its role without
-any role-arn annotation and no inline IAM is defined here. The ServiceAccount
+by the eks-agent-platform operator from the Platform CR, so the pod assumes its
+role without any role-arn annotation and no inline IAM is defined here. The ServiceAccount
 name must match the association's `service_account`, so set `serviceAccount.name`
 to the app name (see values.yaml).
 

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -15,9 +15,10 @@ service:
 serviceAccount:
   create: true
   # Pinned to the app name so it matches the `service_account` of the EKS Pod
-  # Identity association that landing-zone's __APP_NAME__-platform component
-  # creates — that association binds this ServiceAccount to its IAM role, so the
-  # pod needs no role-arn annotation and the chart carries no AWS account values.
+  # Identity association the eks-agent-platform operator creates from the Platform
+  # CR — that association binds this ServiceAccount to the per-Platform IAM role,
+  # so the pod needs no role-arn annotation and the chart carries no AWS account
+  # values.
   name: __APP_NAME__
   # Extra annotations merged onto the ServiceAccount.
   annotations: {}

--- a/templates/k8s-app-tenant/skeleton/platform.yaml
+++ b/templates/k8s-app-tenant/skeleton/platform.yaml
@@ -8,14 +8,17 @@
 #   - ResourceQuota + LimitRange
 #   - Default-deny NetworkPolicy (the chart layers app-specific egress on top)
 #   - ArgoCD AppProject scoped to this Platform
-#   - Per-Platform IRSA role: a baseline policy + spec.identity.extraPolicyArns,
-#     scoped to the families in spec.identity.allowedModelFamilies
+#   - Per-Platform IAM role: a baseline policy + spec.identity.extraPolicyArns,
+#     scoped to the families in spec.identity.allowedModelFamilies, plus a
+#     datastore-access policy generated from spec.datastores
+# The datastores declared below are provisioned by the generic tenant-substrate
+# module from this same declaration — there is no per-app substrate component.
 # BudgetPolicy drives the spend kill-switch (fires at 120% of monthlyUsd when
 # killSwitchEnabled).
 #
-# The chart's pod identity is separate from this CR: the landing-zone
-# __APP_NAME__-platform component creates an EKS Pod Identity association binding
-# the chart's ServiceAccount to its IAM role, so the chart carries no role ARN.
+# The chart's pod identity comes from this CR: the eks-agent-platform operator
+# creates an EKS Pod Identity association binding the tenant ServiceAccount to
+# the per-Platform IAM role, so the chart carries no role ARN.
 #
 # Once Platform.status.phase is Ready, the ApplicationSet entry in __GITOPS_REPO__
 # takes over reconciling the chart.
@@ -58,3 +61,17 @@ spec:
     soc2: true
     hipaa: false
   isolation: namespace   # or vcluster for hard isolation
+  # Stateful substrate the tenant needs. Each entry names a datastore and its
+  # kind — relational | keyValue | objectStore | queue | cache | stream. The
+  # generic tenant-substrate module provisions each one and the operator
+  # generates the scoped IAM to reach it. Omit a kind's config block to take the
+  # young/light defaults (keyValue requires its partitionKey). deletionPolicy
+  # defaults to Retain, so deleting this CR orphans the datastore intact.
+  # Remove this block if the tenant has no stateful needs.
+  datastores:
+    - name: main
+      kind: relational
+    - name: events
+      kind: queue
+      queue:
+        maxReceiveCount: 3

--- a/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
@@ -1,8 +1,8 @@
 {{/*
 ServiceAccount for the tenant's pods. Its AWS identity is bound out of band by
 an EKS Pod Identity association (namespace + ServiceAccount -> IAM role) created
-by landing-zone's <app>-platform component, so the pod assumes its role without
-any role-arn annotation and no inline IAM is defined here. The ServiceAccount
+by the eks-agent-platform operator from the Platform CR, so the pod assumes its
+role without any role-arn annotation and no inline IAM is defined here. The ServiceAccount
 name must match the association's `service_account`, so set `serviceAccount.name`
 to the app name (see values.yaml).
 


### PR DESCRIPTION
Target 5 (nanohype side) of the tenant-substrate line. A tenant declares its stateful substrate in `Platform.spec.datastores` instead of a human hand-writing a landing-zone component per app — and the contract, the public Platform Reference, and the `k8s-app-tenant` template all describe this as the shape.

**`platform-tenant-contract.json`** — the CR shape gains a `datastores` array; a new `datastore_vocabulary` section names the six kinds (relational/keyValue/objectStore/queue/cache/stream), their config, and Retain-by-default deletion. The serviceaccount + `platform.yaml` artifact descriptions now say the operator creates the Pod Identity association and generates the scoped datastore-access policy from the declaration. The do-not list forbids a per-app substrate component — declare the stores; only gaps the vocabulary doesn't cover land in landing-zone/eks-gitops.

**Platform Reference** — the boundary table splits per-tenant identity (operator) from per-tenant stateful substrate (declared, provisioned by the `tenant-substrate` module); the landing-zone row and reading order drop the `<app>-platform` pattern.

**`k8s-app-tenant` template** — the scaffolded `platform.yaml` carries a `datastores` stanza with two examples; its comments, chart values, both serviceaccount partials, and the README describe the operator-created association and the generic module.

The fab side (the vendored contract copy + `PLATFORM_TENANT_CONTRACT` preamble + `CLAUDE.md`) follows in a companion PR. The org `CLAUDE.md` boundary section is corrected locally per T1.

Next (T6): the four apps declare `datastores` and their `<app>-platform` components are deleted.