### PR TITLE
feat: declare non-datastore capabilities; run tenants as the operator SA

### DIFF
--- a/docs/platform-reference.md
+++ b/docs/platform-reference.md
@@ -37,8 +37,9 @@ Each one ships an `AGENTS.md` at its root. The machine-readable list is the SDK'
 The boundary between layers:
 
 - **Slow-moving cloud infra** (VPC, base IAM, KMS keys, cost pipeline, EventBridge, WAF) → `landing-zone`
-- **Per-tenant identity + access** (the tenant IAM role, its scoped datastore-access policy generated from `spec.datastores`, KMS grants, Bedrock model-access) → `eks-agent-platform` operator reconciles via AWS SDK
+- **Per-tenant identity + access** (the tenant IAM role, its scoped datastore-access policy generated from `spec.datastores`, its capability-access policy generated from `spec.identity.capabilities`, KMS grants, Bedrock model-access) → `eks-agent-platform` operator reconciles via AWS SDK
 - **Per-tenant stateful substrate** (databases, buckets, queues, caches, streams) → declared in `Platform.spec.datastores`, provisioned by the generic `tenant-substrate` landing-zone module — no per-app component
+- **Per-tenant managed capabilities** (SES send, EventBridge Scheduler) → declared in `Platform.spec.identity.capabilities`, the operator generates the scoped grants (and mints the scheduler-invoke role) — no per-app policy
 - **Cluster addons** (cert-manager, external-secrets, Kyverno, observability) → `eks-gitops`
 - **Local development** → `kx` (kind cluster mirroring eks-gitops)
 - **Application logic** → templates from `nanohype/templates/` scaffolded into an `<app>/chart/` + `<app>/platform.yaml`

--- a/standards/platform-tenant-contract.json
+++ b/standards/platform-tenant-contract.json
@@ -63,7 +63,8 @@
         },
         "identity": {
           "allowedModelFamilies": ["anthropic"],
-          "extraPolicyArns": []
+          "extraPolicyArns": [],
+          "capabilities": []
         },
         "compliance": {
           "soc2": true,
@@ -91,6 +92,13 @@
       },
       "deletion": "deletionPolicy defaults to Retain: deleting the Platform CR orphans the datastore intact (it keeps the Tenant tag recording what owned it), and the operator holds no delete permission on any datastore. The per-kind deletion_protection backstop is a second gate, defaulting closed."
     },
