### PR TITLE
Make the published coverage floor real in the template catalog

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -125,7 +125,12 @@ jobs:
           failed=0
           tested=0
 
-          for pkg in templates/*/skeleton/package.json; do
+          # Every package.json under a skeleton, not just the one at its root.
+          # A skeleton whose code lives a directory deeper (prompt-library/sdk,
+          # monorepo/packages/*) was invisible to a `templates/*/skeleton/`
+          # glob, so its suite never ran here — which is how prompt-library
+          # shipped a test suite that had been failing outright.
+          while IFS= read -r pkg; do
             [ -f "$pkg" ] || continue
             dir=$(dirname "$pkg")
 
@@ -145,7 +150,7 @@ jobs:
             fi
 
             echo ""
-          done
+          done < <(find templates -mindepth 3 -name package.json -not -path '*/node_modules/*' | sort)
 
           echo "──────────────────────────────────────"
           echo "Templates tested: $tested"

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,10 @@ Thumbs.db
 # Runtime
 tmp/
 
-# Generated lock files in template skeletons
+# Generated lock files in template skeletons, at any depth — a skeleton whose
+# code lives a directory deeper (prompt-library/sdk, monorepo/packages/*) got
+# its lockfile committed by accident under a single-level pattern.
+**/skeleton/**/package-lock.json
 **/skeleton/package-lock.json
 
 # Template doctor report artifact

--- a/templates/a2a-agent/skeleton/vitest.config.ts
+++ b/templates/a2a-agent/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -25,8 +26,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/agent-orchestrator/skeleton/vitest.config.ts
+++ b/templates/agent-orchestrator/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -23,12 +24,13 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
-        lines: 73,
+        lines: 75,
         functions: 85,
-        statements: 73,
+        statements: 75,
         branches: 79,
       },
     },

--- a/templates/agentic-loop/skeleton/vitest.config.ts
+++ b/templates/agentic-loop/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -27,8 +28,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/chrome-ext/skeleton/vitest.config.ts
+++ b/templates/chrome-ext/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/__tests__/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -29,8 +30,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/ci-eval/skeleton/vitest.config.ts
+++ b/templates/ci-eval/skeleton/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -22,8 +23,10 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // Below the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). These are the measured
+      // values, now actually enforced: closing the gap needs tests for the
+      // scaffolding this skeleton ships, not a higher number here.
       thresholds: {
         lines: 55,
         functions: 72,

--- a/templates/data-pipeline/skeleton/vitest.config.ts
+++ b/templates/data-pipeline/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -27,9 +28,9 @@ export default defineConfig({
         "src/pipeline/transform/semantic.ts",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/discord-bot/skeleton/vitest.config.ts
+++ b/templates/discord-bot/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -26,8 +27,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 83,

--- a/templates/electron-app/skeleton/vitest.config.ts
+++ b/templates/electron-app/skeleton/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.{test,spec}.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -31,8 +32,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/eval-harness/skeleton/vitest.config.ts
+++ b/templates/eval-harness/skeleton/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -22,8 +23,10 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // Below the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). These are the measured
+      // values, now actually enforced: closing the gap needs tests for the
+      // scaffolding this skeleton ships, not a higher number here.
       thresholds: {
         lines: 72,
         functions: 69,

--- a/templates/fine-tune-pipeline/skeleton/vitest.config.ts
+++ b/templates/fine-tune-pipeline/skeleton/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -24,8 +25,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/guardrails/skeleton/vitest.config.ts
+++ b/templates/guardrails/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -17,8 +18,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 80,

--- a/templates/llm-wiki/skeleton/vitest.config.ts
+++ b/templates/llm-wiki/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -28,8 +29,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/mcp-server-ts/skeleton/vitest.config.ts
+++ b/templates/mcp-server-ts/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/__tests__/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -20,13 +21,20 @@ export default defineConfig({
         "src/transports/**",
         "src/**/index.ts",
         "src/**/types.ts",
+        // The `example.*` tool and resource are demo handlers a consumer
+        // deletes on first use — the same exclusion ts-service makes, for the
+        // same reason. Gating them would hold the scaffold to coverage of code
+        // that is not meant to survive scaffolding.
+        "src/tools/example.ts",
+        "src/resources/example.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
-        lines: 69,
+        lines: 75,
         functions: 85,
-        statements: 69,
+        statements: 75,
         branches: 83,
       },
     },

--- a/templates/module-analytics-ts/skeleton/vitest.config.ts
+++ b/templates/module-analytics-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -24,8 +25,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-audit-ledger-ts/skeleton/vitest.config.ts
+++ b/templates/module-audit-ledger-ts/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -27,9 +28,9 @@ export default defineConfig({
       // 100% per the rubric's security-critical-100 rule; everything else to the
       // standard module floor.
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
         "**/event-id.ts": { lines: 100, functions: 100, statements: 100, branches: 100 },
       },

--- a/templates/module-auth-ts/skeleton/vitest.config.ts
+++ b/templates/module-auth-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -23,12 +24,13 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
-        lines: 72,
+        lines: 75,
         functions: 82,
-        statements: 72,
+        statements: 75,
         branches: 75,
       },
     },

--- a/templates/module-billing-ts/skeleton/vitest.config.ts
+++ b/templates/module-billing-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -22,8 +23,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-cache-ts/skeleton/vitest.config.ts
+++ b/templates/module-cache-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -20,8 +21,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-database-ts/skeleton/vitest.config.ts
+++ b/templates/module-database-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -22,8 +23,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-feature-flags-ts/skeleton/vitest.config.ts
+++ b/templates/module-feature-flags-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -24,8 +25,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-knowledge-base-ts/skeleton/vitest.config.ts
+++ b/templates/module-knowledge-base-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -24,8 +25,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-llm-gateway/skeleton/vitest.config.ts
+++ b/templates/module-llm-gateway/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -30,9 +31,9 @@ export default defineConfig({
         "src/gateway/caching/index.ts",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/module-llm-observability/skeleton/vitest.config.ts
+++ b/templates/module-llm-observability/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -28,9 +29,9 @@ export default defineConfig({
         "src/llm-observability/exporters/mock.ts",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/module-llm-providers/skeleton/vitest.config.ts
+++ b/templates/module-llm-providers/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -33,9 +34,9 @@ export default defineConfig({
         "src/llm-providers/providers/ollama.ts",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/module-media-ts/skeleton/vitest.config.ts
+++ b/templates/module-media-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -23,8 +24,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-notifications-ts/skeleton/vitest.config.ts
+++ b/templates/module-notifications-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -20,8 +21,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-oauth-delegation-ts/skeleton/vitest.config.ts
+++ b/templates/module-oauth-delegation-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       thresholds: {

--- a/templates/module-observability-ts/skeleton/vitest.config.ts
+++ b/templates/module-observability-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -21,8 +22,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-project-mgmt-ts/skeleton/vitest.config.ts
+++ b/templates/module-project-mgmt-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -24,8 +25,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-queue-ts/skeleton/vitest.config.ts
+++ b/templates/module-queue-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -21,8 +22,10 @@ export default defineConfig({
         "src/queue/providers/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // Below the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). These are the measured
+      // values, now actually enforced: closing the gap needs tests for the
+      // scaffolding this skeleton ships, not a higher number here.
       thresholds: {
         lines: 73,
         functions: 63,

--- a/templates/module-rate-limit-ts/skeleton/vitest.config.ts
+++ b/templates/module-rate-limit-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -21,8 +22,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-search-ts/skeleton/vitest.config.ts
+++ b/templates/module-search-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -23,8 +24,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-semantic-cache/skeleton/vitest.config.ts
+++ b/templates/module-semantic-cache/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -25,9 +26,9 @@ export default defineConfig({
         "src/semantic-cache/metrics.ts",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/module-storage-ts/skeleton/vitest.config.ts
+++ b/templates/module-storage-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -21,8 +22,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/module-vector-store/skeleton/vitest.config.ts
+++ b/templates/module-vector-store/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -30,9 +31,9 @@ export default defineConfig({
         "src/vector-store/filters/types.ts",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/module-webhook-ts/skeleton/vitest.config.ts
+++ b/templates/module-webhook-ts/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -18,8 +19,10 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // Below the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). These are the measured
+      // values, now actually enforced: closing the gap needs tests for the
+      // scaffolding this skeleton ships, not a higher number here.
       thresholds: {
         lines: 85,
         functions: 61,

--- a/templates/multimodal-pipeline/skeleton/vitest.config.ts
+++ b/templates/multimodal-pipeline/skeleton/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -23,8 +24,10 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // Below the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). These are the measured
+      // values, now actually enforced: closing the gap needs tests for the
+      // scaffolding this skeleton ships, not a higher number here.
       thresholds: {
         lines: 52,
         functions: 70,

--- a/templates/next-app/skeleton/vitest.config.ts
+++ b/templates/next-app/skeleton/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -29,8 +30,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/prompt-library/skeleton/sdk/package.json
+++ b/templates/prompt-library/skeleton/sdk/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@vitest/coverage-v8": "^3.1.0",
     "eslint": "^9.20.0",
     "prettier": "^3.5.0",
     "tsx": "^4.19.0",

--- a/templates/prompt-library/skeleton/sdk/src/index.ts
+++ b/templates/prompt-library/skeleton/sdk/src/index.ts
@@ -1,7 +1,11 @@
 import { readFile, readdir, stat } from "fs/promises";
 import { join, resolve } from "path";
 import { parse as parseYaml } from "yaml";
-import Ajv from "ajv";
+// ajv 8 ships one entrypoint per JSON Schema draft, and the bare "ajv" import
+// is draft-07. prompt.schema.json declares draft 2020-12, so the default
+// import cannot resolve its $schema and every validation throws before it
+// checks anything.
+import Ajv from "ajv/dist/2020.js";
 
 import type { Prompt, PromptMetadata, RenderedPrompt } from "./types.js";
 

--- a/templates/prompt-library/skeleton/sdk/vitest.config.ts
+++ b/templates/prompt-library/skeleton/sdk/vitest.config.ts
@@ -4,6 +4,23 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],
+    coverage: {
+      enabled: true,
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/__tests__/**", "src/**/types.ts"],
+      // Below the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). These are the measured
+      // values, now actually enforced: closing the gap needs tests for the
+      // directory walk and the render helpers, not a higher number here.
+      thresholds: {
+        lines: 71,
+        functions: 71,
+        statements: 71,
+        branches: 80,
+      },
+    },
   },
 });

--- a/templates/rag-pipeline/skeleton/vitest.config.ts
+++ b/templates/rag-pipeline/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -24,9 +25,9 @@ export default defineConfig({
         "src/providers/**",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/slack-bot/skeleton/vitest.config.ts
+++ b/templates/slack-bot/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -29,9 +30,9 @@ export default defineConfig({
         "src/commands/**",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/ts-service/skeleton/vitest.config.ts
+++ b/templates/ts-service/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -29,9 +30,9 @@ export default defineConfig({
         "src/types/**",
       ],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        statements: 70,
+        lines: 75,
+        functions: 75,
+        statements: 75,
         branches: 70,
       },
     },

--- a/templates/vscode-ext/skeleton/vitest.config.ts
+++ b/templates/vscode-ext/skeleton/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     include: ["src/__tests__/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -23,8 +24,9 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,

--- a/templates/worker-service/skeleton/vitest.config.ts
+++ b/templates/worker-service/skeleton/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      enabled: true,
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
@@ -24,8 +25,9 @@ export default defineConfig({
         "src/worker/health/**",
         "src/**/types.ts",
       ],
-      // Floors sit just below measured coverage so the gate catches
-      // regressions; ratchet upward as the suite grows.
+      // The floor published in nanohype/standards/testing-rubric.json. A
+      // scaffolded project starts held to the same bar it will be graded
+      // against; raise these as the suite grows, never lower them.
       thresholds: {
         lines: 85,
         functions: 85,


### PR DESCRIPTION
`standards/testing-rubric.json` publishes a coverage floor — lines/functions/statements 75, branches 60 — and says to encode it in the test-runner config rather than a CI flag: *"a regression must fail the build, not pass silently."*

**Every TypeScript skeleton encoded it. None of them enforced it.**

## The thresholds never ran

All 43 skeleton vitest configs declare `coverage.thresholds`. None set `coverage.enabled`, and every test script is a bare `vitest run` with no `--coverage`. So vitest collected no coverage and checked no threshold.

Proof: setting ts-service's line threshold to **100** and running its suite exited **0**.

A scaffold consumer inherited a config that looks gated, reads as gated in review, and gates nothing — the exact anti-pattern the rubric names, wearing the costume of the rule. `coverage.enabled` is now true everywhere; the same mutation exits 1 and names the shortfall.

## The numbers were also low — but mostly bookkeeping

Nineteen declared floors sat under the published one. I measured real coverage before changing any of them:

- **37 skeletons already exceed 75** across the board, several at 100. They'd been pinned to whatever the suite happened to score. Raised to the published floor; their suites pass unchanged.
- **5 genuinely fall short** — ci-eval, eval-harness, module-queue-ts, module-webhook-ts, multimodal-pipeline. Thresholds stay at measured and are *now enforced there*, with a comment naming the floor and that closing it takes tests. Raising them here would move the lie rather than remove it. Tracked as follow-up.
- **mcp-server-ts** hits 100% once the `example.*` demo handlers are excluded — the same exclusion ts-service already makes, since a consumer deletes them on first use.

## prompt-library was shipping broken

Its SDK suite fails outright. `prompt.schema.json` declares JSON Schema **draft 2020-12**; the loader imports ajv's default entrypoint, which is **draft-07**. Every validation throws `no schema with key or ref` before checking anything — the library's central function has never worked. `ajv/dist/2020.js` fixes it; suite passes 6/6. It also had no coverage config; it has one now.

## Why none of this was visible

The template test job globbed `templates/*/skeleton/package.json` — exactly one level. prompt-library's package is at `skeleton/sdk`, the monorepo skeleton's at `skeleton/packages/*`. **Three skeletons were never tested by CI**, which is how a suite failing on its first assertion stayed green.

The job now walks every `package.json` under `templates/` excluding `node_modules` (48 → 51 discovered, 47 test-bearing).

## Verification

Ran all 47 test-bearing skeleton packages exactly as CI does: **47 pass, 0 fail.**

## Not included, and why

The plan also claimed the templates violate the toolchain standard by scaffolding ESLint+Prettier instead of Biome. **`standards/language-toolchain.json` is linter-agnostic** — it fixes `npm run lint` as the command, not the tool. No standard or doc in this repo claims Biome. That's an org-consistency question, not a violation, and it isn't grounds for a 47-template migration inside a fix PR.