### PR TITLE
feat: pin the burn-rate windows against the operator, not just the alerts

### DIFF
--- a/.github/workflows/slo-constants.yml
+++ b/.github/workflows/slo-constants.yml
@@ -4,25 +4,29 @@ on:
   push:
     branches: [main]
     paths:
-      - 'standards/observability-slo.json'
-      - 'scripts/check-slo-constants.mjs'
-      - '.github/workflows/slo-constants.yml'
+      - "standards/observability-slo.json"
+      - "scripts/check-slo-constants.mjs"
+      - ".github/workflows/slo-constants.yml"
   pull_request:
     paths:
-      - 'standards/observability-slo.json'
-      - 'scripts/check-slo-constants.mjs'
-      - '.github/workflows/slo-constants.yml'
+      - "standards/observability-slo.json"
+      - "scripts/check-slo-constants.mjs"
+      - ".github/workflows/slo-constants.yml"
 
 permissions:
   contents: read
 
 jobs:
   check:
-    name: Burn-rate constants match the eks-gitops alerts
+    name: Burn-rate constants match every consumer
     runs-on: ubuntu-latest
     steps:
       - name: Checkout nanohype
         uses: actions/checkout@v6
+
+      # The standard lives here; nothing that reads it does. Both consumers
+      # transcribe its numbers, so both get pulled in and diffed against it —
+      # otherwise a change here ships green and breaks them silently.
 
       # The alert PromQL that inlines the standard's burn-rate factors lives in
       # eks-gitops (a public repo), so pull just its alerting dir to diff against.
@@ -34,5 +38,20 @@ jobs:
           sparse-checkout: dashboards/base/alerting
           sparse-checkout-cone-mode: false
 
+      # The eks-agent-platform operator's burnWindows table drives the SLO
+      # reconciler — the loop that decides whether to hold a tenant's rollout.
+      # A drift there does not merely misreport a number; it changes when the
+      # platform acts on a burning error budget.
+      - name: Checkout eks-agent-platform operator
+        uses: actions/checkout@v6
+        with:
+          repository: nanohype/eks-agent-platform
+          path: eks-agent-platform
+          sparse-checkout: operators/internal/controller
+          sparse-checkout-cone-mode: false
+
       - name: Check SLO constants
-        run: node scripts/check-slo-constants.mjs eks-gitops/dashboards/base/alerting
+        run: |
+          node scripts/check-slo-constants.mjs \
+            eks-gitops/dashboards/base/alerting \
+            eks-agent-platform/operators/internal/controller

--- a/scripts/check-slo-constants.mjs
+++ b/scripts/check-slo-constants.mjs
@@ -1,24 +1,33 @@
 #!/usr/bin/env node
 //
-// check-slo-constants.mjs — fail if the burn-rate factors and objective
-// denominators inlined into the eks-gitops alert PromQL drift from
-// standards/observability-slo.json.
+// check-slo-constants.mjs — fail if the burn-rate constants its consumers
+// hard-code drift from standards/observability-slo.json.
 //
-// The standard lives in this repo; its consumers — the GrafanaAlertRuleGroup
-// exprs — live in eks-gitops (inlined because prod has no Prometheus ruler).
-// Neither repo's own CI could otherwise catch the standard changing out from
-// under the alerts. CI sparse-checks-out the eks-gitops alerting dir and runs
-// this so a change here is caught against the live consumers.
+// The standard lives in this repo; nothing that reads it does. Two consumers
+// transcribe its numbers, for different reasons, and neither repo's own CI can
+// see the standard change out from under it:
 //
-// Usage: node scripts/check-slo-constants.mjs <eks-gitops-alerting-dir>
+//   1. The eks-gitops GrafanaAlertRuleGroup exprs, which inline the factors and
+//      the objective denominators because production runs no Prometheus ruler.
+//   2. The eks-agent-platform operator's burnWindows table, which drives the SLO
+//      reconciler — the loop that decides whether to hold a tenant's rollout. A
+//      drift there does not merely misreport; it changes when the platform acts.
+//
+// CI sparse-checks-out both and runs this against them, so a change here is
+// caught against every live consumer rather than discovered in production.
+//
+// Usage: node scripts/check-slo-constants.mjs <eks-gitops-alerting-dir> [operator-controller-dir]
 
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const STANDARD = "standards/observability-slo.json";
 const alertDir = process.argv[2];
+const operatorDir = process.argv[3];
 if (!alertDir) {
-  console.error("usage: check-slo-constants.mjs <eks-gitops-alerting-dir>");
+  console.error(
+    "usage: check-slo-constants.mjs <eks-gitops-alerting-dir> [operator-controller-dir]",
+  );
   process.exit(2);
 }
 
@@ -28,13 +37,24 @@ const c = JSON.parse(readFileSync(STANDARD, "utf-8")).content;
 // actually implements; ticket-tier (3, 1) are defined but not alerted in prod.
 const windows = c.burn_rate_alerts.windows;
 const allFactors = new Set(windows.map((w) => w.factor));
-const pageFactors = new Set(windows.filter((w) => w.severity === "page").map((w) => w.factor));
+const pageFactors = new Set(
+  windows.filter((w) => w.severity === "page").map((w) => w.factor),
+);
+
+// The full (severity, long, short, factor) tuples, keyed for set comparison
+// against the operator's Go table.
+const windowKey = (w) => `${w.severity}|${w.long}|${w.short}|${w.factor}`;
+const standardPairs = new Set(windows.map(windowKey));
 
 // Objective denominators = 1 - objective, rounded to kill float dust (0.999 -> 0.001).
 const round = (n) => Math.round(n * 1e6) / 1e6;
