### PR TITLE
chore: make the base config the catalog's one Biome version, and check it

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/library/config/biome.base.json
+++ b/library/config/biome.base.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -16,7 +16,7 @@
         "nanohype-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.6",
         "@types/node": "^25.8.0",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "^5.7.0",
@@ -37,7 +37,7 @@
         "nanohype": "dist/bin/nanohype.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.6",
         "@types/node": "^25.8.0",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "^6.0.3",
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
+      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -124,20 +124,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.3",
-        "@biomejs/cli-darwin-x64": "2.5.3",
-        "@biomejs/cli-linux-arm64": "2.5.3",
-        "@biomejs/cli-linux-arm64-musl": "2.5.3",
-        "@biomejs/cli-linux-x64": "2.5.3",
-        "@biomejs/cli-linux-x64-musl": "2.5.3",
-        "@biomejs/cli-win32-arm64": "2.5.3",
-        "@biomejs/cli-win32-x64": "2.5.3"
+        "@biomejs/cli-darwin-arm64": "2.5.6",
+        "@biomejs/cli-darwin-x64": "2.5.6",
+        "@biomejs/cli-linux-arm64": "2.5.6",
+        "@biomejs/cli-linux-arm64-musl": "2.5.6",
+        "@biomejs/cli-linux-x64": "2.5.6",
+        "@biomejs/cli-linux-x64-musl": "2.5.6",
+        "@biomejs/cli-win32-arm64": "2.5.6",
+        "@biomejs/cli-win32-x64": "2.5.6"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
       "cpu": [
         "arm64"
       ],
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
       "cpu": [
         "x64"
       ],
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
+      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
       "cpu": [
         "arm64"
       ],
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
       "cpu": [
         "arm64"
       ],
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
+      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
       "cpu": [
         "x64"
       ],
@@ -229,9 +229,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
       "cpu": [
         "x64"
       ],
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
       "cpu": [
         "arm64"
       ],
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
       "cpu": [
         "x64"
       ],

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -37,7 +37,7 @@
     "@nanohype/sdk": "file:../sdk"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.3",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^25.8.0",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "^5.7.0",

--- a/scripts/check-skeleton-toolchain.mjs
+++ b/scripts/check-skeleton-toolchain.mjs
@@ -26,12 +26,27 @@
  *      skeleton is a failure rather than a local preference.
  *   3. No eslint or prettier config file survives anywhere under templates/.
  *   4. No manifest declares an eslint or prettier dependency.
- *   5. Every manifest declares @biomejs/biome.
+ *   5. Every manifest declares @biomejs/biome, pinned to an exact version.
  *   6. `lint`, `format` and `format:check` invoke Biome.
+ *   7. That version is the one `library/config/biome.base.json` declares in its
+ *      `$schema`, and each skeleton's own `$schema` names it too.
  *
  * Rule 2 is the one that matters over time. Without it each skeleton's config
  * is free to drift from the base, and the catalog goes back to teaching 48
  * slightly different bars.
+ *
+ * Rule 7 is why `$schema` is a local key at all. Biome only validates the
+ * `$schema` of the config it enters through, so a skeleton's is never checked by
+ * anything until someone scaffolds it — and even then a mismatch is an `info`,
+ * not a failure, so it never turns a build red. It stays wrong quietly, and an
+ * editor validates the config against rules the installed Biome does not have.
+ *
+ * The pin has to be exact for that to mean anything: `^2.5.6` resolves to
+ * whatever patch is newest at install time, so the `$schema` beside it starts
+ * lying on the next release and every scaffolded project inherits the lie.
+ * Exact is also what every repository in the org already does — Biome is the one
+ * dependency pinned rather than ranged, because a formatter that floats makes
+ * two contributors disagree about the same file.
  *
  *   node scripts/check-skeleton-toolchain.mjs
  */
@@ -45,10 +60,16 @@ const BASE_PATH = join(ROOT, "library", "config", "biome.base.json");
 
 /** Keys a skeleton may set beyond the shared base, and why. */
 const LOCAL_KEYS = new Set([
-  "$schema", // editor metadata, tracks whichever Biome the skeleton pins
+  "$schema", // editor metadata — excluded here, checked by rule 7 instead
   "files", // build-output paths differ per template
   "css", // only the Tailwind-bearing skeletons need the directive parser
 ]);
