### PR TITLE
Gate skeleton configs against the standards this repo publishes

### DIFF
--- a/.github/workflows/template-doctor.yml
+++ b/.github/workflows/template-doctor.yml
@@ -14,13 +14,17 @@ on:
       - 'composites/**'
       - 'scripts/template-doctor/**'
       - '.github/workflows/template-doctor.yml'
+      # The standards group compares skeleton configs against these files, so
+      # raising a published floor has to run the check that enforces it —
+      # otherwise the bar moves and the catalog silently stops meeting it.
+      - 'standards/**'
   # Manual trigger for on-demand runs (e.g., before cutting a release).
   workflow_dispatch:
     inputs:
       only:
-        description: 'Limit to specific check groups (comma-separated: ts,go,java,python,cross)'
+        description: 'Limit to specific check groups (comma-separated: ts,go,java,python,cross,standards)'
         required: false
-        default: 'ts,go,java,python,cross'
+        default: 'ts,go,java,python,cross,standards'
 
 jobs:
   # Supply-chain gate. osv-scanner checks the committed lockfiles against the
@@ -80,7 +84,7 @@ jobs:
       - name: Run doctor
         id: doctor
         env:
-          ONLY: ${{ github.event.inputs.only || 'ts,go,java,python,cross' }}
+          ONLY: ${{ github.event.inputs.only || 'ts,go,java,python,cross,standards' }}
           # Gate pull requests on hard errors; cron / manual runs stay report-only.
           FAIL_ON: ${{ github.event_name == 'pull_request' && 'error' || '' }}
         run: |

--- a/scripts/template-doctor/Makefile
+++ b/scripts/template-doctor/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 DOCTOR := ./run.sh
 
-.PHONY: help doctor ts go java python cross markdown
+.PHONY: help doctor ts go java python cross standards markdown
 
 help:
 	@echo "Targets:"
@@ -11,6 +11,7 @@ help:
 	@echo "  java      Run Java checks only"
 	@echo "  python    Run Python checks only"
 	@echo "  cross     Run cross-cutting checks only"
+	@echo "  standards Run skeleton-config-vs-standards checks only"
 	@echo "  markdown  Emit the report as markdown on stdout"
 	@echo ""
 	@echo "Flags via env:"
@@ -36,6 +37,9 @@ python:
 
 cross:
 	$(DOCTOR) --only cross
+
+standards:
+	$(DOCTOR) --only standards
 
 markdown:
 	$(DOCTOR) --format markdown

--- a/scripts/template-doctor/README.md
+++ b/scripts/template-doctor/README.md
@@ -1,13 +1,16 @@
 # Template doctor
 
-Report-only catalog health tool. Runs per-ecosystem checks across every
-template under `templates/` and produces a grouped report of findings
-(outdated dependencies, broken builds, stale references, dead
-placeholders).
+Catalog health tool. Runs per-ecosystem checks across every template under
+`templates/` and produces a grouped report of findings (outdated
+dependencies, broken builds, stale references, dead placeholders, skeleton
+configs that fall below a published standard).
 
-The doctor never fails CI on findings. It exists to give maintainers
-visibility into catalog drift so it can be batch-fixed intentionally
-rather than surfacing as one-off bug reports.
+Two modes, and the difference matters. Scheduled and manual runs are
+report-only: they exist to give maintainers visibility into catalog drift
+so it can be batch-fixed intentionally rather than arriving as one-off bug
+reports. **Pull requests run with `--fail-on error`**, so a hard finding
+blocks the merge — drift that a maintainer would fix on their own schedule
+is one thing, and landing new drift is another.
 
 ## Quick start
 
@@ -21,6 +24,7 @@ make -C scripts/template-doctor go
 make -C scripts/template-doctor java
 make -C scripts/template-doctor python
 make -C scripts/template-doctor cross
+make -C scripts/template-doctor standards
 
 # Markdown report (stdout-safe for PR comments)
 make -C scripts/template-doctor markdown > report.md
@@ -34,6 +38,35 @@ make -C scripts/template-doctor markdown > report.md
 - `template.yaml` `composition.pairsWith` / `nestsInside` entries exist
 - Composites' `- template: X` entries reference a real template
 - Placeholders declared in `template.yaml` appear somewhere in `skeleton/`
