### PR TITLE
feat: lint for unheld promises in the shared Biome base

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,11 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended"
+      "preset": "recommended",
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noMisusedPromises": "error"
+      }
     }
   },
   "javascript": {

--- a/library/config/biome.base.json
+++ b/library/config/biome.base.json
@@ -12,6 +12,10 @@
       "preset": "recommended",
       "style": {
         "noNonNullAssertion": "off"
+      },
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noMisusedPromises": "error"
       }
     }
   },


### PR DESCRIPTION
`noFloatingPromises` and `noMisusedPromises` at `error`, in the vendored `library/config/biome.base.json` the tenant repos consume and in this repo's own `biome.json`.

## Severity is the point

Both rules ship at `info` — they report the violation and still exit 0. A rule left at its default reads as enabled and gates nothing, and a survey that greps for `error` finds no hits and calls the tree clean. That default is exactly how two real floating promises survived in sibling repos.

## Why the base

`library/config/biome.base.json` is vendored byte-identical into every tenant repo behind a drift gate, so a policy declared once here reaches all of them and can't be quietly relaxed downstream. Four copies of the same two lines is the drift this file exists to prevent. Consumers keep their own `biome.json` for local overrides via `extends`.

## Why the root config too

This repo doesn't consume its own base. `sdk/` and `mcp-server/` carry no Biome config, so `biome check .` inside either resolves upward to the root `biome.json` — which is what the sdk and mcp-server workflows enforce.

## Verification

- Propagation: synced the new base into a consumer, planted a floating promise and a misused promise — both fail at `error`
- Resolution: planted a floating promise inside `sdk/`, confirmed the root config's rule fires there
- `sdk` lint exit 0, `mcp-server` lint exit 0, 140 sdk tests pass
- `validate:schema`, `validate:standards`, `validate:manifest`, `verify:catalog` all pass; catalog regenerates identically
- Zero new violations in this repo

Root `npm run lint` still exits 1 on pre-existing formatting, unchanged by this PR and untouched by CI per the note in `release.yml`.

## Sequencing

Merging this turns the four tenant repos' `vendored-drift` job red until each re-syncs — that job checks out `nanohype/nanohype` at its default branch. Re-syncs follow immediately.