+
+/** The version in a `$schema` URL, or null when there isn't one. */
+function schemaVersion(config) {
+  const match = /biomejs\.dev\/schemas\/(\d+\.\d+\.\d+)\/schema\.json/.exec(config?.$schema ?? "");
+  return match ? match[1] : null;
+}
 
 const BANNED = /eslint|prettier/i;
 const CONFIG_NAMES =
@@ -80,6 +101,19 @@ function readJson(path) {
 const base = readJson(BASE_PATH);
 if (!base) {
   console.error("check-skeleton-toolchain: cannot read the shared Biome base");
+  process.exit(1);
+}
+
+// The base's `$schema` is the catalog's Biome version: one place to bump, and
+// rule 7 holds every skeleton to it. Without a parseable version here the rule
+// would compare everything against null and pass, so this is a hard stop.
+const BASE_VERSION = schemaVersion(base);
+if (!BASE_VERSION) {
+  console.error(
+    "check-skeleton-toolchain: library/config/biome.base.json has no versioned $schema\n" +
+      "  (expected https://biomejs.dev/schemas/<x.y.z>/schema.json) — it is the catalog's\n" +
+      "  Biome version, and nothing else names it.",
+  );
   process.exit(1);
 }
 
@@ -145,6 +179,20 @@ for (const dir of readdirSync(TEMPLATES, { withFileTypes: true })) {
       fail(relative(ROOT, configPath), `declares \`${key}\`, which the shared base does not`);
     }
   }
+
+  // 7a. Its `$schema` names the catalog's Biome version.
+  const version = schemaVersion(config);
+  if (version === null) {
+    fail(
+      relative(ROOT, configPath),
+      `has no versioned $schema — it should be https://biomejs.dev/schemas/${BASE_VERSION}/schema.json`,
+    );
+  } else if (version !== BASE_VERSION) {
+    fail(
+      relative(ROOT, configPath),
+      `$schema names Biome ${version}, but the catalog is on ${BASE_VERSION} (library/config/biome.base.json)`,
+    );
+  }
 }
 
 // 4-6. Manifest rules, for nested packages as well as skeleton roots.