+
+### Standards conformance (`standards.sh` + `standards.mjs`)
+
+Compares every skeleton's test configuration against the floor published in
+`standards/testing-rubric.json` and the toolchain named in
+`standards/language-toolchain.json`. The floor is read from the standard, never
+copied here — a second copy is a second thing to drift.
+
+- **TypeScript** — a coverage block exists; `coverage.enabled` is true, so
+  `vitest run` actually collects and the thresholds bind; all four metrics are
+  set; each is at or above the published floor.
+- **Python** — pytest runs with `--cov-fail-under` at or above the floor; mypy
+  is configured; black is not, since the standard's lint step is `ruff check .
+  && ruff format --check .` and two formatters over the same files disagree
+  eventually.
+- **Go** — the Makefile defines `COVERAGE_MIN`, so `make test` enforces
+  something.
+
+A skeleton whose suite does not yet reach the floor is pinned at what it
+measures and **declared** in `BELOW_FLOOR` / `GO_BELOW_FLOOR` with the reason.
+The check runs both directions: an undeclared shortfall is an error, and so is a
+declaration that no longer matches its config — a skeleton since raised leaves a
+stale apology behind, and one whose number drifted leaves a record describing a
+config that no longer exists.
+
+The reason this group exists at all: every TypeScript skeleton in this catalog
+once declared thresholds that `vitest run` never evaluated. A threshold that is
+present and a threshold that binds look identical in review, so the only way to
+tell them apart is a check that knows the difference.
 
 ### TypeScript (`ts.sh`)
 

--- a/scripts/template-doctor/checks/standards.mjs
+++ b/scripts/template-doctor/checks/standards.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Assert every skeleton's test configuration against the standards this repo
+ * publishes.
+ *
+ * The catalog is the vocabulary the factory scaffolds from, so a skeleton that
+ * ships below the published bar hands every consumer a project that starts in
+ * violation of a rule this repository owns. That had happened quietly and at
+ * scale: forty-three TypeScript skeletons declared coverage thresholds that
+ * `vitest run` never evaluated, nineteen of those numbers sat under the
+ * published floor, and the Python skeleton shipped no coverage configuration at
+ * all. None of it was detectable by reading a config, because a threshold that
+ * is present and a threshold that binds look identical.
+ *
+ * So this checks both directions, the same way the fix did:
+ *
+ *   - A skeleton below the floor must be DECLARED below it, with a reason.
+ *     Silence is the failure mode being prevented — a number nobody chose reads
+ *     exactly like a number someone did.
+ *   - A declaration that no longer matches its config is also an error. An
+ *     exception whose skeleton has since been raised is a stale apology, and one
+ *     whose value has drifted describes a config that no longer exists.
+ *
+ * Emits TSV on stdout: severity, category, template, message. standards.sh
+ * turns each line into a `finding`.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const TEMPLATES = join(ROOT, "templates");
+
+/** The published floor. Read, never hardcoded — this file must not become a second source. */
+const FLOOR = JSON.parse(readFileSync(join(ROOT, "standards", "testing-rubric.json"), "utf-8"))
+  .content.coverage_floor;
+
+/**
+ * Skeletons whose suites do not yet reach the floor, pinned at what they
+ * actually measure so a regression still fails, with what it would take to
+ * close the distance. Raising a number here without writing the tests puts the
+ * gate back to decorative, which is the exact failure this check exists to
+ * prevent.
+ */
+const BELOW_FLOOR = {
+  "ci-eval": {
+    lines: 55,
+    functions: 72,
+    statements: 55,
+    why: "assertions.ts and runner.ts carry the evaluation logic and are largely untested",
+  },
+  "eval-harness": {
+    lines: 72,
+    functions: 69,
+    statements: 72,
+    why: "assertions.ts is the reusable half and sits around two thirds covered",
+  },
+  "module-queue-ts": {
+    functions: 63,
+    lines: 73,
+    statements: 73,
+    why: "job.ts has no tests for its handler surface",
+  },
+  "module-webhook-ts": {
+    functions: 61,
+    why: "hmac-sha1.ts and the mock transport have no function-level coverage",
+  },
+  "multimodal-pipeline": {
+    lines: 52,
+    functions: 70,
+    statements: 52,
+    why: "the per-modality processors and the pipeline stage runner are untested",
+  },
+  "prompt-library": {
+    lines: 71,
+    functions: 71,
+    statements: 71,
+    why: "the recursive directory walk and the render helpers have no cases",
+  },
+};
+
+/** Go skeletons gate through a Makefile COVERAGE_MIN, pinned the same way. */
+const GO_BELOW_FLOOR = {
+  "go-cli": { min: 34, why: "cobra command bodies carry the logic and are untested" },
+  "go-service": { min: 12, why: "handlers, middleware and the repository layer have no tests" },
+  "module-auth-go": { min: 56, why: "the provider implementations are partially covered" },
+};
+
+const findings = [];
+const report = (severity, category, template, message) =>
+  findings.push([severity, category, template, message].join("\t"));
+
+/** Every file matching name under dir, skipping node_modules. */
+function findFiles(dir, name, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) findFiles(full, name, acc);
+    else if (entry === name) acc.push(full);
+  }
+  return acc;
+}
+
+const templates = readdirSync(TEMPLATES).filter((t) =>
+  existsSync(join(TEMPLATES, t, "template.yaml")),
+);
+
+// --- TypeScript ---------------------------------------------------------------
+
+for (const template of templates) {
+  const configs = findFiles(join(TEMPLATES, template, "skeleton"), "vitest.config.ts");
+  for (const config of configs) {
+    const where = relative(ROOT, config);
+    const source = readFileSync(config, "utf-8");
+
+    const coverage = source.match(/coverage:\s*\{/);
+    if (!coverage) {
+      report(
+        "error",
+        "coverage-config",
+        template,
+        `${where} declares no coverage block; standards/testing-rubric.json requires a floor encoded in the runner config`,
+      );
+      continue;
+    }
+
+    // The distinction that made this whole class of bug invisible: a threshold
+    // vitest never evaluates is indistinguishable from one it enforces.
+    if (!/coverage:\s*\{[^}]*?\benabled:\s*true/s.test(source)) {
+      report(
+        "error",
+        "coverage-inert",
+        template,
+        `${where} declares thresholds but not coverage.enabled, so \`vitest run\` collects nothing and the floor never binds`,
+      );
+    }
+
+    const block = source.match(/thresholds:\s*\{(.*?)\n\s*\}/s);
+    if (!block) {
+      report("error", "coverage-config", template, `${where} declares no thresholds`);
+      continue;
+    }
+
+    const declared = {};
+    for (const [, key, value] of block[1].matchAll(
+      /\b(lines|functions|statements|branches):\s*(\d+)/g,
+    )) {
+      declared[key] = Number(value);
+    }
+
+    const exception = BELOW_FLOOR[template];
+    for (const metric of Object.keys(FLOOR)) {
+      if (!(metric in declared)) {
+        report(
+          "error",
+          "coverage-config",
+          template,
+          `${where} sets no ${metric} threshold; the published floor names all four`,
+        );
+        continue;
+      }
+      const value = declared[metric];
+      const allowed = exception?.[metric];
+
+      if (value >= FLOOR[metric]) {
+        if (allowed !== undefined) {
+          report(
+            "error",
+            "stale-exception",
+            template,
+            `${metric} is ${value}, at or above the floor of ${FLOOR[metric]}, but BELOW_FLOOR still records ${allowed} — drop the entry`,
+          );
+        }
+        continue;
+      }
+      if (allowed === undefined) {
+        report(
+          "error",
+          "below-floor",
+          template,
+          `${where} sets ${metric} to ${value}, under the published floor of ${FLOOR[metric]}, and is not declared in BELOW_FLOOR — raise it or record why it cannot be raised`,
+        );
+      } else if (allowed !== value) {
+        report(
+          "error",
+          "stale-exception",
+          template,
+          `${metric} is ${value} but BELOW_FLOOR records ${allowed}; the config moved and the record did not`,
+        );
+      }
+    }
+  }
+}
+
+for (const template of Object.keys(BELOW_FLOOR)) {
+  if (!templates.includes(template)) {
+    report(
+      "error",
+      "stale-exception",
+      template,
+      `BELOW_FLOOR names a template that no longer exists — drop the entry`,
+    );
+  }
+}
+
+// --- Python -------------------------------------------------------------------
+
+for (const template of templates) {
+  const pyproject = join(TEMPLATES, template, "skeleton", "pyproject.toml");
+  if (!existsSync(pyproject)) continue;
+  const where = relative(ROOT, pyproject);
+  const source = readFileSync(pyproject, "utf-8");
+
+  const failUnder = source.match(/--cov-fail-under=(\d+)/);
+  if (!failUnder) {
+    report(
+      "error",
+      "coverage-config",
+      template,
+      `${where} runs pytest with no --cov-fail-under; a project that ships no thresholds at all is the anti-pattern testing-rubric.json names`,
+    );
+  } else if (Number(failUnder[1]) < FLOOR.lines) {
+    report(
+      "error",
+      "below-floor",
+      template,
+      `${where} sets --cov-fail-under=${failUnder[1]}, under the published floor of ${FLOOR.lines}`,
+    );
+  }
+
+  // language-toolchain.json names `mypy src` as the Python typecheck step and
+  // `ruff check . && ruff format --check .` as lint. black is a second
+  // formatter over the same files.
+  if (!/\[tool\.mypy\]/.test(source)) {
+    report(
+      "error",
+      "toolchain",
+      template,
+      `${where} configures no mypy; language-toolchain.json names \`mypy src\` as the Python typecheck`,
+    );
+  }
+  if (/\[tool\.black\]/.test(source)) {
+    report(
+      "error",
+      "toolchain",
+      template,
+      `${where} configures black alongside ruff; language-toolchain.json's lint step is \`ruff check . && ruff format --check .\``,
+    );
+  }
+}
+
+// --- Go -----------------------------------------------------------------------
+
+for (const template of templates) {
+  const makefile = join(TEMPLATES, template, "skeleton", "Makefile");
+  if (!existsSync(join(TEMPLATES, template, "skeleton", "go.mod"))) continue;
+  if (!existsSync(makefile)) {
+    report("error", "coverage-config", template, `a Go skeleton with no Makefile to gate coverage`);
+    continue;
+  }
+  const where = relative(ROOT, makefile);
+  const source = readFileSync(makefile, "utf-8");
+  const min = source.match(/^COVERAGE_MIN\s*:?=\s*(\d+)/m);
+
+  if (!min) {
+    report(
+      "error",
+      "coverage-config",
+      template,
+      `${where} defines no COVERAGE_MIN, so \`make test\` enforces no floor`,
+    );
+    continue;
+  }
+  const value = Number(min[1]);
+  const exception = GO_BELOW_FLOOR[template];
+  if (value >= FLOOR.lines) {
+    if (exception) {
+      report(
+        "error",
+        "stale-exception",
+        template,
+        `COVERAGE_MIN is ${value}, at or above the floor, but GO_BELOW_FLOOR still records ${exception.min} — drop the entry`,
+      );
+    }
+  } else if (!exception) {
+    report(
+      "error",
+      "below-floor",
+      template,
+      `${where} sets COVERAGE_MIN=${value}, under the published floor of ${FLOOR.lines}, and is not declared in GO_BELOW_FLOOR`,
+    );
+  } else if (exception.min !== value) {
+    report(
+      "error",
+      "stale-exception",
+      template,
+      `COVERAGE_MIN is ${value} but GO_BELOW_FLOOR records ${exception.min}; the Makefile moved and the record did not`,
+    );
+  }
+}
+
+for (const template of Object.keys(GO_BELOW_FLOOR)) {
+  if (!templates.includes(template)) {
+    report(
+      "error",
+      "stale-exception",
+      template,
+      `GO_BELOW_FLOOR names a template that no longer exists — drop the entry`,
+    );
+  }
+}
+
+process.stdout.write(findings.length ? `${findings.join("\n")}\n` : "");