-const denominators = new Set(c.slo.sli_types.map((t) => round(1 - t.default_objective)));
+const denominators = new Set(
+  c.slo.sli_types.map((t) => round(1 - t.default_objective)),
+);
 
-const files = readdirSync(alertDir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+const files = readdirSync(alertDir).filter(
+  (f) => f.endsWith(".yaml") || f.endsWith(".yml"),
+);
 if (files.length === 0) {
   console.error(`no alert files under ${alertDir}`);
   process.exit(2);
@@ -69,7 +89,61 @@ for (const f of files) {
 // Every page-tier factor must be implemented by at least one alert.
 for (const pf of pageFactors) {
   if (!usedFactors.has(pf)) {
-    errors.push(`page-tier burn-rate factor ${pf} from ${STANDARD} is not used in any alert expr`);
+    errors.push(
+      `page-tier burn-rate factor ${pf} from ${STANDARD} is not used in any alert expr`,
+    );
+  }
+}
+
+// ── Consumer 2: the operator's burnWindows table ────────────────────────────
+// The table is transcribed Go, not generated, because the operator cannot reach
+// this repo at build time. Compared as a SET of complete tuples rather than as
+// loose factors: a table that kept every factor but paired 14.4 with the 6h
+// window would still pass a factor-only check while paging on a different
+// condition than the standard describes.
+let operatorChecked = false;
+if (operatorDir) {
+  const goFile = join(operatorDir, "slo_reconcile.go");
+  if (!existsSync(goFile)) {
+    errors.push(
+      `operator source ${goFile} not found; the burn-rate table moved or the checkout path is wrong`,
+    );
+  } else {
+    operatorChecked = true;
+    const go = readFileSync(goFile, "utf-8");
+    const table = go.match(/var burnWindows = \[\]burnWindow\{([\s\S]*?)\n\}/);
+    if (!table) {
+      errors.push(
+        `could not find the burnWindows table in ${goFile}; the declaration shape changed`,
+      );
+    } else {
+      const rowRE =
+        /\{severity:\s*(severityCritical|severityWarning),\s*long:\s*"([^"]+)",\s*short:\s*"([^"]+)",\s*factor:\s*([0-9]+(?:\.[0-9]+)?)\}/g;
+      const goPairs = new Set();
+      for (const m of table[1].matchAll(rowRE)) {
+        const severity = m[1] === "severityCritical" ? "page" : "ticket";
+        goPairs.add(`${severity}|${m[2]}|${m[3]}|${Number(m[4])}`);
+      }
+      if (goPairs.size === 0) {
+        errors.push(
+          `parsed no rows out of the burnWindows table in ${goFile}; the row shape changed`,
+        );
+      }
+      for (const key of standardPairs) {
+        if (!goPairs.has(key)) {
+          errors.push(
+            `burn-rate window ${key} from ${STANDARD} is missing from the operator's burnWindows table`,
+          );
+        }
+      }
+      for (const key of goPairs) {
+        if (!standardPairs.has(key)) {
+          errors.push(
+            `the operator's burnWindows table declares ${key}, which is not a window in ${STANDARD}`,
+          );
+        }
+      }
+    }
   }
 }
 
@@ -80,11 +154,16 @@ if (errors.length) {
     `\nThe alert PromQL inlines the burn-rate factors + objective denominators from ${STANDARD}.`,
   );
   console.error(
-    "When the standard changes, update the eks-gitops alert exprs to match (or vice versa).",
+    "When the standard changes, update every consumer to match (or vice versa): the eks-gitops alert exprs, and the eks-agent-platform operator's burnWindows table.",
   );
   process.exit(1);
 }
 
 console.log(
   `SLO-constants OK: alert factors {${[...usedFactors].sort((a, b) => a - b).join(", ")}} and objective denominators all match ${STANDARD}.`,
+);
+console.log(
+  operatorChecked
+    ? `SLO-constants OK: the operator's burnWindows table matches all ${standardPairs.size} window pairs in ${STANDARD}.`
+    : "SLO-constants: operator burnWindows table NOT checked (no operator dir passed).",
 );


### PR DESCRIPTION
The observability-slo standard lives here; nothing that reads it does. Its consumers transcribe the burn-rate numbers into their own source, and neither repo's CI can see the standard change out from under them — which is why this gate exists. It covered one consumer.

The second is now load-bearing: the eks-agent-platform operator's `burnWindows` table drives the SLO reconciler, the loop that decides whether a tenant's error budget is burning fast enough to hold its rollout ([eks-agent-platform#122](https://github.com/nanohype/eks-agent-platform/pull/122)). A drift there does not merely misreport a dashboard number — it changes when the platform takes an automated action against a tenant.

The gate now takes an optional second path and compares the Go table to the standard as a set of complete (severity, long window, short window, factor) tuples, in both directions: a window the table omits fails, and a window the table invents fails too.

**Tuples rather than loose factors, deliberately.** A factor-only check passes a table that keeps all four numbers but pairs 14.4 with the 6h window instead of the 1h — paging on a materially different condition than the standard describes, while every individual constant still matched.

CI sparse-checks-out the operator's controller package alongside the eks-gitops alerting dir. The argument stays optional so a local run against one consumer still works, and the run says explicitly when the table was not checked rather than passing silently on a narrower scan.