@@ -161,8 +209,17 @@ for (const path of files) {
   for (const name of Object.keys(deps)) {
     if (BANNED.test(name)) fail(where, `declares \`${name}\` — the catalog is Biome-only`);
   }
-  if (!deps["@biomejs/biome"]) {
+  const pin = deps["@biomejs/biome"];
+  if (!pin) {
     fail(where, "does not declare @biomejs/biome, so its lint and format scripts cannot run");
+  } else if (pin !== BASE_VERSION) {
+    // 7b. Exact, and the catalog's version. A range would resolve to a newer
+    // patch than the `$schema` beside it names.
+    fail(
+      where,
+      `pins @biomejs/biome to \`${pin}\`, but the catalog is on exactly ${BASE_VERSION} ` +
+        "(library/config/biome.base.json's $schema) — an exact pin keeps that claim true",
+    );
   }
 
   for (const [name, command] of Object.entries(manifest.scripts ?? {})) {

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -15,7 +15,7 @@
         "nanohype": "dist/bin/nanohype.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.6",
         "@types/node": "^25.8.0",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "^6.0.3",
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
+      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -102,20 +102,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.3",
-        "@biomejs/cli-darwin-x64": "2.5.3",
-        "@biomejs/cli-linux-arm64": "2.5.3",
-        "@biomejs/cli-linux-arm64-musl": "2.5.3",
-        "@biomejs/cli-linux-x64": "2.5.3",
-        "@biomejs/cli-linux-x64-musl": "2.5.3",
-        "@biomejs/cli-win32-arm64": "2.5.3",
-        "@biomejs/cli-win32-x64": "2.5.3"
+        "@biomejs/cli-darwin-arm64": "2.5.6",
+        "@biomejs/cli-darwin-x64": "2.5.6",
+        "@biomejs/cli-linux-arm64": "2.5.6",
+        "@biomejs/cli-linux-arm64-musl": "2.5.6",
+        "@biomejs/cli-linux-x64": "2.5.6",
+        "@biomejs/cli-linux-x64-musl": "2.5.6",
+        "@biomejs/cli-win32-arm64": "2.5.6",
+        "@biomejs/cli-win32-x64": "2.5.6"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
       "cpu": [
         "arm64"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
       "cpu": [
         "x64"
       ],
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
+      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
       "cpu": [
         "arm64"
       ],
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
+      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
       "cpu": [
         "x64"
       ],
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
       "cpu": [
         "x64"
       ],
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
       "cpu": [
         "arm64"
       ],
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
       "cpu": [
         "x64"
       ],

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -37,7 +37,7 @@
     "js-yaml": "^5.2.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.3",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^25.8.0",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "^6.0.3",

--- a/templates/a2a-agent/skeleton/package.json
+++ b/templates/a2a-agent/skeleton/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/agent-orchestrator/skeleton/package.json
+++ b/templates/agent-orchestrator/skeleton/package.json
@@ -28,7 +28,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/agentic-loop/skeleton/package.json
+++ b/templates/agentic-loop/skeleton/package.json
@@ -24,7 +24,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/api-gateway/skeleton/package.json
+++ b/templates/api-gateway/skeleton/package.json
@@ -23,7 +23,7 @@
     "dotenv": "^16.4.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.8.0",

--- a/templates/chrome-ext/skeleton/package.json
+++ b/templates/chrome-ext/skeleton/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/chrome": "^0.0.287",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/templates/ci-eval/skeleton/package.json
+++ b/templates/ci-eval/skeleton/package.json
@@ -24,7 +24,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",

--- a/templates/data-pipeline/skeleton/package.json
+++ b/templates/data-pipeline/skeleton/package.json
@@ -26,7 +26,7 @@
     "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@types/pdf-parse": "^1.1.4",
     "@vitest/coverage-v8": "^4.1.4",

--- a/templates/discord-bot/skeleton/package.json
+++ b/templates/discord-bot/skeleton/package.json
@@ -24,7 +24,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/electron-app/skeleton/package.json
+++ b/templates/electron-app/skeleton/package.json
@@ -26,7 +26,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/templates/eval-harness/skeleton/package.json
+++ b/templates/eval-harness/skeleton/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "tsx": "^4.19.0",

--- a/templates/fine-tune-pipeline/skeleton/package.json
+++ b/templates/fine-tune-pipeline/skeleton/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "tsx": "^4.19.0",

--- a/templates/guardrails/skeleton/package.json
+++ b/templates/guardrails/skeleton/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "typescript": "^5.8.0",

--- a/templates/infra-aws/skeleton/package.json
+++ b/templates/infra-aws/skeleton/package.json
@@ -20,7 +20,7 @@
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/jest": "^29.5.0",
     "@types/node": "^22.0.0",
     "aws-cdk": "^2.178.0",

--- a/templates/llm-wiki/skeleton/package.json
+++ b/templates/llm-wiki/skeleton/package.json
@@ -33,7 +33,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/mcp-server-ts/skeleton/package.json
+++ b/templates/mcp-server-ts/skeleton/package.json
@@ -22,7 +22,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",

--- a/templates/module-analytics-ts/skeleton/package.json
+++ b/templates/module-analytics-ts/skeleton/package.json
@@ -28,7 +28,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-audit-ledger-ts/skeleton/package.json
+++ b/templates/module-audit-ledger-ts/skeleton/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0",
     "@vitest/coverage-v8": "^3.1.0",

--- a/templates/module-auth-ts/skeleton/package.json
+++ b/templates/module-auth-ts/skeleton/package.json
@@ -37,7 +37,7 @@
     "jose": "^6.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "typescript": "^5.8.0",

--- a/templates/module-billing-ts/skeleton/package.json
+++ b/templates/module-billing-ts/skeleton/package.json
@@ -26,7 +26,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-cache-ts/skeleton/package.json
+++ b/templates/module-cache-ts/skeleton/package.json
@@ -27,7 +27,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-database-ts/skeleton/package.json
+++ b/templates/module-database-ts/skeleton/package.json
@@ -34,7 +34,7 @@
     "pg": "^8.13.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0",

--- a/templates/module-feature-flags-ts/skeleton/package.json
+++ b/templates/module-feature-flags-ts/skeleton/package.json
@@ -26,7 +26,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-knowledge-base-ts/skeleton/package.json
+++ b/templates/module-knowledge-base-ts/skeleton/package.json
@@ -35,7 +35,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "typescript": "^5.8.0",

--- a/templates/module-llm-gateway/skeleton/package.json
+++ b/templates/module-llm-gateway/skeleton/package.json
@@ -36,7 +36,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.4",
     "tsx": "^4.21.0",

--- a/templates/module-llm-observability/skeleton/package.json
+++ b/templates/module-llm-observability/skeleton/package.json
@@ -31,7 +31,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.4",
     "tsx": "^4.19.0",

--- a/templates/module-llm-providers/skeleton/package.json
+++ b/templates/module-llm-providers/skeleton/package.json
@@ -36,7 +36,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.4",
     "tsx": "^4.21.0",

--- a/templates/module-media-ts/skeleton/package.json
+++ b/templates/module-media-ts/skeleton/package.json
@@ -27,7 +27,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-notifications-ts/skeleton/package.json
+++ b/templates/module-notifications-ts/skeleton/package.json
@@ -28,7 +28,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@types/web-push": "^3.6.0",
     "@vitest/coverage-v8": "^3.1.0",

--- a/templates/module-oauth-delegation-ts/skeleton/package.json
+++ b/templates/module-oauth-delegation-ts/skeleton/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1030.0",
     "@aws-sdk/client-kms": "^3.1030.0",
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@smithy/node-http-handler": "^4.0.0",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.4",

--- a/templates/module-observability-ts/skeleton/package.json
+++ b/templates/module-observability-ts/skeleton/package.json
@@ -34,7 +34,7 @@
     "@opentelemetry/semantic-conventions": "^1.41.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@opentelemetry/context-async-hooks": "^2.8.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",

--- a/templates/module-project-mgmt-ts/skeleton/package.json
+++ b/templates/module-project-mgmt-ts/skeleton/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-queue-ts/skeleton/package.json
+++ b/templates/module-queue-ts/skeleton/package.json
@@ -27,7 +27,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-rate-limit-ts/skeleton/package.json
+++ b/templates/module-rate-limit-ts/skeleton/package.json
@@ -27,7 +27,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-search-ts/skeleton/package.json
+++ b/templates/module-search-ts/skeleton/package.json
@@ -26,7 +26,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/module-semantic-cache/skeleton/package.json
+++ b/templates/module-semantic-cache/skeleton/package.json
@@ -32,7 +32,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.4",
     "tsx": "^4.21.0",

--- a/templates/module-storage-ts/skeleton/package.json
+++ b/templates/module-storage-ts/skeleton/package.json
@@ -32,7 +32,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "typescript": "^5.8.0",

--- a/templates/module-vector-store/skeleton/package.json
+++ b/templates/module-vector-store/skeleton/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@types/pg": "^8.11.0",
     "@vitest/coverage-v8": "^4.1.4",

--- a/templates/module-webhook-ts/skeleton/package.json
+++ b/templates/module-webhook-ts/skeleton/package.json
@@ -24,7 +24,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/templates/monorepo/skeleton/package.json
+++ b/templates/monorepo/skeleton/package.json
@@ -14,7 +14,7 @@
     "clean": "turbo run clean && rm -rf node_modules"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "turbo": "^2.4.0",
     "typescript": "^5.8.0"
   },

--- a/templates/monorepo/skeleton/packages/shared-ui/package.json
+++ b/templates/monorepo/skeleton/packages/shared-ui/package.json
@@ -22,7 +22,7 @@
     "format:check": "biome format ."
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "typescript": "^5.8.0"
   }
 }

--- a/templates/monorepo/skeleton/packages/shared-utils/package.json
+++ b/templates/monorepo/skeleton/packages/shared-utils/package.json
@@ -22,7 +22,7 @@
     "format:check": "biome format ."
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "typescript": "^5.8.0"
   }
 }