--- a/scripts/template-doctor/checks/standards.sh
+++ b/scripts/template-doctor/checks/standards.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Standards checks: skeleton test configuration against standards/*.json.
+#
+# The analysis lives in standards.mjs — it reads the published floor out of
+# standards/testing-rubric.json and compares every skeleton's runner config
+# against it, in both directions (a shortfall must be declared; a declaration
+# must still match its config). This wrapper turns its TSV into findings.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR}/../lib/common.sh"
+
+check_standards() {
+  if ! command -v node >/dev/null 2>&1; then
+    log_warn "node not found — skipping standards checks"
+    return 0
+  fi
+
+  log_step "standards: skeleton configs against standards/*.json"
+
+  local output status=0
+  output="$(node "${SCRIPT_DIR}/standards.mjs" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ]; then
+    # The analysis itself failed — a malformed standards file, an unreadable
+    # skeleton. Reported rather than swallowed: a checker that cannot run and
+    # says nothing is indistinguishable from one that found nothing.
+    #
+    # Flattened to one line first. The report is TSV, so a stack trace pasted in
+    # whole becomes a dozen rows the renderer counts as findings and cannot
+    # attribute to any severity — the failure reads as twelve unknown problems
+    # instead of one broken checker.
+    finding "error" "standards" "-" "checker" \
+      "standards.mjs exited ${status}: $(printf '%s' "$output" | tr '\n\t' '  ' | cut -c1-400)"
+    return 0
+  fi
+
+  [ -z "$output" ] && return 0
+
+  local severity category template message
+  while IFS=$'\t' read -r severity category template message; do
+    [ -z "$severity" ] && continue
+    finding "$severity" "standards" "$template" "$category" "$message"
+  done <<< "$output"
+}

--- a/scripts/template-doctor/lib/report.sh
+++ b/scripts/template-doctor/lib/report.sh
@@ -40,7 +40,7 @@ render_report() {
 
   # Group by ecosystem, then category.
   local ecosystem
-  for ecosystem in ts go java python cross; do
+  for ecosystem in ts go java python cross standards; do
     local count
     count=$(awk -F'\t' -v eco="$ecosystem" '$2==eco' "$REPORT_FILE" | wc -l | tr -d ' ')
     [ "$count" -eq 0 ] && continue
@@ -109,7 +109,7 @@ render_markdown_report() {
     "$total" "$errors" "$warns" "$infos"
 
   local ecosystem
-  for ecosystem in ts go java python cross; do
+  for ecosystem in ts go java python cross standards; do
     local count
     count=$(awk -F'\t' -v eco="$ecosystem" '$2==eco' "$REPORT_FILE" | wc -l | tr -d ' ')
     [ "$count" -eq 0 ] && continue

--- a/scripts/template-doctor/run.sh
+++ b/scripts/template-doctor/run.sh
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   run.sh [--only <list>] [--skip <list>] [--format text|markdown] [--fail-on <sev>]
-#   --only    comma-separated subset of {ts,go,java,python,cross} (default: all)
+#   --only    comma-separated subset of {ts,go,java,python,cross,standards} (default: all)
 #   --skip    comma-separated subset to skip (runs after --only)
 #   --format  report format; default text. markdown is stdout-safe for PR comments.
 #   --fail-on exit non-zero on a finding at/above {error|warn|info}; default off (report-only)
@@ -22,7 +22,7 @@ CHECKS_DIR="${SCRIPT_DIR}/checks"
 # shellcheck source=lib/report.sh
 . "${SCRIPT_DIR}/lib/report.sh"
 
-ONLY="ts,go,java,python,cross"
+ONLY="ts,go,java,python,cross,standards"
 SKIP=""
 FORMAT="text"
 FAIL_ON=""
@@ -60,11 +60,13 @@ run_group() {
     java)   check_java ;;
     python) check_python ;;
     cross)  check_cross ;;
+    standards) check_standards ;;
   esac
 }
 
 log_step "template-doctor running (only=${ONLY}, skip=${SKIP:-none})"
 run_group cross
+run_group standards
 run_group ts
 run_group go
 run_group java


### PR DESCRIPTION
Closes the T48 loop: PRs #177 and #178 brought the catalog up to the published bar; this keeps it there.

The catalog is the vocabulary the factory scaffolds from, so a skeleton below the published bar hands every consumer a project that starts in violation of a rule this repository owns. That had happened at scale and was **undetectable by reading a config** — 43 TypeScript skeletons declared coverage thresholds `vitest run` never evaluated, and a threshold that is present looks exactly like one that binds.

## What it checks

A `standards` check group compares every skeleton's test configuration against `testing-rubric.json` and `language-toolchain.json`. **The floor is read out of the standard, never copied into the checker** — a second copy is a second thing to drift, which is the problem rather than the fix.

- **TypeScript** — coverage block exists; `coverage.enabled` true so thresholds bind; all four metrics set; each at or above the floor
- **Python** — `--cov-fail-under` at or above the floor; mypy configured; black absent
- **Go** — Makefile defines `COVERAGE_MIN`

## Both directions, deliberately

Skeletons that don't yet reach the floor are pinned at what they measure and **declared** in `BELOW_FLOOR` / `GO_BELOW_FLOOR` with the reason. An undeclared shortfall is an error — *and so is a declaration that no longer matches its config*. A skeleton since raised leaves a stale apology; one whose number drifted leaves a record describing a config that no longer exists.

Without that second direction the exception list just becomes the new place for numbers to rot.

## Two gaps wiring it in surfaced

- The workflow passed `--only` with an explicit group list, so **a new group would not have run in CI** despite being in run.sh's default.
- The PR trigger didn't watch `standards/**` — **raising a published floor would not have run the check that enforces it**, the one moment it matters most.

Also: the README claimed the doctor never fails CI. It has gated PRs with `--fail-on error` for as long as the workflow has existed. Corrected.

## Verification

Each failure it exists to catch, reintroduced:

| Mutation | Caught as |
|---|---|
| `coverage.enabled` removed | `coverage-inert` |
| undeclared drop below the floor | `below-floor` |
| declared exception silently raised | `stale-exception` |
| Go `COVERAGE_MIN` deleted | `coverage-config` |
| black added back to Python | `toolchain` |
| published floor moved in the standard | tracked — confirms it reads the file, not a copy |
| standard made unparseable | checker error, not a quiet pass |

That last case caught a defect in my own wrapper: the report is TSV, and pasting a multi-line stack trace into a finding turned one broken checker into twelve rows the renderer counted but couldn't attribute. Flattened.

End to end: `--fail-on error` exits 1 on a violation, 0 when clean.