### PR TITLE
feat: make the SDK and MCP server publishable, and say which variable failed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: release
+
+# Publishes @nanohype/sdk and @nanohype/mcp to npm.
+#
+# Tag-driven, because a release should be a thing you can point at afterwards:
+# `sdk-v0.2.0` publishes the SDK at that version, `mcp-v0.1.0` the MCP server.
+# The two version independently, so they get separate tags rather than one
+# release train.
+#
+# ── Auth ──────────────────────────────────────────────────────────────────────
+# npm trusted publishing (OIDC). No NPM_TOKEN, no long-lived secret in the repo,
+# and it is what makes automated releases possible at all here: the publishing
+# account runs 2FA in `auth-and-writes` mode, so an interactive `npm publish`
+# demands a fresh OTP every time and cannot be automated. A trusted publisher is
+# the supported way out, not a workaround.
+#
+# One-time setup, per package, after the package exists on the registry:
+#   npmjs.com → the package → Settings → Trusted Publisher → GitHub Actions
+#   repository: nanohype/nanohype   workflow: release.yml
+# The first publish of a brand-new package still has to be done by hand, because
+# there is no package page to configure until it exists.
+#
+# `--provenance` attaches a signed attestation linking the tarball to this
+# workflow run and commit. It requires `id-token: write` and a public repo, and
+# it is why `publishConfig` does NOT set `provenance: true` — that would apply to
+# a laptop publish too, which cannot generate one and fails outright.
+
+on:
+  push:
+    tags:
+      - 'sdk-v*'
+      - 'mcp-v*'
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Which package to publish
+        required: true
+        type: choice
+        options: [sdk, mcp]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      # sdk-v* → sdk (@nanohype/sdk); mcp-v* → mcp-server (@nanohype/mcp).
+      # The directory and the package name differ, so both are resolved here
+      # rather than assumed downstream.
+      - name: Resolve the target
+        id: target
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            key='${{ inputs.package }}'
+            tag_version=''
+          else
+            key="${GITHUB_REF_NAME%%-v*}"
+            tag_version="${GITHUB_REF_NAME#*-v}"
+          fi
+          case "$key" in
+            sdk) dir=sdk ;;
+            mcp) dir=mcp-server ;;
+            *) echo "::error::unrecognised release key '$key' (expected sdk or mcp)"; exit 1 ;;
+          esac
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "tag_version=$tag_version" >> "$GITHUB_OUTPUT"
+
+      - name: Install
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      # A tag that disagrees with package.json publishes a version nobody asked
+      # for under a name that says otherwise. Cheap to check, silent if skipped.
+      - name: Tag must match the manifest version
+        if: steps.target.outputs.tag_version != ''
+        run: |
+          set -euo pipefail
+          manifest=$(node -p "require('./${{ steps.target.outputs.dir }}/package.json').version")
+          if [ "$manifest" != "${{ steps.target.outputs.tag_version }}" ]; then
+            echo "::error::tag says ${{ steps.target.outputs.tag_version }}, ${{ steps.target.outputs.dir }}/package.json says $manifest"
+            exit 1
+          fi
+
+      # The repo-level gates plus the package's own suite. The SDK is the
+      # reference implementation of the rendering contract, so a release that
+      # skipped the template and catalog validation would be the least
+      # trustworthy artifact in the org.
+      # Deliberately not `npm run lint` (root `biome check .`). That script is
+      # not gated by any workflow and does not currently pass — the package
+      # suites below run biome inside sdk/ and mcp-server/, which is what CI
+      # actually enforces. Adding a failing gate here would make releases
+      # impossible; fixing the root formatting is its own change, not a rider on
+      # a release.
+      - name: Verify the repo
+        run: |
+          npm run validate:schema
+          npm run validate:standards
+          npm run validate:manifest
+          npm run verify:catalog
+
+      - name: Verify the package
+        working-directory: ${{ steps.target.outputs.dir }}
+        run: |
+          npm run lint
+          npm run typecheck
+          npm test
+
+      - name: Build
+        working-directory: ${{ steps.target.outputs.dir }}
+        run: npm run build
+
+      # --dry-run first so the tarball contents appear in the log of the run
+      # that published them. `files` is easy to get wrong in the direction of
+      # shipping too much, and the log is the only place that is visible after
+      # the fact.
+      - name: Show what will ship
+        working-directory: ${{ steps.target.outputs.dir }}
+        run: npm publish --dry-run
+
+      - name: Publish
+        working-directory: ${{ steps.target.outputs.dir }}
+        run: npm publish --provenance --access public

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -48,5 +48,26 @@
     "body-parser": "^2.3.0",
     "fast-uri": "^3.1.3",
     "hono": "^4.12.27"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nanohype/nanohype.git",