--- a/templates/multimodal-pipeline/skeleton/package.json
+++ b/templates/multimodal-pipeline/skeleton/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/mime-types": "^2.1.4",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",

--- a/templates/next-app/skeleton/package.json
+++ b/templates/next-app/skeleton/package.json
@@ -30,7 +30,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@tailwindcss/postcss": "^4.1.0",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^24.13.2",

--- a/templates/prompt-library/skeleton/package.json
+++ b/templates/prompt-library/skeleton/package.json
@@ -11,7 +11,7 @@
     "format:check": "biome format ."
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "ajv": "^8.17.0",
     "tsx": "^4.19.0",
     "yaml": "^2.7.0"

--- a/templates/prompt-library/skeleton/sdk/package.json
+++ b/templates/prompt-library/skeleton/sdk/package.json
@@ -18,7 +18,7 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",

--- a/templates/rag-pipeline/skeleton/package.json
+++ b/templates/rag-pipeline/skeleton/package.json
@@ -30,7 +30,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@types/pg": "^8.11.0",
     "@vitest/coverage-v8": "^4.1.4",

--- a/templates/slack-bot/skeleton/package.json
+++ b/templates/slack-bot/skeleton/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.4",
     "tsx": "^4.21.0",

--- a/templates/test-automation/skeleton/package.json
+++ b/templates/test-automation/skeleton/package.json
@@ -18,7 +18,7 @@
     "@faker-js/faker": "^9.3.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@playwright/test": "^1.50.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.8.0"

