### PR TITLE
feat: require BackupPolicy on backup-eligible resource kinds

### DIFF
--- a/schemas/standards.schema.json
+++ b/schemas/standards.schema.json
@@ -317,6 +317,34 @@
                 "type": "object",
                 "required": ["aws", "k8s", "otel"],
                 "additionalProperties": { "type": "array", "items": { "type": "string" } }
+              },
+              "conditional_requirements": {
+                "type": "array",
+                "description": "Tags required only on certain resource kinds, not universally.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "dimension",
+                    "surface",
+                    "tag",
+                    "required_on_kinds",
+                    "value",
+                    "rationale"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "dimension": { "type": "string" },
+                    "surface": { "type": "string", "enum": ["aws", "k8s", "otel"] },
+                    "tag": { "type": "string" },
+                    "required_on_kinds": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": { "type": "string" }
+                    },
+                    "value": { "type": "string" },
+                    "rationale": { "type": "string" }
+                  }
+                }
               }
             }
           }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -296,7 +296,24 @@ export interface ResourceTaggingStandard {
     };
     dimensions: TagDimension[];
     required_by_surface: Record<"aws" | "k8s" | "otel", string[]>;
+    /**
+     * Tags required only on certain resource kinds, not universally. Each entry names a
+     * dimension, the surface + tag it renders as, and the resource kinds it is required on —
+     * e.g. BackupPolicy on backup-eligible kinds, without which a resource is silently
+     * unprotected. Optional: absent on standards versions predating conditional requirements.
+     */
+    conditional_requirements?: ConditionalTagRequirement[];
   };
+}
+
+/** A tag required only on certain resource kinds (see ResourceTaggingStandard). */
+export interface ConditionalTagRequirement {
+  dimension: string;
+  surface: "aws" | "k8s" | "otel";
+  tag: string;
+  required_on_kinds: string[];
+  value: string;
+  rationale: string;
 }
 
 /** One SLI definition: the good/valid ratio and its default objective. */

--- a/standards/resource-tagging.json
+++ b/standards/resource-tagging.json
@@ -3,7 +3,7 @@
   "kind": "nanohype/standards/resource-tagging",
   "version": "1",
   "title": "Resource tagging and labeling standard",
-  "summary": "The canonical org-wide tag/label taxonomy every cloud resource and k8s object on the nanohype stack carries. Defines vendor-neutral dimensions, their per-surface rendering (AWS tag keys, k8s labels, OTel attributes), the deterministic casing transforms, the reserved namespaces, and which dimensions are required. cloudgov reads the required-tier keys from this file to gate CI; landing-zone and the eks-agent-platform operator inject them; tenant charts label workloads from it.",
+  "summary": "The canonical org-wide tag/label taxonomy every cloud resource and k8s object on the nanohype stack carries. Defines vendor-neutral dimensions, their per-surface rendering (AWS tag keys, k8s labels, OTel attributes), the deterministic casing transforms, the reserved namespaces, which dimensions are required, and conditional requirements — tags required only on certain resource kinds, such as BackupPolicy on backup-eligible kinds, without which a resource is silently unprotected. cloudgov reads the required-tier keys from this file to gate CI; landing-zone and the eks-agent-platform operator inject them; tenant charts label workloads from it.",
   "content": {
     "transforms": {
       "aws": "Render the canonical kebab-case id as PascalCase (split on '-', capitalize each part, join). cost-center -> CostCenter.",
@@ -215,6 +215,16 @@
           "k8s": null,
           "otel": "agents.model_id"
         }
+      },
+      {
+        "id": "backup-policy",
+        "tier": "contextual",
+        "meaning": "The AWS Backup plan key whose vault selection tag-matches this resource, so it is protected. Cloud tag only. Required on backup-eligible resource kinds (see conditional_requirements): a backup-eligible resource without this tag is silently unprotected — the tag-based selection never picks it up and nothing errors until a restore is attempted. tenant-substrate stamps it on every datastore from spec.datastores; anything created outside a component is caught by the eks-gitops Kyverno rule and cloudgov.",
+        "render": {
+          "aws": "BackupPolicy",
+          "k8s": null,
+          "otel": null
+        }
       }
     ],
     "required_by_surface": {
@@ -237,6 +247,16 @@
         "platform.nanohype.dev/team"
       ],
       "otel": ["agents.tenant", "agents.platform"]
-    }
+    },
+    "conditional_requirements": [
+      {
+        "dimension": "backup-policy",
+        "surface": "aws",
+        "tag": "BackupPolicy",
+        "required_on_kinds": ["Aurora", "RDS", "DynamoDB", "S3", "EFS"],
+        "value": "The AWS Backup plan key (e.g. \"daily\") whose vault selection tag-matches this value.",
+        "rationale": "A backup-eligible resource without a BackupPolicy tag is silently unprotected — the tag-based backup selection never selects it, and nothing errors until a restore is attempted. This is the highest-probability coverage failure because it produces no signal. Enforced preventively where the resource is minted (tenant-substrate stamps it from spec.datastores) and detectively by the eks-gitops Kyverno rule and cloudgov, which flag a backup-eligible resource of one of required_on_kinds that lacks the tag."
+      }
+    ]
   }
 }


### PR DESCRIPTION
Target 5a of the central-backup campaign — the declaration behind backup-coverage enforcement.

A backup-eligible resource without a `BackupPolicy` tag is **silently unprotected**: AWS Backup's tag-based vault selection never selects it, nothing errors, and the gap is invisible until a restore is attempted. It's the highest-probability coverage failure because it produces no signal at all.

## What changed

The `resource-tagging` standard gains:
- a **`backup-policy` dimension** (the AWS `BackupPolicy` tag), tier `contextual` — a cloud tag only;
- a **`conditional_requirements`** section declaring it required on the backup-eligible kinds: **Aurora, RDS, DynamoDB, S3, EFS**.

Conditional requirements are tags required only on certain resource kinds, not universally — so `BackupPolicy` deliberately does **not** enter `required_by_surface` (which would demand it on every resource and fail the tagging-consistency check). The scope is the kinds that can actually carry a recovery point.

The standards schema describes the new section, and the SDK exposes it as an optional `ConditionalTagRequirement[]` for typed consumers.

## Enforcement (this file is the source those readers consume)

- **Preventive** — `tenant-substrate` already stamps `BackupPolicy` on every datastore from `spec.datastores`.
- **Detective** — the eks-gitops Kyverno rule and cloudgov flag a backup-eligible resource that lacks it (shipping in follow-up targets).

## Verification

`validate:standards` (schema + the tagging-consistency cross-check) passes, biome clean, SDK typecheck + 135 tests green, mcp-server typecheck + 50 tests green.