### PR TITLE
fix: make the public surface match the contracts it points at

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,15 +23,15 @@ curl https://raw.githubusercontent.com/nanohype/nanohype/main/catalog.json \
 Render programmatically (TypeScript):
 
 ```ts
-import { GitHubSource, renderTemplate } from '@nanohype/sdk';
+import { GitHubSource, renderTemplate } from "@nanohype/sdk";
 
-const source = new GitHubSource('nanohype/nanohype');
-await renderTemplate({
-  source,
-  templateName: 'rag-pipeline',
-  outputDir: './my-rag-bot',
-  variables: { ProjectName: 'my-rag-bot', LlmProvider: 'anthropic' },
+const source = new GitHubSource({ repo: "nanohype/nanohype" });
+const { manifest, files } = await source.fetchTemplate("rag-pipeline");
+const result = renderTemplate(manifest, files, {
+  ProjectName: "my-rag-bot",
+  LlmProvider: "anthropic",
 });
+// result.files — write these to disk yourself; hooks are returned, not executed
 ```
 
 Or via MCP (Claude Desktop snippet):

--- a/docs/platform-reference.md
+++ b/docs/platform-reference.md
@@ -71,7 +71,7 @@ The production bar every build meets, in machine-readable JSON under [`standards
 | [`language-toolchain.json`](../standards/language-toolchain.json)               | Per-language `{install, build, lint, test, docs}` command sets + manifest, lockfile, registry, version-lookup                                                                                                                                                                                                                                  |
 | [`version-currency.json`](../standards/version-currency.json)                   | EOL policy, version floor, accepted `@pin` reasons, per-language registries                                                                                                                                                                                                                                                                    |
 | [`platform-tenant-contract.json`](../standards/platform-tenant-contract.json)   | The required artifacts (chart, ApplicationSet entry, Platform CR), the minimum Platform CR shape, OTel resource attrs, and what NOT to do                                                                                                                                                                                                      |
-| [`llm-policy.json`](../standards/llm-policy.json)                               | Bedrock-primary, IRSA auth, model tiers (sonnet default / opus escalation / haiku light), region preferences, prompt-caching requirement                                                                                                                                                                                                       |
+| [`llm-policy.json`](../standards/llm-policy.json)                               | Bedrock-primary, IAM-role auth (Pod Identity on EKS), model tiers (sonnet default / opus-4-8 escalation / haiku light), region preferences, prompt-caching requirement                                                                                                                                                                          |
 | [`quality-rubric-dimensions.json`](../standards/quality-rubric-dimensions.json) | The ten quality dimensions every build is graded against. Dimension names + summaries only — the weights, reviewer assignments, and merge-gate enforcement live in the reference client                                                                                                                                                        |
 | [`testing-rubric.json`](../standards/testing-rubric.json)                       | The testing-strategy bar — per-language coverage floors enforced in-config, the testing-trophy shape, and `security-critical-100` (100% on audit ledgers, auth, and approval gates)                                                                                                                                                            |
 | [`resource-tagging.json`](../standards/resource-tagging.json)                   | The org-wide tag/label taxonomy every cloud resource and k8s object carries — vendor-neutral dimensions, per-surface rendering (AWS tags, k8s labels, OTel attributes), casing transforms, required tiers                                                                                                                                      |
@@ -112,28 +112,35 @@ import {
   renderTemplate,
 } from "@nanohype/sdk";
 
-// Discovery
-const source = new LocalSource("/path/to/nanohype-repo");
+// Discovery — LocalSource takes { rootDir }, not a bare path string
+const source = new LocalSource({ rootDir: "/path/to/nanohype-repo" });
 const catalog = await loadCatalog(source);
 const standards = await loadStandards(source);
 
 // Selection (your client decides which template fits)
 const templateName = catalog.templates.find(
   (t) => t.category === "ai-systems" && t.tags.includes("rag"),
-)?.name;
+)?.name; // e.g. "rag-pipeline"
 
-// Render
-await renderTemplate({
-  source,
-  templateName,
-  outputDir: "/path/to/output",
-  variables: { ProjectName: "my-rag-bot", LlmProvider: "anthropic" },
+// Fetch skeleton, then render — renderTemplate is sync and writes nothing to disk
+const { manifest, files } = await source.fetchTemplate(templateName!);
+const result = renderTemplate(manifest, files, {
+  ProjectName: "my-rag-bot",
+  LlmProvider: "anthropic",
 });
+// result.files — SkeletonFile[] with rendered paths and content
+// consumer writes them (and runs hooks) however it likes
 ```
 
-For agents running remotely without a checkout, use `GitHubSource` instead — same API, fetches manifests from the GitHub API.
+For agents running remotely without a checkout, use `GitHubSource` instead
+(`new GitHubSource({ repo: "nanohype/nanohype" })`) — same `CatalogSource`
+API, fetches manifests from the GitHub API.
 
-`loadStandards()` returns a typed bundle covering all ten standards files. `loadContract(repo)` fetches the corresponding `AGENTS.md` so your agent can present the deploy contract for any specific repo. See [`docs/spec/consumer-guide.md`](spec/consumer-guide.md) for the full rendering algorithm.
+`loadStandards()` returns a typed bundle covering all ten standards files.
+`loadContract(source, repo)` fetches the corresponding `AGENTS.md` so your
+agent can present the deploy contract for any specific repo. See
+[`docs/spec/consumer-guide.md`](spec/consumer-guide.md) for the full rendering
+algorithm.
 
 ## MCP server
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -62,6 +62,9 @@ interface CatalogSource {
   fetchTemplate(name: string): Promise<{ manifest: TemplateManifest; files: SkeletonFile[] }>;
   listComposites(): Promise<CompositeCatalogEntry[]>;
   fetchComposite(name: string): Promise<CompositeManifest>;
+  fetchCatalogManifest(): Promise<Catalog>;
+  fetchStandard(name: StandardName): Promise<Standard>;
+  fetchContract(repo: ContractRepo): Promise<string>;
 }
 ```
 

--- a/standards/README.md
+++ b/standards/README.md
@@ -42,14 +42,21 @@ A tenant ships three artifacts:
 
 1. A Helm chart in `<app>/chart/` with per-env values files
 2. An ApplicationSet entry referenced by `nanohype/eks-gitops`
-3. A Platform CR (and any required BudgetPolicy CR) declaring the tenant boundary
+3. A Platform CR (and any required BudgetPolicy CR) declaring the tenant boundary **and** its stateful substrate
 
-The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IRSA role. The chart's own ServiceAccount carries the `eks.amazonaws.com/role-arn` annotation rendered from a per-env Helm value pointing at the landing-zone-owned IRSA role.
+The Platform CR is the declaration surface. In particular:
+
+- **`spec.datastores`** — relational / keyValue / objectStore / queue / cache / stream. The generic `tenant-substrate` module provisions them; the operator generates the scoped IAM from the same list. There is no per-app landing-zone component for datastores.
+- **`spec.identity.capabilities`** — managed AWS capabilities outside the datastore vocabulary (SES send, EventBridge Scheduler). The operator generates those grants.
+- **`spec.identity.directSecretReads`** — the few secret names a pod resolves itself via the AWS SDK (not ExternalSecret projection). Empty means the tenant role holds no Secrets Manager grant.
+
+The operator reconciles Namespace, ResourceQuota, LimitRange, default-deny NetworkPolicy, ArgoCD AppProject, and the per-Platform IAM role. Identity is **EKS Pod Identity**: the operator creates a Pod Identity association binding the tenant ServiceAccount (`tenant-runtime`) to that role. The chart's ServiceAccount carries **no** `eks.amazonaws.com/role-arn` annotation.
 
 What you must **not** do inside a chart:
 
-- Scaffold IAM roles (the operator + landing-zone own IRSA)
-- Add cloud-substrate tofu (substrate lives in `nanohype/landing-zone`)
+- Scaffold IAM roles or annotate the ServiceAccount with a role ARN (the operator owns Pod Identity)
+- Hand-write a per-app landing-zone component for databases, buckets, queues, caches, or streams (declare `spec.datastores`)
+- Add cloud-substrate tofu for gaps the vocabulary does not cover outside `nanohype/landing-zone` / `nanohype/eks-gitops`
 - Add cluster-level addons (addons live in `nanohype/eks-gitops`)
 - Skip per-env values files (every chart has three, even if some are empty)
 - Hardcode AWS account IDs, region names, or KMS ARNs
@@ -60,12 +67,12 @@ OTel resource attributes every pod must emit: `agents.tenant`, `agents.platform`
 
 ## LLM policy — `llm-policy.json`
 
-Claude via **AWS Bedrock** is the primary LLM. Authentication is IAM-role-based (IRSA on EKS, task role on ECS, execution role on Lambda) — never API keys.
+Claude via **AWS Bedrock** is the primary LLM. Authentication is IAM-role-based (Pod Identity on EKS, task role on ECS, execution role on Lambda) — never API keys. On-demand invoke uses cross-region inference profile IDs (`us.anthropic.…`); bare foundation-model IDs are refused.
 
-Models:
+Models (from `llm-policy.json`):
 
 - **Default**: `anthropic.claude-sonnet-4-6` — most work
-- **Escalation**: `anthropic.claude-opus-4-6` — complex reasoning, architecture decisions
+- **Escalation**: `anthropic.claude-opus-4-8` — complex reasoning, architecture decisions
 - **Light**: `anthropic.claude-haiku-4-5` — classification, routing, filter steps
 
 Regions in order of preference: `us-west-2`, `us-east-1`, `eu-central-1`. Verify the chosen model is available in the deploy region before committing IaC.
@@ -89,6 +96,7 @@ Ten dimensions every build is graded against. This file names them and summarize
 7. **Code Quality & Craft** — naming, complexity, boundary error handling, explicit timeouts
 8. **Documentation & Developer Experience** — README, runbook, CLAUDE.md, regenerated API docs
 9. **Consistency & Polish** — convention inheritance, code shape, no aspirational comments
+10. **AI & Agent Systems** — eval suites for non-deterministic components, prompt discipline, model routing + fallback, token/cost metering, structured-output validation, prompt-injection defense, tool-use least privilege (N/A when there is no LLM surface)
 
 ---
 

--- a/standards/llm-policy.json
+++ b/standards/llm-policy.json
@@ -23,7 +23,7 @@
     "requirements": [
       {
         "id": "iam-role-auth",
-        "summary": "Authenticate via IAM role assumption (IRSA on EKS, ECS task role, Lambda execution role). No API keys in code, env vars, or secrets."
+        "summary": "Authenticate via IAM role assumption (EKS Pod Identity on EKS, ECS task role, Lambda execution role). No API keys in code, env vars, or secrets."
       },
       {
         "id": "default-sonnet",


### PR DESCRIPTION
## Summary

**T20** of audit-remediation — nanohype public surface self-conformance.

- `standards/README.md`: Pod Identity (not IRSA), 10th quality dimension, datastores/capabilities/directSecretReads, opus-4-8 escalation
- Front-door samples compile against real `@nanohype/sdk` API
- `llm-policy.json` EKS auth wording

## Merge

**Holding for your sign-off.**

## Test plan

- [x] SDK tests
- [ ] CI green