### PR TITLE
Hold the Python and Go skeletons to the standards they scaffold under

### DIFF
--- a/templates/go-cli/skeleton/.gitignore
+++ b/templates/go-cli/skeleton/.gitignore
@@ -2,3 +2,6 @@ bin/
 dist/
 *.exe
 .env
+
+# Coverage profile written by `make test`
+coverage.out

--- a/templates/go-cli/skeleton/Makefile
+++ b/templates/go-cli/skeleton/Makefile
@@ -6,8 +6,18 @@ MODULE := __GO_MODULE__
 build:
 	go build -o $(BINARY) .
 
+# Coverage floor. standards/testing-rubric.json publishes 75 and says to encode
+# it where a regression fails the build rather than as a CI flag. This suite
+# reaches 34%, so the gate is set there and the distance to 75 is closed by
+# writing tests for the packages below — never by lowering this number.
+COVERAGE_MIN := 34
+
 test:
-	go test ./...
+	go test ./... -coverprofile=coverage.out
+	@total=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/,"",$$3); print $$3}'); \
+	awk -v t="$$total" -v m="$(COVERAGE_MIN)" 'BEGIN { \
+	  if (t+0 < m+0) { printf "coverage %s%% is below the %s%% floor\n", t, m; exit 1 } \
+	  printf "coverage %s%% (floor %s%%)\n", t, m }'
 
 lint:
 	golangci-lint run ./...

--- a/templates/go-service/skeleton/.gitignore
+++ b/templates/go-service/skeleton/.gitignore
@@ -2,3 +2,6 @@ bin/
 dist/
 *.exe
 .env
+
+# Coverage profile written by `make test`
+coverage.out

--- a/templates/go-service/skeleton/Makefile
+++ b/templates/go-service/skeleton/Makefile
@@ -9,8 +9,18 @@ build:
 run: build
 	./$(BINARY)
 
+# Coverage floor. standards/testing-rubric.json publishes 75 and says to encode
+# it where a regression fails the build rather than as a CI flag. This suite
+# reaches 12%, so the gate is set there and the distance to 75 is closed by
+# writing tests for the packages below — never by lowering this number.
+COVERAGE_MIN := 12
+
 test:
-	go test ./...
+	go test ./... -coverprofile=coverage.out
+	@total=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/,"",$$3); print $$3}'); \
+	awk -v t="$$total" -v m="$(COVERAGE_MIN)" 'BEGIN { \
+	  if (t+0 < m+0) { printf "coverage %s%% is below the %s%% floor\n", t, m; exit 1 } \
+	  printf "coverage %s%% (floor %s%%)\n", t, m }'
 
 lint:
 	golangci-lint run ./...

--- a/templates/mcp-server-python/skeleton/.gitignore
+++ b/templates/mcp-server-python/skeleton/.gitignore
@@ -8,3 +8,9 @@ dist/
 .mypy_cache/
 *.pyc
 *.pyo
+
+# Coverage data written by pytest-cov
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml

--- a/templates/mcp-server-python/skeleton/pyproject.toml
+++ b/templates/mcp-server-python/skeleton/pyproject.toml
@@ -8,7 +8,11 @@ version = "0.1.0"
 description = "__DESCRIPTION__"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.27.0",
+    # Upper-bounded deliberately: mcp 2.0 removed mcp.server.fastmcp, which
+    # this skeleton is built on, so an unbounded floor resolves to a release
+    # the code cannot import. Within one major of current stable, so no @pin
+    # annotation is owed under standards/version-currency.json.
+    "mcp>=1.29.0,<2.0.0",
     "pydantic>=2.11.0",
     "pydantic-settings>=2.8.0",
     "fastapi>=0.115.0",
@@ -18,10 +22,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.3.0",
-    "pytest-asyncio>=0.26.0",
-    "ruff>=0.11.0",
-    "black>=25.1.0",
+    "pytest>=9.1.0",
+    "pytest-asyncio>=1.4.0",
+    "pytest-cov>=7.1.0",
+    "mypy>=2.3.0",
+    "ruff>=0.16.0",
 ]
 
 [project.scripts]
