### PR TITLE
fix: stop scaffolding known-vulnerable dependencies

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/catalog.schema.json",
   "kind": "nanohype/catalog",
   "version": "1",
-  "generated_at": "2026-07-29T19:29:57.000Z",
+  "generated_at": "2026-07-29T21:35:09.000Z",
   "templates": [
     {
       "name": "a2a-agent",

--- a/templates/api-gateway/skeleton/package.json
+++ b/templates/api-gateway/skeleton/package.json
@@ -15,8 +15,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "hono": "^4.7.0",
-    "@hono/node-server": "^1.13.0",
+    "hono": "^4.12.32",
+    "@hono/node-server": "^2.0.12",
     "jose": "^6.0.0",
     "@opentelemetry/api": "^1.9.0",
     "zod": "^3.24.0",

--- a/templates/multimodal-pipeline/skeleton/package.json
+++ b/templates/multimodal-pipeline/skeleton/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.4.0",
     "mime-types": "^2.1.35",
     "openai": "^4.85.0",
-    "sharp": "^0.33.0",
+    "sharp": "^0.35.3",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/templates/worker-service/skeleton/package.json
+++ b/templates/worker-service/skeleton/package.json
@@ -16,10 +16,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.0",
+    "@hono/node-server": "^2.0.12",
     "@opentelemetry/api": "^1.9.0",
     "dotenv": "^16.4.0",
-    "hono": "^4.7.0",
+    "hono": "^4.12.32",
     "zod": "^3.24.0"
   },
   "devDependencies": {


### PR DESCRIPTION
All three open advisories on this repository are in **template skeletons**, not in its own tooling — which makes them worse than they look. The catalog is the factory's vocabulary, so every project scaffolded from these templates started with a vulnerable dependency and an `npm audit` that was red on its first commit.

| Template | Bump | Advisory |
|---|---|---|
| multimodal-pipeline | sharp `^0.33.0` → `^0.35.3` | high |
| api-gateway, worker-service | @hono/node-server `^1.13.0` → `^2.0.12` | GHSA-frvp-7c67-39w9 (moderate) |
| api-gateway, worker-service | hono `^4.7.0` → `^4.12.32` | — |

**The Hono adapter is a major bump**, because no 1.x carries the fix. v2's breaking changes are dropping Node 18 and removing the Vercel adapter, and neither applies: both skeletons declare `engines.node >= 22`, neither imports `@hono/node-server/vercel`, and both use only `serve()`, whose signature is unchanged. `hono` moves with it since the adapter and framework are a pair and the range was five minors behind.

## Verification

Per skeleton, on a clean install with the lockfile regenerated: typecheck passes and the suites pass in all three. Both catalog gates (`validate:skeleton-toolchain`, `lint:skeletons`) stay green.