### PR TITLE
Build @nanohype/tokens without needing @types/node

### DIFF
--- a/tokens/tsconfig.build.json
+++ b/tokens/tsconfig.build.json
@@ -5,7 +5,11 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    // Nothing under src/ touches node. Inheriting `types: ["node"]` made the
+    // build fail on a machine that had not installed dev dependencies — which
+    // is exactly the state `npm publish` runs prepublishOnly in.
+    "types": []
   },
   "include": ["src"],
   "exclude": ["dist", "__tests__"]

--- a/tokens/tsconfig.json
+++ b/tokens/tsconfig.json
@@ -8,6 +8,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // node types are for __tests__ only (the parity test reads tokens.css off
+    // disk). tsconfig.build.json clears them: the published output is data and
+    // types, with nothing from node in it.
     "types": ["node"],
     "noEmit": true
   },


### PR DESCRIPTION
`npm publish` runs `prepublishOnly` → `npm run build` → `tsc`, and the build config inherited `"types": ["node"]` from the base tsconfig. On a checkout whose dev dependencies aren't installed — a normal state to publish from — that fails with `TS2688` before the tarball is ever built.

Nothing under `src/` touches node. The published output is a stylesheet, a data object and its types. Only `__tests__/parity.test.ts` needs node, because it reads `tokens.css` off disk to compare against the mirror — so the base config keeps the types and `tsconfig.build.json` clears them.

**CI didn't catch this**: the workflow runs `npm ci` first, so `@types/node` resolved there. The publish path has no such step, which is exactly the difference that matters for a package whose first release is by hand.

Verified by building with no `node_modules` present in the package directory.