@@ -34,10 +39,44 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
-[tool.black]
-line-length = 100
-target-version = ["py310"]
-
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# The coverage floor published in nanohype/standards/testing-rubric.json,
+# encoded here rather than as a CI flag so a regression fails the build for
+# whoever caused it. Raise it as the suite grows, never lower it.
+addopts = "--cov=src --cov-report=term-missing --cov-fail-under=75"
+
+[tool.coverage.run]
+source = ["src"]
+omit = [
+    # Process entrypoint and transport wiring: argument parsing and a
+    # server.run() call, exercised by running the server rather than by a
+    # unit test. Same categories the TypeScript sibling excludes.
+    "src/main.py",
+    "src/logger.py",
+    "src/transports/*",
+    "src/__init__.py",
+    "src/*/__init__.py",
+]
+
+[tool.mypy]
+# language-toolchain.json names `mypy src` as the Python typecheck step.
+python_version = "3.10"
+strict = true
+warn_unreachable = true
+files = ["src"]
+
+[[tool.mypy.overrides]]
+# The MCP SDK ships types, but its FastMCP decorators are untyped enough that
+# strict mode cannot follow a decorated tool's signature.
+module = "mcp.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# main.py imports src.transports.__TRANSPORT__ — a placeholder the scaffolder
+# replaces with the chosen transport module. Unrendered, there is nothing at
+# that path to resolve; after rendering there is, and this override no longer
+# matches anything.
+module = "src.transports.__TRANSPORT__"
+ignore_missing_imports = true

--- a/templates/mcp-server-python/skeleton/src/logger.py
+++ b/templates/mcp-server-python/skeleton/src/logger.py
@@ -44,7 +44,7 @@ def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
     Returns:
         A bound structlog logger.
     """
-    logger = structlog.get_logger()
+    logger: structlog.stdlib.BoundLogger = structlog.get_logger()
     if name:
         logger = logger.bind(logger_name=name)
     return logger

--- a/templates/mcp-server-python/skeleton/src/server.py
+++ b/templates/mcp-server-python/skeleton/src/server.py
@@ -31,10 +31,10 @@ def create_server(config: Config) -> FastMCP:
     Returns:
         A fully configured FastMCP server instance.
     """
-    server = FastMCP(
-        name=config.server_name,
-        version=config.server_version,
-    )
+    # FastMCP takes no version argument — the MCP handshake advertises the
+    # protocol version, not the server's. The server's own version is surfaced
+    # through the server-info resource, which is where a client looks for it.
+    server = FastMCP(name=config.server_name)
 
     logger.info("server.create", name=config.server_name)
 

--- a/templates/mcp-server-python/skeleton/src/transports/http.py
+++ b/templates/mcp-server-python/skeleton/src/transports/http.py
@@ -29,8 +29,11 @@ def start(server: FastMCP, config: Config | None = None) -> None:
         host=config.host,
         port=config.port,
     )
+    # FastMCP.run takes only the transport and an optional mount path — host
+    # and port live on the server's settings, and passing them here raises
+    # TypeError the moment the transport starts.
+    server.settings.host = config.host
+    server.settings.port = config.port
     server.run(
         transport="streamable-http",
-        host=config.host,
-        port=config.port,
     )

