### PR TITLE
Allow tenant OTLP egress to the collector gateway by default

### DIFF
--- a/templates/k8s-app-tenant/skeleton/chart/values.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/values.yaml
@@ -109,6 +109,16 @@ networkPolicy:
       ports:
         - protocol: TCP
           port: 443
+    # OTLP export to the cluster's OpenTelemetry Collector gateway
+    # (telemetry.monitoring.svc:4318). Required whenever otel.enabled renders
+    # OTEL_EXPORTER_OTLP_ENDPOINT; a gRPC tenant (otel.protocol grpc) adds 4317.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 4318
 
 # Secret material via External Secrets Operator (the eks-gitops external-secrets
 # addon provisions the `aws-secrets-manager` ClusterSecretStore). Off by default —
@@ -128,9 +138,10 @@ externalSecret:
 # (set it to a non-empty list and it is emitted verbatim instead of the SLO default).
 #
 # Off by default: a PrometheusRule is inert without a Prometheus Operator to
-# evaluate it, and the managed-Prometheus stack this platform runs (grafana-agent
-# scraping pod annotations into Amazon Managed Prometheus, alerting in Amazon
-# Managed Grafana) doesn't run one. Set `enabled: true` on a cluster that does —
+# evaluate it, and the managed-Prometheus stack this platform runs (the
+# OpenTelemetry Collector agent scraping pod annotations into Amazon Managed
+# Prometheus, alerting in Amazon Managed Grafana) doesn't run one. Set
+# `enabled: true` on a cluster that does —
 # e.g. the local kx workspace with kube-prometheus-stack.
 prometheusRule:
   enabled: false


### PR DESCRIPTION
The `k8s-app-tenant` chart always renders `OTEL_EXPORTER_OTLP_ENDPOINT` (`otel.enabled` defaults true), but the default `networkPolicy.egress` permitted only DNS and HTTPS. Under default-deny, a freshly scaffolded tenant's telemetry export to `telemetry.monitoring.svc:4318` was silently dropped — the app stays healthy, no telemetry arrives.

Adds a TCP 4318 egress rule to the `monitoring` namespace so a fresh tenant exports out of the box (a gRPC tenant adds 4317). Also refreshes the `prometheusRule` comment, which still described the metrics stack as grafana-agent scraping into AMP — it's the OpenTelemetry Collector agent.

`./scripts/validate.sh` passes.