--- a/templates/ts-service/skeleton/package.json
+++ b/templates/ts-service/skeleton/package.json
@@ -29,7 +29,7 @@
     "dotenv": "^17.4.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.0",
     "tsx": "^4.21.0",

--- a/templates/vscode-ext/skeleton/package.json
+++ b/templates/vscode-ext/skeleton/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/templates/worker-service/skeleton/package.json
+++ b/templates/worker-service/skeleton/package.json
@@ -23,7 +23,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "tsx": "^4.19.0",

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.6",
         "@types/node": "^25.8.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.6"
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
+      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -32,20 +32,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.3",
-        "@biomejs/cli-darwin-x64": "2.5.3",
-        "@biomejs/cli-linux-arm64": "2.5.3",
-        "@biomejs/cli-linux-arm64-musl": "2.5.3",
-        "@biomejs/cli-linux-x64": "2.5.3",
-        "@biomejs/cli-linux-x64-musl": "2.5.3",
-        "@biomejs/cli-win32-arm64": "2.5.3",
-        "@biomejs/cli-win32-x64": "2.5.3"
+        "@biomejs/cli-darwin-arm64": "2.5.6",
+        "@biomejs/cli-darwin-x64": "2.5.6",
+        "@biomejs/cli-linux-arm64": "2.5.6",
+        "@biomejs/cli-linux-arm64-musl": "2.5.6",
+        "@biomejs/cli-linux-x64": "2.5.6",
+        "@biomejs/cli-linux-x64-musl": "2.5.6",
+        "@biomejs/cli-win32-arm64": "2.5.6",
+        "@biomejs/cli-win32-x64": "2.5.6"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
       "cpu": [
         "arm64"
       ],
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
       "cpu": [
         "x64"
       ],
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
+      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
       "cpu": [
         "arm64"
       ],
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
       "cpu": [
         "arm64"
       ],
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
+      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
       "cpu": [
         "arm64"
       ],
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
       "cpu": [
         "x64"
       ],

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -40,7 +40,7 @@
     "nanohype"
   ],
   "devDependencies": {
-    "@biomejs/biome": "2.5.3",
+    "@biomejs/biome": "2.5.6",
     "@types/node": "^25.8.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"


### PR DESCRIPTION
The catalog carried three answers to "which Biome is this?". The root config declared schema 2.5.3 while the root manifest pinned 2.5.6, so every Biome run in this repository reported the mismatch and nobody saw it. The shared base declared 2.5.3, which is what the four tenant repositories vendor. And the skeletons ranged `^2.5.6` beside a `$schema` naming 2.5.6 exactly.

Everything now reads 2.5.6, and the base's `$schema` is where that version lives.

## Why nothing caught this

Biome validates the `$schema` of the config it enters through and no further, so a base pulled in by `extends` is never checked, and a skeleton's config is not read by anything in this repository at all — `biome.json` is data until someone scaffolds it. Even where it is checked, a mismatch is an `info`. It never turns a build red.

So the failure mode is silent in both directions: an editor validates against rules the installed Biome does not have, and a config key that moved between versions is accepted by one and dropped by the other.

## Exact pins

The skeletons ranged where every repository in the org pins. Biome is the one dependency the org pins rather than ranges, because a formatter that floats makes two contributors disagree about the same file — and a range beside a versioned `$schema` guarantees the two disagree on the next patch release, in every project scaffolded from that point on.

## The gate

`check-skeleton-toolchain.mjs` gains rule 7: each skeleton's `$schema` names the version the base declares, and each manifest pins exactly that version. The base becomes the single place to bump, and `$schema` stops being untracked editor metadata — which is what its exclusion from the rule-for-rule comparison had quietly made it.

A base with no parseable version in its `$schema` is a hard stop rather than a skipped rule: comparing 51 manifests against null would report the catalog compliant.

## Verification

The three ways this can break — a ranged pin, a skeleton `$schema` behind the base, and a base with no version — each fail the gate with the file named. Every check the template workflow runs passes.

`biome.base.json` is vendored into the four tenant repositories, so they pick this up by re-syncing at a new pin.