--- a/templates/mcp-server-python/skeleton/tests/test_registries.py
+++ b/templates/mcp-server-python/skeleton/tests/test_registries.py
@@ -1,0 +1,122 @@
+"""Tests for the tool and resource registration helpers.
+
+These two wrappers are the pattern a consumer follows for every tool and
+resource they add, so what matters is not that they return something — it is
+that what they return actually lands on the server under the name and
+description given. A wrapper that registered nothing, or registered under the
+wrong name, would leave a server that starts cleanly and exposes an empty tool
+list to its client.
+"""
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from src.resources.registry import register_resource
+from src.tools.registry import register_tool
+
+
+@pytest.fixture
+def server() -> FastMCP:
+    return FastMCP(name="registry-test")
+
+
+class TestRegisterTool:
+    @pytest.mark.asyncio
+    async def test_registers_under_the_given_name(self, server: FastMCP) -> None:
+        @register_tool(server, name="shout", description="Uppercase a word")
+        def shout(word: str) -> str:
+            return word.upper()
+
+        tools = await server.list_tools()
+        assert [t.name for t in tools] == ["shout"]
+
+    @pytest.mark.asyncio
+    async def test_carries_the_description_through(self, server: FastMCP) -> None:
+        # The description is what an LLM selects on, so a wrapper that dropped
+        # it would leave the tool callable but effectively invisible.
+        @register_tool(server, name="shout", description="Uppercase a word")
+        def shout(word: str) -> str:
+            return word.upper()
+
+        tools = await server.list_tools()
+        assert tools[0].description == "Uppercase a word"
+
+    @pytest.mark.asyncio
+    async def test_the_registered_tool_is_callable(self, server: FastMCP) -> None:
+        @register_tool(server, name="shout", description="Uppercase a word")
+        def shout(word: str) -> str:
+            return word.upper()
+
+        content, structured = await server.call_tool("shout", {"word": "hey"})
+        assert content[0].text == "HEY"
+        assert structured["result"] == "HEY"
+
+    def test_returns_the_function_so_it_stays_directly_callable(self, server: FastMCP) -> None:
+        # Registration must not replace the function with the decorator's
+        # bookkeeping — the module that defines a tool usually also unit-tests
+        # it directly, without a server.
+        @register_tool(server, name="shout", description="Uppercase a word")
+        def shout(word: str) -> str:
+            return word.upper()
+
+        assert shout("hey") == "HEY"
+
+    @pytest.mark.asyncio
+    async def test_registrations_are_scoped_to_their_server(self) -> None:
+        # State is instance-scoped by design; a module-level registry would
+        # leak tools between servers in the same process.
+        first, second = FastMCP(name="first"), FastMCP(name="second")
+
+        @register_tool(first, name="only-on-first", description="…")
+        def only_on_first() -> str:
+            return "x"
+
+        assert [t.name for t in await first.list_tools()] == ["only-on-first"]
+        assert await second.list_tools() == []
+
+
+class TestRegisterResource:
+    @pytest.mark.asyncio
+    async def test_registers_under_the_given_uri(self, server: FastMCP) -> None:
+        @register_resource(server, "config://theme", name="Theme", mime_type="application/json")
+        def theme() -> str:
+            return '{"theme": "dark"}'
+
+        resources = await server.list_resources()
+        assert [str(r.uri) for r in resources] == ["config://theme"]
+
+    @pytest.mark.asyncio
+    async def test_carries_name_and_mime_type_through(self, server: FastMCP) -> None:
+        @register_resource(
+            server,
+            "config://theme",
+            name="Theme",
+            description="UI theme",
+            mime_type="application/json",
+        )
+        def theme() -> str:
+            return '{"theme": "dark"}'
+
+        resource = (await server.list_resources())[0]
+        assert resource.name == "Theme"
+        assert resource.description == "UI theme"
+        assert resource.mimeType == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_the_registered_resource_is_readable(self, server: FastMCP) -> None:
+        @register_resource(server, "config://theme", name="Theme")
+        def theme() -> str:
+            return '{"theme": "dark"}'
+
+        contents = list(await server.read_resource("config://theme"))
+        assert contents[0].content == '{"theme": "dark"}'
+
+    @pytest.mark.asyncio
+    async def test_optional_metadata_may_be_omitted(self, server: FastMCP) -> None:
+        # Every keyword defaults to None; passing none of them must still
+        # produce a resource a client can list.
+        @register_resource(server, "config://bare")
+        def bare() -> str:
+            return "x"
+
+        assert [str(r.uri) for r in await server.list_resources()] == ["config://bare"]

--- a/templates/mcp-server-python/skeleton/tests/test_server.py
+++ b/templates/mcp-server-python/skeleton/tests/test_server.py
@@ -1,7 +1,6 @@
 """Tests for MCP server lifecycle and tool listing."""
 
 import pytest
-
 from mcp.server.fastmcp import FastMCP
 
 from src.config import Config

--- a/templates/mcp-server-python/skeleton/tests/test_tools.py
+++ b/templates/mcp-server-python/skeleton/tests/test_tools.py
@@ -1,10 +1,9 @@
 """Tests for individual tool execution and validation."""
 
 import pytest
+from mcp.server.fastmcp import FastMCP
 
 from src.tools.example import Enthusiasm, GreetInput, format_greeting, register_example_tool
-
-from mcp.server.fastmcp import FastMCP
 
 
 class TestGreetInput:
@@ -60,23 +59,35 @@ class TestGreetToolExecution:
 
     @pytest.fixture
     def tool_server(self) -> FastMCP:
-        server = FastMCP(name="test-server", version="0.0.1")
+        server = FastMCP(name="test-server")
         register_example_tool(server)
         return server
 
+    # FastMCP.call_tool returns (content_blocks, structured_result). Both halves
+    # are asserted: a client reading the text blocks and one reading the
+    # structured payload must agree, and checking only one would miss a tool
+    # that populates it and drops the other.
+
     @pytest.mark.asyncio
     async def test_default_enthusiasm(self, tool_server: FastMCP) -> None:
-        result = await tool_server.call_tool("greet", {"name": "Alice"})
-        assert len(result) > 0
-        assert "Alice" in result[0].text
+        content, structured = await tool_server.call_tool("greet", {"name": "Alice"})
+        assert len(content) > 0
+        assert "Alice" in content[0].text
+        assert structured["result"] == content[0].text
 
     @pytest.mark.asyncio
     async def test_low_enthusiasm(self, tool_server: FastMCP) -> None:
