### PR TITLE
feat: document directSecretReads in the tenant contract

### DIFF
--- a/docs/platform-reference.md
+++ b/docs/platform-reference.md
@@ -40,6 +40,7 @@ The boundary between layers:
 - **Per-tenant identity + access** (the tenant IAM role, its scoped datastore-access policy generated from `spec.datastores`, its capability-access policy generated from `spec.identity.capabilities`, KMS grants, Bedrock model-access) → `eks-agent-platform` operator reconciles via AWS SDK
 - **Per-tenant stateful substrate** (databases, buckets, queues, caches, streams) → declared in `Platform.spec.datastores`, provisioned by the generic `tenant-substrate` landing-zone module — no per-app component
 - **Per-tenant managed capabilities** (SES send, EventBridge Scheduler) → declared in `Platform.spec.identity.capabilities`, the operator generates the scoped grants (and mints the scheduler-invoke role) — no per-app policy
+- **Per-tenant secret reads** → secrets projected into the pod by the chart's `ExternalSecret` are read by the External Secrets controller's own identity (no tenant-role grant); the few a pod reads itself via the SDK are declared in `Platform.spec.identity.directSecretReads`, and the operator grants read on exactly those
 - **Cluster addons** (cert-manager, external-secrets, Kyverno, observability) → `eks-gitops`
 - **Local development** → `kx` (kind cluster mirroring eks-gitops)
 - **Application logic** → templates from `nanohype/templates/` scaffolded into an `<app>/chart/` + `<app>/platform.yaml`

--- a/standards/platform-tenant-contract.json
+++ b/standards/platform-tenant-contract.json
@@ -64,7 +64,8 @@
         "identity": {
           "allowedModelFamilies": ["anthropic"],
           "extraPolicyArns": [],
-          "capabilities": []
+          "capabilities": [],
+          "directSecretReads": []
         },
         "compliance": {
           "soc2": true,
@@ -99,6 +100,10 @@
         "eventBridgeScheduler": "Grants scheduler:*Schedule on the tenant's own schedule prefix plus iam:PassRole (Scheduler-service-capped) on an operator-minted <env>-<platform>-scheduler-invoke role, which may SendMessage to the tenant's own queue datastores. Declare a queue datastore as the schedule's target."
       }
     },
+    "secret_access": {
+      "summary": "Most secret material reaches a tenant through the chart's ExternalSecret, projected by the cluster's External Secrets controller under its own identity — the tenant role needs no Secrets Manager grant for those. Only the secrets a pod resolves itself through the pod role via the AWS SDK are declared in spec.identity.directSecretReads, and the operator grants secretsmanager:GetSecretValue / DescribeSecret on exactly those.",
+      "directSecretReads": "A list of secret names under the tenant's own <platform>/<env>/ prefix (e.g. \"grafana/oncall-webhook-hmac\"). Use it for the values a pod reads directly rather than by ExternalSecret projection — rotation-sensitive secrets a handler re-fetches and caches by version, or config bulk-loaded at startup. Each entry scopes to arn:...:secret:<platform>/<env>/<name>-*; leaving it empty means the tenant role holds no Secrets Manager grant at all."
+    },
     "otel_resource_attrs": [
       {
         "name": "agents.tenant",
@@ -125,6 +130,7 @@
       "Do NOT scaffold IAM roles inside the chart, and do NOT annotate the ServiceAccount with a role ARN. The eks-agent-platform operator provisions the per-Platform IAM role — with a datastore-access policy generated from spec.datastores — and creates the EKS Pod Identity association that binds the tenant ServiceAccount to it. The chart carries no role ARN.",
       "Do NOT hand-write a per-app landing-zone component for the tenant's databases, buckets, queues, caches, or streams. Declare them in Platform.spec.datastores — the generic tenant-substrate module provisions them and the operator generates the scoped IAM. Cloud-substrate GAPS the datastore vocabulary does not cover (a shared VPC, base IAM, a KMS key, a new addon) still land in `nanohype/landing-zone` or `nanohype/eks-gitops`, never in-app tofu.",
       "Do NOT reference a hand-written managed policy through extraPolicyArns for SES or EventBridge Scheduler. Declare them in Platform.spec.identity.capabilities — the operator generates the scoped grants (and mints the scheduler-invoke role). extraPolicyArns stays the escape hatch only for grants outside both the datastore and capability vocabularies.",
+      "Do NOT rely on a broad Secrets Manager grant for the tenant role. Secrets projected into the pod by the chart's ExternalSecret need no grant at all (the External Secrets controller reads them under its own identity); for the few a pod reads itself via the SDK, list them in Platform.spec.identity.directSecretReads so the operator grants read on exactly those.",
       "Do NOT add cluster-level addons in the chart (ingress controller, cert-manager, External Secrets, observability stack). Those are gitops-repo concerns in `nanohype/eks-gitops`.",
       "Do NOT skip per-env `values-{dev,staging,production}.yaml` — every chart has three deltas even if some are empty.",
       "Do NOT hardcode AWS account IDs, region names, or KMS key ARNs in chart values. Per-env values plumb them in from landing-zone outputs at deploy time."

--- a/templates/k8s-app-tenant/skeleton/platform.yaml
+++ b/templates/k8s-app-tenant/skeleton/platform.yaml
@@ -70,6 +70,12 @@ spec:
     #                          scheduler-invoke role targeting the tenant's queues
     # capabilities:
     #   - ses
+    # Secrets the pod reads itself via the AWS SDK, named under the tenant's own
+    # <platform>/<env>/ prefix; the operator grants read on exactly these. Most
+    # secrets arrive via the chart's ExternalSecret (projected by the cluster's
+    # External Secrets controller) and need no entry — omit the field for those.
+    # directSecretReads:
+    #   - grafana/oncall-webhook-hmac
   compliance:
     soc2: true
     hipaa: false


### PR DESCRIPTION
## What

The Platform tenant contract now covers how a tenant's pods reach Secrets Manager.

Most secret material arrives through the chart's `ExternalSecret`, read by the cluster's External Secrets controller under its own identity — the tenant role needs no grant for those. The few secrets a pod resolves itself via the AWS SDK are declared in `spec.identity.directSecretReads`, and the operator grants read on exactly those under the tenant's own `<platform>/<env>/` prefix.

## Changes

- `standards/platform-tenant-contract.json`: `directSecretReads` in the identity example, a `secret_access` section describing the field and the `ExternalSecret` split, and a do-not against a broad tenant-role grant.
- `docs/platform-reference.md`: boundary list gains a per-tenant secret-reads row.
- `templates/k8s-app-tenant/skeleton/platform.yaml`: a commented `directSecretReads` example in the identity block.

Pairs with the operator field (`eks-agent-platform`) and the fab preamble copy.