### PR TITLE
Point tenant OTLP export at the collector gateway's stable Service

### DIFF
--- a/templates/k8s-app-tenant/skeleton/chart/templates/deployment.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/deployment.yaml
@@ -46,9 +46,9 @@ spec:
               value: {{ $v | quote }}
             {{- end }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "http://otel-collector.observability.svc.cluster.local:4318"
+              value: {{ .Values.otel.endpoint | quote }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: "http/protobuf"
+              value: {{ .Values.otel.protocol | quote }}
           {{- if .Values.externalSecret.enabled }}
           envFrom:
             - secretRef:

--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -175,6 +175,10 @@ serviceMonitor:
 # OTel Collector tags downstream exporters using these.
 otel:
   enabled: true
+  # The cluster's OpenTelemetry Collector gateway, addressed by its stable,
+  # implementation-neutral Service alias. Override only for a non-default collector.
+  endpoint: "http://telemetry.monitoring.svc.cluster.local:4318"
+  protocol: "http/protobuf"
   resourceAttributes:
     agents.tenant: __TENANT__
     agents.platform: __APP_NAME__

--- a/templates/slack-bot/skeleton/Dockerfile
+++ b/templates/slack-bot/skeleton/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV=production
 # before user code, exporting to the cluster collector. Requires
 # @opentelemetry/auto-instrumentations-node in production deps.
 ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
-ENV OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector.observability.svc.cluster.local:4318"
+ENV OTEL_EXPORTER_OTLP_ENDPOINT="http://telemetry.monitoring.svc.cluster.local:4318"
 ENV OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 
 COPY package.json package-lock.json* ./


### PR DESCRIPTION
Generated tenant workloads export OpenTelemetry data to `telemetry.monitoring.svc.cluster.local` — the stable, implementation-neutral Service alias in front of the cluster's OpenTelemetry Collector gateway.

The `k8s-app-tenant` chart exposes the endpoint and protocol as `otel` values (so a tenant can retarget a non-default collector), and the `slack-bot` image carries the same default for its auto-instrumentation. Both previously pointed at a service name and namespace that no cluster serves.

`./scripts/validate.sh` passes for both affected templates.