+    "capability_vocabulary": {
+      "summary": "Managed AWS capabilities outside the datastore vocabulary — SES send, EventBridge Scheduler — are declared in spec.identity.capabilities. The operator generates the scoped IAM from that declaration (a capability-access policy on the tenant role, and for eventBridgeScheduler a minted scheduler-invoke role), so these ride the declaration too instead of a hand-written managed policy referenced by ARN.",
+      "capabilities": {
+        "ses": "Grants ses:SendEmail / ses:SendRawEmail scoped by a ses:FromAddress condition to the tenant's sending domain, plus ses:GetSendQuota. The verified sending identity is account-level mail infrastructure in landing-zone, not provisioned per app.",
+        "eventBridgeScheduler": "Grants scheduler:*Schedule on the tenant's own schedule prefix plus iam:PassRole (Scheduler-service-capped) on an operator-minted <env>-<platform>-scheduler-invoke role, which may SendMessage to the tenant's own queue datastores. Declare a queue datastore as the schedule's target."
+      }
+    },
     "otel_resource_attrs": [
       {
         "name": "agents.tenant",
@@ -116,6 +124,7 @@
     "do_not": [
       "Do NOT scaffold IAM roles inside the chart, and do NOT annotate the ServiceAccount with a role ARN. The eks-agent-platform operator provisions the per-Platform IAM role — with a datastore-access policy generated from spec.datastores — and creates the EKS Pod Identity association that binds the tenant ServiceAccount to it. The chart carries no role ARN.",
       "Do NOT hand-write a per-app landing-zone component for the tenant's databases, buckets, queues, caches, or streams. Declare them in Platform.spec.datastores — the generic tenant-substrate module provisions them and the operator generates the scoped IAM. Cloud-substrate GAPS the datastore vocabulary does not cover (a shared VPC, base IAM, a KMS key, a new addon) still land in `nanohype/landing-zone` or `nanohype/eks-gitops`, never in-app tofu.",
+      "Do NOT reference a hand-written managed policy through extraPolicyArns for SES or EventBridge Scheduler. Declare them in Platform.spec.identity.capabilities — the operator generates the scoped grants (and mints the scheduler-invoke role). extraPolicyArns stays the escape hatch only for grants outside both the datastore and capability vocabularies.",
       "Do NOT add cluster-level addons in the chart (ingress controller, cert-manager, External Secrets, observability stack). Those are gitops-repo concerns in `nanohype/eks-gitops`.",
       "Do NOT skip per-env `values-{dev,staging,production}.yaml` — every chart has three deltas even if some are empty.",
       "Do NOT hardcode AWS account IDs, region names, or KMS key ARNs in chart values. Per-env values plumb them in from landing-zone outputs at deploy time."

--- a/templates/k8s-app-tenant/README.md
+++ b/templates/k8s-app-tenant/README.md
@@ -7,14 +7,14 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
 - **Helm chart** in `chart/` with `Chart.yaml`, `values.yaml`, per-env deltas (`values-development.yaml`, `values-staging.yaml`, `values-production.yaml`), and templates for:
   - `deployment.yaml` — non-root, read-only rootfs, distinct `/healthz` + `/readyz` probes, OTel resource attrs + OTLP wiring (`:4318`, `http/protobuf`), `terminationGracePeriodSeconds` headroom
   - `service.yaml` — ClusterIP
-  - `serviceaccount.yaml` — pod ServiceAccount, name pinned to the app name; bound to the per-Platform IAM role by an EKS Pod Identity association the operator creates from the Platform CR, so no role-arn annotation and never inline IAM
+  - `serviceaccount.yaml` — references the operator-owned `tenant-runtime` ServiceAccount (`serviceAccount.create: false`); the operator binds it to the per-Platform IAM role with an EKS Pod Identity association from the Platform CR, so no role-arn annotation and never inline IAM
   - `networkpolicy.yaml` — default-deny + explicit egress allow-list (DNS + `:443`, IMDS blocked)
   - `externalsecret.yaml` — _(toggle, off by default)_ AWS Secrets Manager → k8s Secret via External Secrets Operator, mounted `envFrom`
   - `prometheusrule.yaml` — _(on by default)_ SLI recording rules + multi-window multi-burn-rate error-budget alerts (the `observability-slo` standard), driven by the `slo.*` values
   - `grafana-dashboard.yaml` + `dashboards/<app>.json` — _(on by default)_ a `GrafanaDashboard` CR (grafana-operator → external Amazon Managed Grafana): self-contained SRE board — SLO/error-budget row + traffic + errors + latency p50/p95/p99 + saturation
   - `servicemonitor.yaml` — _(toggle, off by default)_ Prometheus scrape for apps that expose `/metrics` instead of pushing via OTLP
 - **ApplicationSet entry** in `gitops/applicationset-entry.yaml` ready to copy into `nanohype/eks-gitops/applicationsets/`
-- **Platform CR** in `platform.yaml` — a `Platform` (`platform.nanohype.dev/v1alpha1`) plus its required `BudgetPolicy` (`governance.nanohype.dev/v1alpha1`). The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IAM role (scoped to `spec.identity.allowedModelFamilies`, plus a datastore-access policy generated from `spec.datastores`); the tenant's declared datastores are provisioned by the generic `tenant-substrate` module; the BudgetPolicy drives the spend kill-switch
+- **Platform CR** in `platform.yaml` — a `Platform` (`platform.nanohype.dev/v1alpha1`) plus its required `BudgetPolicy` (`governance.nanohype.dev/v1alpha1`). The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, the operator-owned `tenant-runtime` ServiceAccount, and the per-Platform IAM role (scoped to `spec.identity.allowedModelFamilies`, plus a datastore-access policy generated from `spec.datastores` and a capability-access policy generated from `spec.identity.capabilities`); the tenant's declared datastores are provisioned by the generic `tenant-substrate` module; the BudgetPolicy drives the spend kill-switch
 - **Skeleton README** documenting how to apply the Platform CR, register the ApplicationSet entry, and roll out new versions
 
 ## Variables
@@ -47,7 +47,7 @@ Primary scaffolding for a nanohype-org k8s-native application. Produces a Helm c
     templates/
       deployment.yaml
       service.yaml
-      serviceaccount.yaml          # name pinned to app; role bound via the operator's Pod Identity association
+      serviceaccount.yaml          # references operator-owned tenant-runtime; role bound via Pod Identity
       networkpolicy.yaml           # default-deny + egress allow-list
       externalsecret.yaml          # toggle: Secrets Manager → k8s Secret (off by default)
       prometheusrule.yaml          # SLO recording rules + burn-rate alerts (on by default)

--- a/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_serviceaccount.tpl
+++ b/templates/k8s-app-tenant/skeleton/chart/charts/tenant-chart-base/templates/_serviceaccount.tpl
@@ -1,10 +1,13 @@
 {{/*
-ServiceAccount for the tenant's pods. Its AWS identity is bound out of band by
-an EKS Pod Identity association (namespace + ServiceAccount -> IAM role) created
-by the eks-agent-platform operator from the Platform CR, so the pod assumes its
-role without any role-arn annotation and no inline IAM is defined here. The ServiceAccount
-name must match the association's `service_account`, so set `serviceAccount.name`
-to the app name (see values.yaml).
+ServiceAccount for the tenant's pods. The operator creates and owns the
+`tenant-runtime` ServiceAccount in the workload namespace and binds it to the
+per-Platform IAM role with an EKS Pod Identity association, so the pod assumes
+its role with no role-arn annotation and no inline IAM here. The chart therefore
+references that SA (serviceAccount.create: false, name: tenant-runtime) rather
+than minting its own — an SA the chart created would get no association and no
+credentials. This partial renders a chart-owned SA only if serviceAccount.create
+is set true (an externally-managed-association escape hatch), and is inert
+otherwise.
 
 Usage (consumer templates/serviceaccount.yaml):
   {{ include "tenant-chart-base.serviceaccount" . }}

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -13,14 +13,15 @@ service:
   targetPort: __PORT__
 
 serviceAccount:
-  create: true
-  # Pinned to the app name so it matches the `service_account` of the EKS Pod
-  # Identity association the eks-agent-platform operator creates from the Platform
-  # CR — that association binds this ServiceAccount to the per-Platform IAM role,
-  # so the pod needs no role-arn annotation and the chart carries no AWS account
-  # values.
-  name: __APP_NAME__
-  # Extra annotations merged onto the ServiceAccount.
+  # The eks-agent-platform operator creates and owns the `tenant-runtime`
+  # ServiceAccount in the workload namespace and binds it to the per-Platform IAM
+  # role via an EKS Pod Identity association — so the pod runs as it with no
+  # role-arn annotation and the chart carries no AWS account values. The chart
+  # references that SA rather than minting its own: an SA the chart created would
+  # get no association and therefore no credentials.
+  create: false
+  name: tenant-runtime
+  # Extra annotations merged onto the ServiceAccount (only used if create: true).
   annotations: {}
 
 resources:

--- a/templates/k8s-app-tenant/skeleton/platform.yaml
+++ b/templates/k8s-app-tenant/skeleton/platform.yaml
@@ -10,15 +10,17 @@
 #   - ArgoCD AppProject scoped to this Platform
 #   - Per-Platform IAM role: a baseline policy + spec.identity.extraPolicyArns,
 #     scoped to the families in spec.identity.allowedModelFamilies, plus a
-#     datastore-access policy generated from spec.datastores
+#     datastore-access policy generated from spec.datastores and a
+#     capability-access policy generated from spec.identity.capabilities
 # The datastores declared below are provisioned by the generic tenant-substrate
 # module from this same declaration — there is no per-app substrate component.
 # BudgetPolicy drives the spend kill-switch (fires at 120% of monthlyUsd when
 # killSwitchEnabled).
 #
 # The chart's pod identity comes from this CR: the eks-agent-platform operator
-# creates an EKS Pod Identity association binding the tenant ServiceAccount to
-# the per-Platform IAM role, so the chart carries no role ARN.
+# creates and owns the `tenant-runtime` ServiceAccount and binds it to the
+# per-Platform IAM role via an EKS Pod Identity association, so the pod runs as
+# it and the chart carries no role ARN (serviceAccount.create: false).
 #
 # Once Platform.status.phase is Ready, the ApplicationSet entry in __GITOPS_REPO__
 # takes over reconciling the chart.
@@ -56,7 +58,18 @@ spec:
     allowedModelFamilies:
       - anthropic
     # Extra managed IAM policies attached on top of the per-tenant baseline.
+    # The escape hatch for grants outside both the datastore and capability
+    # vocabularies — not for SES or EventBridge Scheduler, which are capabilities.
     extraPolicyArns: []
+    # Managed AWS capabilities the datastore vocabulary doesn't cover; the
+    # operator generates the scoped grants from this list. Omit the field if the
+    # tenant needs none.
+    #   ses                  — send email (ses:SendEmail, FromAddress-scoped to
+    #                          the tenant's sending domain)
+    #   eventBridgeScheduler — create + fire schedules; the operator mints the
+    #                          scheduler-invoke role targeting the tenant's queues
+    # capabilities:
+    #   - ses
   compliance:
     soc2: true
     hipaa: false

--- a/templates/tenant-chart-base/README.md
+++ b/templates/tenant-chart-base/README.md
@@ -6,7 +6,7 @@ A Helm **library chart** (`type: library`) holding the named templates every nan
 
 A `chart/` directory containing a library chart with these named templates (all in `templates/_*.tpl`):
 
-- `tenant-chart-base.serviceaccount` — the pod's ServiceAccount. No role-arn annotation and no inline IAM: landing-zone binds it to its IAM role with an EKS Pod Identity association, so `serviceAccount.name` is pinned to the app name to match.
+- `tenant-chart-base.serviceaccount` — the pod's ServiceAccount. No role-arn annotation and no inline IAM: the eks-agent-platform operator creates and owns the `tenant-runtime` ServiceAccount and binds it to the per-Platform IAM role with an EKS Pod Identity association, so the chart references it (`serviceAccount.create: false`, `name: tenant-runtime`) rather than minting its own — a chart-created SA would get no association and no credentials. The partial renders a chart-owned SA only if `serviceAccount.create` is set true.
 - `tenant-chart-base.networkpolicy` — the NetworkPolicy CR scaffold with values-driven `ingress` (varies by workload topology) and `egress` (the DNS + HTTPS-out baseline).
 - `tenant-chart-base.prometheusrule` — the PrometheusRule CR scaffold. Per the `observability-slo` standard it renders SLI recording rules over the burn-rate windows plus multi-window multi-burn-rate error-budget alerts (2 page, 2 ticket) from the `slo.*` values. `prometheusRule.groups` overrides it verbatim for latency or custom-shaped SLOs.
 - `tenant-chart-base.serviceMonitor` — an optional ServiceMonitor for apps that expose a Prometheus `/metrics` endpoint. Off by default (the baseline pushes metrics via OTLP to the cluster collector — the standard's equivalent scrape config).

--- a/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
+++ b/templates/tenant-chart-base/skeleton/chart/templates/_serviceaccount.tpl
@@ -1,10 +1,13 @@
 {{/*
-ServiceAccount for the tenant's pods. Its AWS identity is bound out of band by
-an EKS Pod Identity association (namespace + ServiceAccount -> IAM role) created
-by the eks-agent-platform operator from the Platform CR, so the pod assumes its
-role without any role-arn annotation and no inline IAM is defined here. The ServiceAccount
-name must match the association's `service_account`, so set `serviceAccount.name`
-to the app name (see values.yaml).
+ServiceAccount for the tenant's pods. The operator creates and owns the
+`tenant-runtime` ServiceAccount in the workload namespace and binds it to the
+per-Platform IAM role with an EKS Pod Identity association, so the pod assumes
+its role with no role-arn annotation and no inline IAM here. The chart therefore
+references that SA (serviceAccount.create: false, name: tenant-runtime) rather
+than minting its own — an SA the chart created would get no association and no
+credentials. This partial renders a chart-owned SA only if serviceAccount.create
+is set true (an externally-managed-association escape hatch), and is inert
+otherwise.
 
 Usage (consumer templates/serviceaccount.yaml):
   {{ include "tenant-chart-base.serviceaccount" . }}


### PR DESCRIPTION
## What

Completes the picture the datastore vocabulary started, on the contract + template surface:

1. **Capability vocabulary** — `spec.identity.capabilities` (`ses`, `eventBridgeScheduler`) is now the declaration for the AWS grants outside the datastore vocabulary. The operator generates a `capability-access` policy on the tenant role — and, for `eventBridgeScheduler`, mints the scheduler-invoke role targeting the tenant's own queues — instead of the tenant referencing a hand-written managed policy through `extraPolicyArns`. Landed in `platform-tenant-contract.json` (new field + `capability_vocabulary` section + do-not bullet), the Platform Reference boundary table, and the `k8s-app-tenant` `platform.yaml` (commented example).

2. **ServiceAccount** — the chart references the operator-owned `tenant-runtime` ServiceAccount (`serviceAccount.create: false`, `name: tenant-runtime`) rather than minting its own. The operator creates that SA and Pod-Identity-binds it to the per-Platform IAM role; a chart-created SA would get no association and no credentials. `tenant-chart-base`'s partial stays an escape hatch — inert unless `serviceAccount.create` is set true — and the vendored copy is re-synced.

## Gates

`validate:standards`, `verify:catalog`, `verify:library`, the `k8s-app-tenant` template validation, and markdownlint on the touched reference doc all pass locally.