+    "directory": "mcp-server"
+  },
+  "homepage": "https://github.com/nanohype/nanohype/tree/main/mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/nanohype/nanohype/issues"
+  },
+  "keywords": [
+    "nanohype",
+    "mcp",
+    "model-context-protocol",
+    "platform",
+    "kubernetes",
+    "eks",
+    "catalog"
+  ]
 }

--- a/sdk/__tests__/resolver.test.ts
+++ b/sdk/__tests__/resolver.test.ts
@@ -90,6 +90,47 @@ describe("resolveVariables", () => {
     ).toThrow("Must be kebab-case");
   });
 
+  it("names the variable and value alongside the template's own message", () => {
+    // A template-authored message explains the rule and cannot name what broke
+    // it. Both halves have to survive, or a caller gets a bare rule with no
+    // indication of which variable it applies to.
+    expect(() =>
+      resolveVariables(
+        [v({ name: "Name", validation: { pattern: "[a-z-]+", message: "Must be kebab-case" } })],
+        { Name: "Not Kebab" },
+      ),
+    ).toThrow(/Variable 'Name' value 'Not Kebab'.*Must be kebab-case/);
+  });
+
+  it("says when the failing value came from a default the caller never set", () => {
+    // The k8s-app-tenant case: AppName is required to be kebab-case, AppMetric
+    // defaults to ${AppName} and must be snake_case, so any hyphenated app name
+    // fails validation on a variable the caller never supplied. That is
+    // documented template behaviour; the error just has to be diagnosable.
+    expect(() =>
+      resolveVariables(
+        [
+          v({ name: "AppName", validation: { pattern: "[a-z][a-z0-9-]*" } }),
+          v({
+            name: "AppMetric",
+            default: "${AppName}",
+            validation: { pattern: "[a-z][a-z0-9_]*", message: "Must be lowercase snake_case" },
+          }),
+        ],
+        { AppName: "my-app" },
+      ),
+    ).toThrow(/Variable 'AppMetric' value 'my-app' \(defaulted from `\$\{AppName\}`.*snake_case/);
+  });
+
+  it("does not claim a caller-supplied value came from a default", () => {
+    expect(() =>
+      resolveVariables(
+        [v({ name: "AppMetric", default: "fallback", validation: { pattern: "[a-z_]+" } })],
+        { AppMetric: "NOT-SNAKE" },
+      ),
+    ).toThrow(/AppMetric' value 'NOT-SNAKE': /);
+  });
+
   it("passes valid regex patterns", () => {
     const result = resolveVariables([v({ name: "Name", validation: { pattern: "[a-z-]+" } })], {
       Name: "my-app",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -42,5 +42,27 @@
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nanohype/nanohype.git",
+    "directory": "sdk"
+  },
+  "homepage": "https://github.com/nanohype/nanohype/tree/main/sdk#readme",
+  "bugs": {
+    "url": "https://github.com/nanohype/nanohype/issues"
+  },
+  "keywords": [
+    "nanohype",
+    "platform",
+    "kubernetes",
+    "templates",
+    "scaffolding",
+    "catalog",
+    "eks",
+    "gitops"
+  ]
 }

--- a/sdk/src/resolver.ts
+++ b/sdk/src/resolver.ts
@@ -17,12 +17,19 @@ export function resolveVariables(
 ): Record<string, string> {
   const resolved: Record<string, string> = {};
 
+  // Variables the caller never supplied, so the value under validation came
+  // from the template's own default. Carried to the error message: the hardest
+  // resolution failure to diagnose is one on a variable you never set, where
+  // the value is derived from a variable you did.
+  const fromDefault = new Set<string>();
+
   // Apply provided values, then defaults, then type zero-values
   for (const v of variables) {
     if (v.name in values) {
       resolved[v.name] = String(values[v.name]);
     } else if (v.default !== undefined) {
       resolved[v.name] = String(v.default);
+      fromDefault.add(v.name);
     } else if (v.required) {
       throw new VariableResolutionError(
         `Required variable '${v.name}' has no value and no default`,
@@ -81,9 +88,18 @@ export function resolveVariables(
     if (v.validation?.pattern) {
       const regex = new RegExp(`^(?:${v.validation.pattern})$`);
       if (!regex.test(resolved[v.name])) {
+        // A template-authored message explains the RULE; it cannot know which
+        // variable or which value tripped it. Previously it replaced the naming
+        // rather than adding to it, so `scaffold k8s-app-tenant --var
+        // AppName=my-app` failed with a bare "Must be lowercase snake_case"
+        // naming nothing — on AppMetric, which the caller never set and which
+        // defaults to ${AppName}. Compose instead of choosing.
+        const rule = v.validation.message || `does not match pattern: ${v.validation.pattern}`;
+        const origin = fromDefault.has(v.name)
+          ? ` (defaulted from \`${v.default}\`, not supplied by the caller)`
+          : "";
         throw new VariableResolutionError(
-          v.validation.message ||
-            `Variable '${v.name}' value '${resolved[v.name]}' does not match pattern: ${v.validation.pattern}`,
+          `Variable '${v.name}' value '${resolved[v.name]}'${origin}: ${rule}`,
         );
       }
     }


### PR DESCRIPTION
`npm install @nanohype/sdk` is the first instruction on the org's front door and **has never worked** — neither package has ever been published, and no release path existed to publish them with.

### Publish metadata

`publishConfig.access: "public"` is the load-bearing bit: scoped packages default to restricted, so a publish without it either fails or quietly ships a *private* package — the worse outcome for a public reference implementation. Plus `repository` (with `directory`), `homepage`, `bugs`, `keywords`.

`publishConfig` deliberately does **not** set `provenance: true` — that applies to every publish including a local one, and provenance needs CI OIDC, so a laptop publish fails outright with it set. The workflow passes `--provenance` on the command line instead.

### Release workflow

Tag-driven — `sdk-v0.2.0` and `mcp-v0.1.0`, since the two version independently.

Auth is **npm trusted publishing over OIDC, no NPM_TOKEN**. Not a preference: the publishing account runs 2FA in `auth-and-writes`, so an interactive publish demands a fresh OTP and cannot be automated at all. The one-time per-package setup is documented in the workflow header, including why the *first* publish of a new package still has to be done by hand.

Two guards: the tag version must match `package.json` (a mismatch publishes a version nobody asked for), and `--dry-run` runs first so the tarball file list lands in the log of the run that published it.

Verify deliberately skips the root `npm run lint` — that script is gated by no workflow and doesn't currently pass; CI enforces biome inside `sdk/` and `mcp-server/`. Adding a failing gate would make releases impossible. Root formatting is its own change.

### A resolution error that named nothing

`nanohype scaffold k8s-app-tenant --var AppName=my-app …` failed with a bare `Must be lowercase snake_case` — no variable, no value. The culprit is `AppMetric`, which the caller never set: it defaults to `${AppName}`, and `AppName` must be kebab-case while `AppMetric` must be snake_case. That interaction is documented on the variable, so the template is fine — the error wasn't.

A template-authored `validation.message` was *replacing* the naming instead of adding to it. Now:

```
Variable 'AppMetric' value 'my-app' (defaulted from `${AppName}`, not supplied by the caller): Must be lowercase snake_case (…)
```