-        result = await tool_server.call_tool("greet", {"name": "Bob", "enthusiasm": "low"})
-        assert result[0].text == "Hello, Bob."
+        content, structured = await tool_server.call_tool(
+            "greet", {"name": "Bob", "enthusiasm": "low"}
+        )
+        assert content[0].text == "Hello, Bob."
+        assert structured["result"] == "Hello, Bob."
 
     @pytest.mark.asyncio
     async def test_high_enthusiasm(self, tool_server: FastMCP) -> None:
-        result = await tool_server.call_tool("greet", {"name": "Carol", "enthusiasm": "high"})
-        assert "HELLO" in result[0].text
-        assert "Carol" in result[0].text
+        content, structured = await tool_server.call_tool(
+            "greet", {"name": "Carol", "enthusiasm": "high"}
+        )
+        assert "HELLO" in content[0].text
+        assert "Carol" in content[0].text
+        assert structured["result"] == content[0].text

--- a/templates/module-auth-go/skeleton/Makefile
+++ b/templates/module-auth-go/skeleton/Makefile
@@ -15,8 +15,18 @@ tidy:
 build:
 	go build ./...
 
+# Coverage floor. standards/testing-rubric.json publishes 75 and says to encode
+# it where a regression fails the build rather than as a CI flag. This suite
+# reaches 56%, so the gate is set there and the distance to 75 is closed by
+# writing tests for the packages below — never by lowering this number.
+COVERAGE_MIN := 56
+
 test:
-	go test ./...
+	go test ./... -coverprofile=coverage.out
+	@total=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/,"",$$3); print $$3}'); \
+	awk -v t="$$total" -v m="$(COVERAGE_MIN)" 'BEGIN { \
+	  if (t+0 < m+0) { printf "coverage %s%% is below the %s%% floor\n", t, m; exit 1 } \
+	  printf "coverage %s%% (floor %s%%)\n", t, m }'
 
 test-race:
 	go test -race ./...


### PR DESCRIPTION
The Python MCP skeleton **did not run on any version its own manifest allowed**, and neither it nor the three Go skeletons had a coverage gate. None of it was visible: the template test job only knows how to run `package.json` scripts, so no Python or Go skeleton has ever been executed by CI.

## mcp-server-python didn't import

The manifest asked for `mcp>=1.27.0`, unbounded. **mcp 2.0 removed `mcp.server.fastmcp`**, which this skeleton is built on — a fresh scaffold installed a release the code cannot import.

Bounded to `>=1.29.0,<2.0.0` (within one major of current stable, so `version-currency.json` owes no `@pin`).

On 1.x it was broken differently: `FastMCP(version=...)` isn't a parameter FastMCP takes, so `create_server` raised `TypeError` — **3 failed, 7 errors**. Dropped, since the MCP handshake advertises the *protocol* version and the server's own version was already on the server-info resource. Three tool tests asserted `result[0].text` when `call_tool` returns `(content_blocks, structured_result)`; they now assert **both halves**, since a tool populating one and dropping the other passes a check of either alone.

`server.run(host=..., port=...)` was the same error one layer down — `run` takes a transport and mount path; host/port live on `server.settings`. mypy found it once switched on.

## …and enforced nothing

pytest ran with no coverage plugin, no floor, no typecheck — the *"ships no thresholds at all"* anti-pattern `testing-rubric.json` names. Now `--cov=src --cov-fail-under=75` in `pyproject.toml` so the floor binds on plain `pytest`. **Reaches 92.75%.**

The two registration helpers were at **0%**. They're the pattern a consumer copies for every tool and resource they add, so they get tests asserting registration lands under the given name and description, the registered tool is callable and its two result halves agree, the decorator returns the original function, and registrations stay scoped to their server rather than leaking between instances.

mypy added at **strict** per `language-toolchain.json`, with narrow overrides for the SDK's untyped decorators and the `__TRANSPORT__` placeholder import. **black dropped** — the same standard's lint is `ruff check . && ruff format --check .`, and a second formatter over the same files is a disagreement waiting to happen. Two import-ordering violations ruff had never been run to find are fixed.

## The Go skeletons

All three ran `go test ./...` with no profile and no floor. `make test` now writes a profile and fails under a floor set at what each suite **actually** reaches — 34% / 12% / 56% — with the published 75 named next to it. These need tests written, not a number raised; a gate at 75 today would just mean nobody runs it.

## Verification

- Python suite from an **empty virtualenv** resolving only what the manifest asks for
- `ruff check`, `ruff format --check`, `mypy` strict — all clean
- Each Go gate passing, and **failing with the expected message** when its floor is raised past what the suite reaches