### PR TITLE
fix: invoke Claude through inference profiles, and gate the model IDs

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -101,6 +101,15 @@ jobs:
       - name: Validate standards manifests
         run: npm run validate:standards
 
+      # A model ID is a plain string, so no compiler, linter or type checker has
+      # an opinion about it — a scaffold born on a retired or never-existent ID
+      # fails only at the first invocation, in the consumer's project. This
+      # checks every ID against the set standards/llm-policy.json names, and
+      # rejects a bare Bedrock foundation-model ID in invoke position (the
+      # current Claude family is INFERENCE_PROFILE-only, so those are refused).
+      - name: Verify model IDs match the LLM policy
+        run: npm run validate:model-ids
+
       - name: Verify catalog is regenerated (no drift)
         run: npm run verify:catalog
 

--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/catalog.schema.json",
   "kind": "nanohype/catalog",
   "version": "1",
-  "generated_at": "2026-07-29T21:35:09.000Z",
+  "generated_at": "2026-07-30T02:27:09.000Z",
   "templates": [
     {
       "name": "a2a-agent",

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -81,7 +81,7 @@ import Anthropic from '@anthropic-ai/sdk';
 
 const client = new Anthropic();
 const message = await client.messages.create({
-  model: 'claude-sonnet-4-6',
+  model: 'claude-sonnet-5',
   max_tokens: 1024,
   mcp_servers: [
     {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "validate:schema": "node scripts/validate-schema.mjs --schema schemas/template.schema.json --data 'templates/*/template.yaml'",
     "validate:catalog": "./scripts/validate-catalog.sh",
     "validate:standards": "node scripts/validate-schema.mjs --schema schemas/standards.schema.json --data 'standards/*.json' && node scripts/check-tagging-standard.mjs",
+    "validate:model-ids": "node scripts/check-model-ids.mjs",
     "validate:manifest": "node scripts/validate-schema.mjs --schema schemas/catalog.schema.json --data catalog.json",
     "validate:doc-commands": "node scripts/check-doc-commands.mjs",
     "validate:skeleton-toolchain": "node scripts/check-skeleton-toolchain.mjs",

--- a/scripts/check-model-ids.mjs
+++ b/scripts/check-model-ids.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+//
+// check-model-ids.mjs — fail if a Claude model ID in the catalog is not one the
+// LLM policy names, or is written in a form Bedrock refuses.
+//
+// Two separate failure modes, both of which shipped:
+//
+//   1. Retired and never-existent IDs. A scaffold born on
+//      claude-sonnet-4-20250514 (retired) or claude-haiku-4-20250514 (never
+//      existed) 404s on its first call. Nothing caught it because a model ID is
+//      just a string — no compiler, linter or type checker has an opinion.
+//
+//   2. Bare Bedrock foundation-model IDs in invoke position. The whole current
+//      Claude family reports inferenceTypesSupported: [INFERENCE_PROFILE], so
+//      anthropic.claude-sonnet-5 is refused with a ValidationException while
+//      us.anthropic.claude-sonnet-5 works. The policy said so in prose while
+//      every skeleton default contradicted it.
+//
+// The allowed set is derived from standards/llm-policy.json rather than listed
+// here, so moving the catalog to a new model is one edit to the standard and
+// this gate follows. Same reason check-slo-constants.mjs reads its numbers from
+// the standard instead of transcribing them.
+//
+// Usage: node scripts/check-model-ids.mjs [root]
+
+import { globSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+const root = resolve(process.argv[2] ?? ".");
+const STANDARD = resolve(root, "standards/llm-policy.json");
+
+const declared = Object.values(JSON.parse(readFileSync(STANDARD, "utf-8")).content.models);
+
+const GEOS = ["us", "eu", "jp", "ap", "apac", "global"];
+const GEO = new RegExp(`^(?:${GEOS.join("|")})\\.`);
+// Bedrock carries a release date and API version on some IDs and not others —
+// claude-haiku-4-5-20251001-v1:0 against a dateless claude-sonnet-5 — and the
+// direct Anthropic API never carries either. Strip them to get the one model
+// name both delivery paths share, so a single declaration covers both.
+const BEDROCK_SUFFIX = /(?:-\d{8})?(?:-v\d+(?::\d+)?)?$/;
+
+/** The model name the direct Anthropic API uses, from any spelling of the ID. */
+const directName = (id) =>
+  id
+    .replace(GEO, "")
+    .replace(/^anthropic\./, "")
+    .replace(BEDROCK_SUFFIX, "");
+
+const bareNames = new Set(declared.map(directName));
+if (bareNames.size !== declared.length) {
+  console.error(`check-model-ids: ${STANDARD} declares the same model twice.`);
+  process.exit(1);
+}
+
+// Model IDs the catalog may use, in any of the three forms a caller needs:
+// the direct-API name, the Bedrock foundation-model ID, and the inference
+// profile. The foundation-model form is allowed in a pricing key or an IAM
+// resource — the invoke-position rule below is what rejects it as a default.
+// Bedrock's own form for a model may carry the release date and API version the
+// direct-API name omits, and both spellings appear legitimately (a pricing key
+// keyed on the foundation-model ID, an inference profile that keeps the date).
+// Accept the declared IDs verbatim alongside every derived spelling.
+const allowed = new Set(declared);
+for (const name of bareNames) {
+  const bedrock = declared.find((id) => directName(id) === name).replace(GEO, "");
+  for (const form of new Set([name, bedrock, `anthropic.${name}`])) {
+    allowed.add(form);
+    if (form.startsWith("anthropic.")) {
+      for (const geo of GEOS) allowed.add(`${geo}.${form}`);
+    }
+  }
+}
+
+// What counts as a Claude model ID. Anchored on a family word so prose ("Claude
+// is the primary LLM"), package names (claude-agent-sdk, claude-cli) and
+// arbitrary label strings in fixtures are not swept in. A trailing -vN:M or
+// date is part of the ID.
+const MODEL_ID =
+  /\b(?:(?:us|eu|jp|ap|apac|global)\.)?(?:anthropic\.)?claude-(?:opus|sonnet|haiku)-[0-9][A-Za-z0-9.:-]*/g;
+
+// Invoke position: a bare foundation-model ID assigned as a model default or
+// passed as a model argument. Matching the assignment rather than the file lets
+// a pricing table keep the bare form, which is the correct key there.
+const INVOKE_CONTEXT = /(?:model|modelId|LLM_MODEL|DEFAULT_MODEL|ModelId)\s*[:=]|\.default\(|\?\?/i;
+
+// `dist/` is gitignored build output inside skeletons that have been compiled
+// locally — it holds a stale copy of source this gate already reads, so a hit
+// there is a duplicate of a hit it will report anyway, or a false one for code
+// that no longer exists. This script is skipped because naming the bad IDs is
+// its job.
+const SKIP =
+  /(?:^|[/\\])(?:node_modules|dist|\.git|\.turbo)[/\\]|scripts[/\\]check-model-ids\.mjs$/;
+// The dotfile pattern is separate because `*` does not match a leading dot, and
+// `.env.example` is exactly where a scaffold's model ID is configured — the most
+// important file to scan was the one a single glob silently skipped.
+const files = [
+  ...globSync("**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,json,yaml,yml,md,example}", { cwd: root }),
+  ...globSync("**/.env*", { cwd: root }),
+].filter((p) => !SKIP.test(p));
+
+const unknown = [];
+const bareInvoke = [];
+
+for (const rel of files) {
+  const path = resolve(root, rel);
+  let text;
+  try {
+    text = readFileSync(path, "utf-8");
+  } catch {
+    continue; // a directory matched the glob
+  }
+  if (!text.includes("claude-")) continue;
+
+  const lines = text.split("\n");
+  for (const [i, line] of lines.entries()) {
+    for (const id of line.match(MODEL_ID) ?? []) {
+      const where = `${relative(root, path)}:${i + 1}`;
+      if (!allowed.has(id)) {
+        unknown.push(`${where}  ${id}`);
+        continue;
+      }
+      // Allowed, but is it the refused form in a position that invokes?
+      if (/^anthropic\./.test(id) && INVOKE_CONTEXT.test(line)) {
+        bareInvoke.push(`${where}  ${id}`);
+      }
+    }
+  }
+}
+
+let failed = false;
+
+if (unknown.length) {
+  failed = true;
+  console.error(
+    `check-model-ids: ${unknown.length} Claude model ID(s) the LLM policy does not name.\n` +
+      `Allowed model names: ${[...bareNames].sort().join(", ")}\n` +
+      `Either use one of those, or move the catalog forward by editing\n` +
+      `standards/llm-policy.json — this gate reads its allowed set from there.\n`,
+  );
+  for (const u of unknown) console.error(`  ${u}`);
+}
+
+if (bareInvoke.length) {
+  failed = true;
+  console.error(
+    `\ncheck-model-ids: ${bareInvoke.length} bare Bedrock foundation-model ID(s) in invoke position.\n` +
+      `The current Claude family is INFERENCE_PROFILE-only, so these are refused with a\n` +
+      `ValidationException on the first call. Prefix with the deploy region's geo —\n` +
+      `us.anthropic.<model> — or, for the direct Anthropic API, drop the provider prefix.\n`,
+  );
+  for (const b of bareInvoke) console.error(`  ${b}`);
+}
+
+if (failed) process.exit(1);
+
+console.log(
+  `check-model-ids: every Claude model ID in the catalog is one the LLM policy names ` +
+    `(${[...bareNames].sort().join(", ")}), and none is a bare foundation-model ID in ` +
+    `invoke position.`,
+);

--- a/sdk/__tests__/standards.test.ts
+++ b/sdk/__tests__/standards.test.ts
@@ -41,7 +41,14 @@ describe("loadStandard", () => {
     const s = await loadStandard(source, "llm-policy");
     if (s.kind !== "nanohype/standards/llm-policy") throw new Error("kind narrow");
     expect(s.content.primary_provider).toBe("AWS Bedrock");
-    expect(s.content.models.default).toMatch(/^anthropic\.claude-sonnet/);
+    // Every declared tier is a cross-region inference-profile ID, geo prefix and
+    // all. The current Claude family is INFERENCE_PROFILE-only on Bedrock, so a
+    // bare `anthropic.`-prefixed default would name something that cannot be
+    // invoked — which is what this policy shipped before.
+    expect(s.content.models.default).toMatch(/^us\.anthropic\.claude-sonnet/);
+    for (const id of Object.values(s.content.models)) {
+      expect(id).toMatch(/^(?:us|eu|jp|ap|apac|global)\.anthropic\./);
+    }
     expect(s.content.regions_preferred).toContain("us-west-2");
   });
 

--- a/standards/README.md
+++ b/standards/README.md
@@ -67,15 +67,17 @@ OTel resource attributes every pod must emit: `agents.tenant`, `agents.platform`
 
 ## LLM policy — `llm-policy.json`
 
-Claude via **AWS Bedrock** is the primary LLM. Authentication is IAM-role-based (Pod Identity on EKS, task role on ECS, execution role on Lambda) — never API keys. On-demand invoke uses cross-region inference profile IDs (`us.anthropic.…`); bare foundation-model IDs are refused.
+Claude via **AWS Bedrock** is the primary LLM. Authentication is IAM-role-based (Pod Identity on EKS, task role on ECS, execution role on Lambda) — never API keys.
+
+Every current Claude model is invoked through a **cross-region inference-profile ID**, never the bare foundation-model ID. Bedrock reports `inferenceTypesSupported: [INFERENCE_PROFILE]` for the whole family — there is no on-demand path — so `anthropic.claude-sonnet-5` is refused with a `ValidationException` while `us.anthropic.claude-sonnet-5` works. The geo prefix tracks the deploy region (`us.`, `eu.`); prefer it over `global.` so routing stays inside the intended jurisdiction.
 
 Models (from `llm-policy.json`):
 
-- **Default**: `anthropic.claude-sonnet-4-6` — most work
-- **Escalation**: `anthropic.claude-opus-4-8` — complex reasoning, architecture decisions
-- **Light**: `anthropic.claude-haiku-4-5` — classification, routing, filter steps
+- **Default**: `us.anthropic.claude-sonnet-5` — most work
+- **Escalation**: `us.anthropic.claude-opus-5` — complex reasoning, architecture decisions
+- **Light**: `us.anthropic.claude-haiku-4-5-20251001-v1:0` — classification, routing, filter steps
 
-Regions in order of preference: `us-west-2`, `us-east-1`, `eu-central-1`. Verify the chosen model is available in the deploy region before committing IaC.
+Regions in order of preference: `us-west-2`, `us-east-1`, `eu-central-1`. Verify the model's inference profile is `ACTIVE` in the deploy region before committing IaC — `aws bedrock list-inference-profiles` — not merely that the foundation model is listed.
 
 Prompt caching is mandatory — use Bedrock `cachePoint` markers on the system prompt and any stable context prefix; measure cache-hit ratio and surface it in the architecture artifact.
 

--- a/standards/llm-policy.json
+++ b/standards/llm-policy.json
@@ -7,9 +7,9 @@
   "content": {
     "primary_provider": "AWS Bedrock",
     "models": {
-      "default": "anthropic.claude-sonnet-4-6",
-      "escalation": "anthropic.claude-opus-4-8",
-      "light": "anthropic.claude-haiku-4-5"
+      "default": "us.anthropic.claude-sonnet-5",
+      "escalation": "us.anthropic.claude-opus-5",
+      "light": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
     },
     "regions_preferred": ["us-west-2", "us-east-1", "eu-central-1"],
     "sdk_by_language": {
@@ -27,11 +27,15 @@
       },
       {
         "id": "default-sonnet",
-        "summary": "Use claude-sonnet-4-6 for the bulk of inference. Escalate to opus only for complex reasoning or architecture decisions. Use haiku for classification, routing, and filter steps."
+        "summary": "Use claude-sonnet-5 for the bulk of inference. Escalate to claude-opus-5 only for complex reasoning or architecture decisions. Use claude-haiku-4-5 for classification, routing, and filter steps."
+      },
+      {
+        "id": "inference-profile-required",
+        "summary": "Invoke every current Claude model through a cross-region inference-profile ID, never the bare foundation-model ID. Bedrock reports inferenceTypesSupported: [INFERENCE_PROFILE] for the whole current Claude family — there is no ON_DEMAND path — so a bare ID such as anthropic.claude-sonnet-5 is refused with a ValidationException on the first call. The geo prefix must match the deploy region: us. for us-east-1 / us-west-2, eu. for eu-central-1. Prefer a geo prefix over global. so routing stays inside the intended jurisdiction. Confirm with: aws bedrock list-inference-profiles."
       },
       {
         "id": "verify-region",
-        "summary": "Verify the chosen model is available in the deploy region before committing IaC. Cross-region inference profiles (us.anthropic.*) work but require explicit configuration."
+        "summary": "Verify the chosen model is available in the deploy region before committing IaC. Check the model's inference profile is ACTIVE there, not merely that the foundation model is listed."
       },
       {
         "id": "prompt-caching-mandatory",

--- a/templates/a2a-agent/skeleton/src/providers/anthropic.ts
+++ b/templates/a2a-agent/skeleton/src/providers/anthropic.ts
@@ -10,7 +10,7 @@ class AnthropicProvider implements LlmProvider {
   async sendMessage(systemPrompt: string, messages: Message[]): Promise<LlmResponse> {
     const response = await cb.execute(() =>
       client.messages.create({
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-5",
         max_tokens: 4096,
         system: systemPrompt,
         messages: messages.map((m) => ({

--- a/templates/agent-fleet/README.md
+++ b/templates/agent-fleet/README.md
@@ -18,7 +18,7 @@ Both CRs derive their namespace, ownership, and IRSA from the Platform via `spec
 | `Tenant`      | string | (required)                    | Owning team — sets the `tenants-<team>` namespace, matching the Platform                                                          |
 | `AppName`     | string | (required)                    | Companion Platform tenant name (matches `k8s-app-tenant`'s `AppName`); used as `spec.platformRef.name`                            |
 | `ModelFamily` | string | `anthropic`                   | Bedrock model family for the gateway route — `anthropic`, `meta`, `mistral`, `cohere`, `amazon-titan`, `amazon-nova`, `stability` |
-| `ModelId`     | string | `anthropic.claude-sonnet-4-6` | Bedrock model ID (or inference-profile ID) for the gateway route                                                                  |
+| `ModelId`     | string | `us.anthropic.claude-sonnet-5` | Bedrock model ID (or inference-profile ID) for the gateway route                                                                  |
 | `RouteName`   | string | (required)                    | ModelGateway route name referenced by each `AgentFleet.spec.agents[].modelRoute`                                                  |
 | `Compute`     | string | `none`                        | Accelerator — `none` (CPU), `nvidia-l40s`, `nvidia-h100`, `neuron`. Non-`none` references an `AcceleratorClaim` CR by name        |
 

--- a/templates/agent-fleet/skeleton/modelgateway.yaml
+++ b/templates/agent-fleet/skeleton/modelgateway.yaml
@@ -24,9 +24,14 @@ spec:
       modelFamily: __MODEL_FAMILY__
       modelId: __MODEL_ID__
 
-      # Cross-region inference profile (e.g. us.anthropic.claude-sonnet-4-6).
-      # Leave empty to pin to the gateway's home region. Per LLM policy, prefer
-      # the us.* profile so capacity spans us-west-2 / us-east-1.
+      # Redundant here: modelId accepts an inference-profile ID directly and the
+      # default above is already the us.* profile, which is what the current
+      # Claude family requires — Bedrock reports
+      # inferenceTypesSupported: [INFERENCE_PROFILE] for all of it, so there is no
+      # home region to pin to and a bare anthropic.* ID is refused. Set this only
+      # to route a bare foundation-model ID (an older model, or a non-Anthropic
+      # family) through a profile without changing modelId; it overrides modelId
+      # when non-empty.
       crossRegionProfile: ""
 
       # Requests-per-minute cap enforced at the gateway — defends downstream

--- a/templates/agent-fleet/template.yaml
+++ b/templates/agent-fleet/template.yaml
@@ -60,9 +60,9 @@ variables:
   - name: ModelId
     type: string
     placeholder: '__MODEL_ID__'
-    description: 'Bedrock model ID (full path including version).'
-    prompt: 'Bedrock model ID'
-    default: 'anthropic.claude-sonnet-4-6'
+    description: 'Bedrock inference-profile ID, or a foundation-model ID for a family that still offers on-demand invoke. The current Claude family is inference-profile-only, so it needs the geo prefix.'
+    prompt: 'Bedrock model or inference-profile ID'
+    default: 'us.anthropic.claude-sonnet-5'
 
   - name: RouteName
     type: string

--- a/templates/agent-orchestrator/skeleton/src/orchestrator/providers/anthropic.ts
+++ b/templates/agent-orchestrator/skeleton/src/orchestrator/providers/anthropic.ts
@@ -27,7 +27,7 @@ function createAnthropicProvider(): LlmProvider {
     async complete(systemPrompt: string, userMessage: string): Promise<string> {
       const response = await cb.execute(() =>
         getClient().messages.create({
-          model: "claude-sonnet-4-20250514",
+          model: "claude-sonnet-5",
           max_tokens: 4096,
           system: systemPrompt,
           messages: [{ role: "user", content: userMessage }],

--- a/templates/agentic-loop/skeleton/src/providers/anthropic.ts
+++ b/templates/agentic-loop/skeleton/src/providers/anthropic.ts
@@ -50,7 +50,7 @@ class AnthropicProvider implements LlmProvider {
   ): Promise<LlmResponse> {
     const response = await this.cb.execute(() =>
       this.client.messages.create({
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-5",
         max_tokens: 4096,
         system: systemPrompt,
         messages: messages as Anthropic.Messages.MessageParam[],
@@ -92,7 +92,7 @@ class AnthropicProvider implements LlmProvider {
     // before any network I/O occurs.
     const streamPromise = this.cb.execute(async () =>
       this.client.messages.stream({
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-5",
         max_tokens: 4096,
         system: systemPrompt,
         messages: messages as Anthropic.Messages.MessageParam[],

--- a/templates/chrome-ext/skeleton/src/lib/providers/anthropic.ts
+++ b/templates/chrome-ext/skeleton/src/lib/providers/anthropic.ts
@@ -3,7 +3,7 @@ import { registerProvider } from "./registry.js";
 import type { AiProvider, ChatMessage } from "./types.js";
 
 class AnthropicProvider implements AiProvider {
-  readonly defaultModel = "claude-sonnet-4-20250514";
+  readonly defaultModel = "claude-sonnet-5";
 
   async sendMessage(messages: ChatMessage[], apiKey: string, model?: string): Promise<string> {
     const client = new Anthropic({ apiKey });

--- a/templates/chrome-ext/skeleton/src/options/App.tsx
+++ b/templates/chrome-ext/skeleton/src/options/App.tsx
@@ -3,7 +3,7 @@ import type { LlmProvider, Settings } from "@/lib/storage";
 import { getSettings, saveSettings } from "@/lib/storage";
 
 const MODELS: Record<LlmProvider, string[]> = {
-  anthropic: ["claude-sonnet-4-20250514", "claude-haiku-4-20250414"],
+  anthropic: ["claude-sonnet-5", "claude-haiku-4-5"],
   openai: ["gpt-4o", "gpt-4o-mini"],
 };
 

--- a/templates/ci-eval/skeleton/src/ci-eval/providers/anthropic.ts
+++ b/templates/ci-eval/skeleton/src/ci-eval/providers/anthropic.ts
@@ -20,7 +20,7 @@ class AnthropicProvider implements LlmProvider {
 
   async complete(prompt: string): Promise<string> {
     const response = await this.getClient().messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-5",
       max_tokens: 1024,
       messages: [{ role: "user", content: prompt }],
     });

--- a/templates/discord-bot/skeleton/src/providers/anthropic.ts
+++ b/templates/discord-bot/skeleton/src/providers/anthropic.ts
@@ -10,7 +10,7 @@ class AnthropicProvider implements LlmProvider {
   async chat(systemPrompt: string, messages: ChatMessage[]): Promise<string> {
     const response = await cb.execute(() =>
       client.messages.create({
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-5",
         max_tokens: 2048,
         system: systemPrompt,
         messages: messages.map((m) => ({

--- a/templates/electron-app/skeleton/src/__tests__/ipc.test.ts
+++ b/templates/electron-app/skeleton/src/__tests__/ipc.test.ts
@@ -85,7 +85,7 @@ describe("IPC message shape", () => {
         { role: "assistant" as const, content: "Hi there" },
       ],
       provider: "anthropic",
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-5",
     };
 
     expect(payload.messages).toHaveLength(2);

--- a/templates/electron-app/skeleton/src/main/providers/anthropic.ts
+++ b/templates/electron-app/skeleton/src/main/providers/anthropic.ts
@@ -3,7 +3,7 @@ import { registerProvider } from "./registry.js";
 import type { AiProvider, ChatMessage } from "./types.js";
 
 class AnthropicProvider implements AiProvider {
-  readonly defaultModel = "claude-sonnet-4-20250514";
+  readonly defaultModel = "claude-sonnet-5";
 
   async sendMessage(messages: ChatMessage[], apiKey: string, model?: string): Promise<string> {
     const client = new Anthropic({ apiKey });

--- a/templates/eval-harness/skeleton/src/providers/anthropic.ts
+++ b/templates/eval-harness/skeleton/src/providers/anthropic.ts
@@ -12,7 +12,7 @@ export class AnthropicProvider implements LlmProvider {
   private model: string;
   private cb = createCircuitBreaker();
 
-  constructor(model = "claude-sonnet-4-20250514") {
+  constructor(model = "claude-sonnet-5") {
     this.client = new Anthropic();
     this.model = model;
   }

--- a/templates/llm-wiki/skeleton/src/llm/anthropic.ts
+++ b/templates/llm-wiki/skeleton/src/llm/anthropic.ts
@@ -3,7 +3,7 @@ import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 import { registerLlmProvider } from "./registry.js";
 import type { LlmMessage, LlmOptions, LlmProvider } from "./types.js";
 
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MODEL = "claude-sonnet-5";
 const DEFAULT_MAX_TOKENS = 4096;
 
 class AnthropicLlmProvider implements LlmProvider {

--- a/templates/llm-wiki/skeleton/src/schema/default-schema.yaml
+++ b/templates/llm-wiki/skeleton/src/schema/default-schema.yaml
@@ -36,6 +36,6 @@ structure:
 
 llm:
   provider: __LLM_PROVIDER__
-  model: claude-sonnet-4-6
+  model: claude-sonnet-5
   temperature: 0.2
   maxPagesPerIngest: 10

--- a/templates/module-llm-gateway/skeleton/.env.example
+++ b/templates/module-llm-gateway/skeleton/.env.example
@@ -5,7 +5,7 @@
 
 # ── Bedrock (default) ───────────────────────────────────────────────
 # AWS_REGION=us-west-2
-# LLM_MODEL=anthropic.claude-sonnet-4-6
+# LLM_MODEL=us.anthropic.claude-sonnet-5
 # Per-request timeout in ms for the Bedrock Converse call.
 # LLM_REQUEST_TIMEOUT_MS=30000
 

--- a/templates/module-llm-gateway/skeleton/README.md
+++ b/templates/module-llm-gateway/skeleton/README.md
@@ -34,7 +34,7 @@ console.log(cached.cached); // true
 // Query costs
 const costs = gateway.getCosts({ tags: { user: "alice" } });
 console.log(costs.totalCost); // 0.000135
-console.log(costs.byModel); // { "claude-sonnet-4-6": 0.000135 }
+console.log(costs.byModel); // { "claude-sonnet-5": 0.000135 }
 
 // Shut down
 gateway.close();
@@ -44,8 +44,8 @@ gateway.close();
 
 | Provider    | Backend                                          | Default Model                 | Pricing (input/output per 1M) |
 | ----------- | ------------------------------------------------ | ----------------------------- | ----------------------------- |
-| `bedrock`   | Claude Sonnet on Bedrock (Converse + cachePoint) | `anthropic.claude-sonnet-4-6` | $3 / $15                      |
-| `anthropic` | Claude Sonnet                                    | `claude-sonnet-4-6`           | $3 / $15                      |
+| `bedrock`   | Claude Sonnet on Bedrock (Converse + cachePoint) | `us.anthropic.claude-sonnet-5` | $3 / $15                      |
+| `anthropic` | Claude Sonnet                                    | `claude-sonnet-5`           | $3 / $15                      |
 | `openai`    | GPT-4o                                           | `gpt-4o`                      | $2.50 / $10                   |
 | `groq`      | Llama 3 70B                                      | `llama-3.3-70b-versatile`     | $0.59 / $0.79                 |
 | `mock`      | In-memory                                        | `mock-model`                  | $0 / $0                       |

--- a/templates/module-llm-gateway/skeleton/src/gateway/__tests__/cost.test.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/__tests__/cost.test.ts
@@ -21,7 +21,7 @@ describe("pricing", () => {
   });
 
   it("looks up pricing for known models", () => {
-    const pricing = getModelPricing("claude-sonnet-4-6");
+    const pricing = getModelPricing("claude-sonnet-5");
     expect(pricing.input).toBe(3);
     expect(pricing.output).toBe(15);
   });
@@ -44,7 +44,7 @@ describe("cost tracker", () => {
   it("records and queries cost entries", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.01), {
       user: "alice",
       project: "alpha",
     });
@@ -52,7 +52,7 @@ describe("cost tracker", () => {
       user: "bob",
       project: "alpha",
     });
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.02), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.02), {
       user: "alice",
       project: "beta",
     });
@@ -65,7 +65,7 @@ describe("cost tracker", () => {
   it("filters by provider", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01));
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.01));
     tracker.record(makeResponse("openai", "gpt-4o", 0.005));
 
     const summary = tracker.query({ provider: "anthropic" });
@@ -76,10 +76,10 @@ describe("cost tracker", () => {
   it("breaks down cost by user", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.01), {
       user: "alice",
     });
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.02), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.02), {
       user: "alice",
     });
     tracker.record(makeResponse("openai", "gpt-4o", 0.005), { user: "bob" });
@@ -92,7 +92,7 @@ describe("cost tracker", () => {
   it("breaks down cost by project", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.01), {
       project: "alpha",
     });
     tracker.record(makeResponse("openai", "gpt-4o", 0.02), { project: "beta" });
@@ -105,19 +105,19 @@ describe("cost tracker", () => {
   it("breaks down cost by model", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01));
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.02));
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.01));
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.02));
     tracker.record(makeResponse("openai", "gpt-4o", 0.005));
 
     const summary = tracker.query();
-    expect(summary.byModel["claude-sonnet-4-6"]).toBeCloseTo(0.03, 6);
+    expect(summary.byModel["claude-sonnet-5"]).toBeCloseTo(0.03, 6);
     expect(summary.byModel["gpt-4o"]).toBeCloseTo(0.005, 6);
   });
 
   it("filters by tags", () => {
     const tracker = createCostTracker();
 
-    tracker.record(makeResponse("anthropic", "claude-sonnet-4-6", 0.01), {
+    tracker.record(makeResponse("anthropic", "claude-sonnet-5", 0.01), {
       user: "alice",
       project: "alpha",
     });
@@ -142,7 +142,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-5",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01 + Math.random() * 0.001,
@@ -155,7 +155,7 @@ describe("anomaly detection", () => {
     entries.push({
       timestamp: new Date(baseTimestamp.getTime() + 25000).toISOString(),
       provider: "anthropic",
-      model: "claude-sonnet-4-6",
+      model: "claude-sonnet-5",
       inputTokens: 10000,
       outputTokens: 5000,
       cost: 0.5,
@@ -183,7 +183,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-5",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,
@@ -201,7 +201,7 @@ describe("anomaly detection", () => {
       {
         timestamp: new Date().toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-5",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,

--- a/templates/module-llm-gateway/skeleton/src/gateway/cost/pricing.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/cost/pricing.ts
@@ -4,6 +4,12 @@
 // can be overridden by provider pricing. Kept as a reference for
 // cost estimation when provider-reported usage is unavailable.
 //
+// Rates are each vendor's published list price for the direct API, not a
+// cloud reseller's — Bedrock and Vertex price the same models differently.
+// Check the vendor's pricing page when adding a model rather than copying a
+// neighbouring row: tiers within one family do not share a ratio, and a
+// promotional rate is not the rate to store.
+//
 
 export interface ModelPricing {
   /** Cost per 1M input tokens in USD. */
@@ -14,9 +20,9 @@ export interface ModelPricing {
 
 export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   // Anthropic
-  "claude-sonnet-4-6": { input: 3, output: 15 },
-  "claude-haiku-4-20250514": { input: 0.8, output: 4 },
-  "claude-opus-4-20250514": { input: 15, output: 75 },
+  "claude-sonnet-5": { input: 3, output: 15 },
+  "claude-haiku-4-5": { input: 1, output: 5 },
+  "claude-opus-5": { input: 5, output: 25 },
 
   // OpenAI
   "gpt-4o": { input: 2.5, output: 10 },

--- a/templates/module-llm-gateway/skeleton/src/gateway/providers/anthropic.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/providers/anthropic.ts
@@ -12,7 +12,7 @@ import type { GatewayProvider, ProviderPricing } from "./types.js";
 // responses into the unified GatewayResponse shape.
 //
 
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MODEL = "claude-sonnet-5";
 
 let client: Anthropic | null = null;
 function getClient(): Anthropic {

--- a/templates/module-llm-gateway/skeleton/src/gateway/providers/bedrock.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/providers/bedrock.ts
@@ -17,7 +17,7 @@ import type { GatewayProvider, ProviderPricing } from "./types.js";
 // circuit breaker instead of hanging forever.
 //
 
-const DEFAULT_MODEL = process.env.LLM_MODEL ?? "anthropic.claude-sonnet-4-6";
+const DEFAULT_MODEL = process.env.LLM_MODEL ?? "us.anthropic.claude-sonnet-5";
 const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
 
 let client: BedrockRuntimeClient | null = null;

--- a/templates/module-llm-observability/skeleton/README.md
+++ b/templates/module-llm-observability/skeleton/README.md
@@ -26,7 +26,7 @@ const response = await observer.trace(async () => {
   // Call your LLM provider here
   return {
     text: "Hello, world!",
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-5",
     provider: "anthropic",
     inputTokens: 100,
     outputTokens: 50,

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/cost.test.ts
@@ -12,7 +12,7 @@ function makeSpan(overrides: Partial<LlmSpan> = {}): LlmSpan {
     startedAt: new Date().toISOString(),
     endedAt: new Date().toISOString(),
     durationMs: 200,
-    model: "claude-sonnet-4-6",
+    model: "claude-sonnet-5",
     provider: "anthropic",
     inputTokens: 1000,
     outputTokens: 500,
@@ -37,15 +37,15 @@ describe("pricing", () => {
   });
 
   it("looks up pricing for known models", () => {
-    const pricing = getModelPricing("claude-sonnet-4-6");
+    const pricing = getModelPricing("claude-sonnet-5");
     expect(pricing.input).toBe(3);
     expect(pricing.output).toBe(15);
   });
 
   it("calculates anthropic opus pricing", () => {
-    const cost = calculateCost("claude-opus-4-20250514", 1000, 500);
-    // (1000 * 15 / 1M) + (500 * 75 / 1M) = 0.015 + 0.0375 = 0.0525
-    expect(cost).toBeCloseTo(0.0525, 6);
+    const cost = calculateCost("claude-opus-5", 1000, 500);
+    // (1000 * 5 / 1M) + (500 * 25 / 1M) = 0.005 + 0.0125 = 0.0175
+    expect(cost).toBeCloseTo(0.0175, 6);
   });
 });
 
@@ -55,14 +55,14 @@ describe("cost calculator", () => {
 
     const entry = calculator.record(makeSpan());
     expect(entry.cost).toBeGreaterThan(0);
-    expect(entry.model).toBe("claude-sonnet-4-6");
+    expect(entry.model).toBe("claude-sonnet-5");
     expect(entry.provider).toBe("anthropic");
   });
 
   it("queries with no filters returns all entries", () => {
     const calculator = createCostCalculator();
 
-    calculator.record(makeSpan({ model: "claude-sonnet-4-6", inputTokens: 100, outputTokens: 50 }));
+    calculator.record(makeSpan({ model: "claude-sonnet-5", inputTokens: 100, outputTokens: 50 }));
     calculator.record(
       makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 200, outputTokens: 100 }),
     );
@@ -85,7 +85,7 @@ describe("cost calculator", () => {
   it("filters by model", () => {
     const calculator = createCostCalculator();
 
-    calculator.record(makeSpan({ model: "claude-sonnet-4-6" }));
+    calculator.record(makeSpan({ model: "claude-sonnet-5" }));
     calculator.record(makeSpan({ model: "gpt-4o", provider: "openai" }));
 
     const summary = calculator.query({ model: "gpt-4o" });
@@ -95,15 +95,13 @@ describe("cost calculator", () => {
   it("breaks down cost by model", () => {
     const calculator = createCostCalculator();
 
-    calculator.record(
-      makeSpan({ model: "claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500 }),
-    );
+    calculator.record(makeSpan({ model: "claude-sonnet-5", inputTokens: 1000, outputTokens: 500 }));
     calculator.record(
       makeSpan({ model: "gpt-4o", provider: "openai", inputTokens: 1000, outputTokens: 500 }),
     );
 
     const summary = calculator.query();
-    expect(summary.byModel["claude-sonnet-4-6"]).toBeGreaterThan(0);
+    expect(summary.byModel["claude-sonnet-5"]).toBeGreaterThan(0);
     expect(summary.byModel["gpt-4o"]).toBeGreaterThan(0);
   });
 
@@ -151,7 +149,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-5",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01 + Math.random() * 0.001,
@@ -164,7 +162,7 @@ describe("anomaly detection", () => {
     entries.push({
       timestamp: new Date(baseTimestamp.getTime() + 25000).toISOString(),
       provider: "anthropic",
-      model: "claude-sonnet-4-6",
+      model: "claude-sonnet-5",
       inputTokens: 10000,
       outputTokens: 5000,
       cost: 0.5,
@@ -192,7 +190,7 @@ describe("anomaly detection", () => {
       entries.push({
         timestamp: new Date(baseTimestamp.getTime() + i * 1000).toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-5",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,
@@ -210,7 +208,7 @@ describe("anomaly detection", () => {
       {
         timestamp: new Date().toISOString(),
         provider: "anthropic",
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-5",
         inputTokens: 100,
         outputTokens: 50,
         cost: 0.01,

--- a/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/__tests__/tracer.test.ts
@@ -7,7 +7,7 @@ import type { LlmResponse } from "../types.js";
 function makeResponse(overrides: Partial<LlmResponse> = {}): LlmResponse {
   return {
     text: "Hello, world!",
-    model: "claude-sonnet-4-6",
+    model: "claude-sonnet-5",
     provider: "anthropic",
     inputTokens: 100,
     outputTokens: 50,
@@ -22,7 +22,7 @@ describe("LLM tracer", () => {
     const { response, span } = await tracer.trace(async () => makeResponse());
 
     expect(response.text).toBe("Hello, world!");
-    expect(span.model).toBe("claude-sonnet-4-6");
+    expect(span.model).toBe("claude-sonnet-5");
     expect(span.provider).toBe("anthropic");
     expect(span.inputTokens).toBe(100);
     expect(span.outputTokens).toBe(50);

--- a/templates/module-llm-observability/skeleton/src/llm-observability/cost/pricing.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/cost/pricing.ts
@@ -4,6 +4,12 @@
 // can be overridden by provider pricing. Kept as a reference for
 // cost estimation when provider-reported usage is unavailable.
 //
+// Rates are each vendor's published list price for the direct API, not a
+// cloud reseller's — Bedrock and Vertex price the same models differently.
+// Check the vendor's pricing page when adding a model rather than copying a
+// neighbouring row: tiers within one family do not share a ratio, and a
+// promotional rate is not the rate to store.
+//
 
 export interface ModelPricing {
   /** Cost per 1M input tokens in USD. */
@@ -14,9 +20,9 @@ export interface ModelPricing {
 
 export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   // Anthropic
-  "claude-sonnet-4-6": { input: 3, output: 15 },
-  "claude-haiku-4-20250514": { input: 0.8, output: 4 },
-  "claude-opus-4-20250514": { input: 15, output: 75 },
+  "claude-sonnet-5": { input: 3, output: 15 },
+  "claude-haiku-4-5": { input: 1, output: 5 },
+  "claude-opus-5": { input: 5, output: 25 },
 
   // OpenAI
   "gpt-4o": { input: 2.5, output: 10 },

--- a/templates/module-llm-observability/skeleton/src/llm-observability/logger.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/logger.ts
@@ -59,7 +59,7 @@ function emit(level: LogLevel, message: string, fields?: Record<string, unknown>
  * Structured logger that propagates OpenTelemetry trace context.
  *
  * Usage:
- *   logger.info("span captured", { model: "claude-sonnet-4-6", durationMs: 340 });
+ *   logger.info("span captured", { model: "claude-sonnet-5", durationMs: 340 });
  */
 export const logger = {
   debug: (message: string, fields?: Record<string, unknown>) => emit("debug", message, fields),

--- a/templates/module-llm-observability/skeleton/src/llm-observability/types.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/types.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 export interface LlmResponse {
   /** Generated text content. */
   text: string;
-  /** Model identifier (e.g., "claude-sonnet-4-6"). */
+  /** Model identifier (e.g., "claude-sonnet-5"). */
   model: string;
   /** Provider name (e.g., "anthropic", "openai"). */
   provider: string;

--- a/templates/module-llm-providers/skeleton/README.md
+++ b/templates/module-llm-providers/skeleton/README.md
@@ -36,11 +36,11 @@ console.log(`\nTotal tokens: ${final.usage.outputTokens}`);
 
 | Provider | SDK | Default Model | Auth | Always Included |
 |----------|-----|---------------|------|-----------------|
-| `anthropic` | @anthropic-ai/sdk | claude-sonnet-4-6 | `ANTHROPIC_API_KEY` | Yes |
+| `anthropic` | @anthropic-ai/sdk | claude-sonnet-5 | `ANTHROPIC_API_KEY` | Yes |
 | `openai` | openai | gpt-4o | `OPENAI_API_KEY` | Yes |
 | `groq` | groq-sdk | llama-3.3-70b-versatile | `GROQ_API_KEY` | Yes |
 | `mock` | none | mock-model | none | Yes |
-| `bedrock` | @aws-sdk/client-bedrock-runtime | anthropic.claude-sonnet-4-6 | IAM / AWS credentials | Conditional |
+| `bedrock` | @aws-sdk/client-bedrock-runtime | us.anthropic.claude-sonnet-5 | IAM / AWS credentials | Conditional |
 | `vertex` | @google-cloud/vertexai | gemini-2.0-flash | Google ADC | Conditional |
 | `huggingface` | @huggingface/inference | meta-llama/Llama-3.3-70B-Instruct | `HF_TOKEN` | Conditional |
 | `ollama` | native fetch | llama3.2 | none (local) | Conditional |

--- a/templates/module-llm-providers/skeleton/src/llm-providers/__tests__/tokens.test.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/__tests__/tokens.test.ts
@@ -44,7 +44,7 @@ describe("countTokens", () => {
   });
 
   it("counts different models consistently when both fall back", () => {
-    const a = countTokens("Hello", "claude-sonnet-4-6");
+    const a = countTokens("Hello", "claude-sonnet-5");
     const b = countTokens("Hello", "some-unknown-model");
     // Both fall back to gpt-4o encoding, should be equal
     expect(a).toBe(b);

--- a/templates/module-llm-providers/skeleton/src/llm-providers/providers/anthropic.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/providers/anthropic.ts
@@ -23,7 +23,7 @@ import type { LlmProvider } from "./types.js";
 // Auth: ANTHROPIC_API_KEY environment variable (read by the SDK).
 //
 
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MODEL = "claude-sonnet-5";
 
 function createAnthropicProvider(): LlmProvider {
   let client: Anthropic | null = null;

--- a/templates/module-llm-providers/skeleton/src/llm-providers/providers/bedrock.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/providers/bedrock.ts
@@ -34,7 +34,7 @@ import type { LlmProvider } from "./types.js";
 // request/response shape, so there is no hand-rolled body marshalling.
 //
 
-const DEFAULT_MODEL = "anthropic.claude-sonnet-4-6";
+const DEFAULT_MODEL = "us.anthropic.claude-sonnet-5";
 const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
 
 // Never trust raw model output — validate the Converse usage block before
@@ -99,7 +99,7 @@ function createBedrockProvider(): LlmProvider {
     return client;
   }
 
-  const pricing: Pricing = getPricing("claude-sonnet-4-6");
+  const pricing: Pricing = getPricing("claude-sonnet-5");
 
   return {
     name: "bedrock",

--- a/templates/module-llm-providers/skeleton/src/llm-providers/types.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/types.ts
@@ -83,9 +83,9 @@ export interface StreamResponse extends AsyncIterable<StreamChunk> {
 
 /** Default pricing per 1M tokens for known models. */
 export const DEFAULT_PRICING: Record<string, Pricing> = {
-  "claude-sonnet-4-6": { input: 3, output: 15 },
-  "claude-opus-4-20250514": { input: 15, output: 75 },
-  "claude-haiku-4-5-20251001": { input: 0.8, output: 4 },
+  "claude-sonnet-5": { input: 3, output: 15 },
+  "claude-opus-5": { input: 5, output: 25 },
+  "claude-haiku-4-5": { input: 1, output: 5 },
   "gpt-4o": { input: 2.5, output: 10 },
   "gpt-4o-mini": { input: 0.15, output: 0.6 },
   "gpt-4.1": { input: 2, output: 8 },

--- a/templates/multimodal-pipeline/skeleton/.env.example
+++ b/templates/multimodal-pipeline/skeleton/.env.example
@@ -1,7 +1,7 @@
 # ──── LLM Provider ────
 # Provider: anthropic | openai
 LLM_PROVIDER=__LLM_PROVIDER__
-LLM_MODEL=claude-sonnet-4-20250514
+LLM_MODEL=claude-sonnet-5
 LLM_TEMPERATURE=0.1
 LLM_MAX_TOKENS=4096
 

--- a/templates/multimodal-pipeline/skeleton/src/config.ts
+++ b/templates/multimodal-pipeline/skeleton/src/config.ts
@@ -14,7 +14,7 @@ const llmSchema = z.object({
   provider: z.string().default("__LLM_PROVIDER__"),
   anthropicApiKey: z.string().default(""),
   openaiApiKey: z.string().default(""),
-  model: z.string().default("claude-sonnet-4-20250514"),
+  model: z.string().default("claude-sonnet-5"),
   temperature: z.coerce.number().min(0).max(2).default(0.1),
   maxTokens: z.coerce.number().int().positive().default(4096),
 });

--- a/templates/next-app/skeleton/src/__tests__/providers.test.ts
+++ b/templates/next-app/skeleton/src/__tests__/providers.test.ts
@@ -5,7 +5,7 @@ describe("AI Provider Registry", () => {
   it("registers anthropic provider", () => {
     const provider = getProvider("anthropic");
     expect(provider).toBeDefined();
-    expect(provider.defaultModel).toBe("claude-sonnet-4-20250514");
+    expect(provider.defaultModel).toBe("claude-sonnet-5");
   });
 
   it("registers openai provider", () => {

--- a/templates/next-app/skeleton/src/lib/ai/providers/anthropic.ts
+++ b/templates/next-app/skeleton/src/lib/ai/providers/anthropic.ts
@@ -3,7 +3,7 @@ import { registerProvider } from "./registry.js";
 import type { AiProvider, ChatMessage } from "./types.js";
 
 class AnthropicProvider implements AiProvider {
-  readonly defaultModel = "claude-sonnet-4-20250514";
+  readonly defaultModel = "claude-sonnet-5";
 
   async sendMessage(messages: ChatMessage[], model?: string): Promise<string> {
     const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });

--- a/templates/prompt-library/skeleton/README.md
+++ b/templates/prompt-library/skeleton/README.md
@@ -45,7 +45,7 @@ Each prompt is a YAML file with frontmatter metadata and a template body:
 ---
 name: summarize-document
 version: "1.2.0"
-model: claude-sonnet-4-5-20250514
+model: claude-sonnet-5
 temperature: 0.3
 tags: [summarization, documents]
 variables:

--- a/templates/prompt-library/skeleton/prompts/system/example.yaml
+++ b/templates/prompt-library/skeleton/prompts/system/example.yaml
@@ -1,7 +1,7 @@
 ---
 name: coding-assistant
 version: "1.0.0"
-model: claude-sonnet-4-5-20250514
+model: claude-sonnet-5
 temperature: 0.2
 max_tokens: 4096
 tags: [system, coding, assistant]

--- a/templates/prompt-library/skeleton/prompts/user/example.yaml
+++ b/templates/prompt-library/skeleton/prompts/user/example.yaml
@@ -1,7 +1,7 @@
 ---
 name: summarize-document
 version: "1.2.0"
-model: claude-sonnet-4-5-20250514
+model: claude-sonnet-5
 temperature: 0.3
 tags: [summarization, documents]
 variables:

--- a/templates/prompt-library/skeleton/schema/prompt.schema.json
+++ b/templates/prompt-library/skeleton/schema/prompt.schema.json
@@ -20,7 +20,7 @@
     "model": {
       "type": "string",
       "minLength": 1,
-      "description": "Model identifier (e.g. claude-sonnet-4-5-20250514)."
+      "description": "Model identifier (e.g. claude-sonnet-5)."
     },
     "temperature": {
       "type": "number",

--- a/templates/prompt-library/skeleton/sdk/src/__tests__/loader.test.ts
+++ b/templates/prompt-library/skeleton/sdk/src/__tests__/loader.test.ts
@@ -22,7 +22,7 @@ vi.mock("fs/promises", async () => {
 const samplePrompt = `---
 name: test-prompt
 version: 1.0.0
-model: claude-sonnet-4-20250514
+model: claude-sonnet-5
 variables:
   - name: topic
     description: The topic to write about
@@ -78,7 +78,7 @@ describe("loadPrompt", () => {
 
     expect(prompt.metadata.name).toBe("test-prompt");
     expect(prompt.metadata.version).toBe("1.0.0");
-    expect(prompt.metadata.model).toBe("claude-sonnet-4-20250514");
+    expect(prompt.metadata.model).toBe("claude-sonnet-5");
     expect(prompt.metadata.variables).toHaveLength(2);
     expect(prompt.template).toBe("Write a {{tone}} article about {{topic}}.");
   });

--- a/templates/rag-pipeline/skeleton/.env.example
+++ b/templates/rag-pipeline/skeleton/.env.example
@@ -8,7 +8,7 @@ LLM_REQUEST_TIMEOUT_MS=30000
 # ──── Generation (LLM) ────
 # Provider: bedrock (default) | anthropic | openai
 LLM_PROVIDER=__LLM_PROVIDER__
-LLM_MODEL=anthropic.claude-sonnet-4-6
+LLM_MODEL=us.anthropic.claude-sonnet-5
 LLM_TEMPERATURE=0.1
 LLM_MAX_TOKENS=1024
 

--- a/templates/rag-pipeline/skeleton/src/config.ts
+++ b/templates/rag-pipeline/skeleton/src/config.ts
@@ -41,8 +41,8 @@ const generationSchema = z.object({
   anthropicApiKey: z.string().default(""),
   openaiApiKey: z.string().default(""),
   // Bedrock model id (the org default). For the direct Anthropic API use
-  // "claude-sonnet-4-6"; for OpenAI use e.g. "gpt-4o".
-  model: z.string().default("anthropic.claude-sonnet-4-6"),
+  // "claude-sonnet-5"; for OpenAI use e.g. "gpt-4o".
+  model: z.string().default("us.anthropic.claude-sonnet-5"),
   temperature: z.coerce.number().min(0).max(2).default(0.1),
   maxTokens: z.coerce.number().int().positive().default(1024),
 });

--- a/templates/slack-bot/skeleton/.env.example
+++ b/templates/slack-bot/skeleton/.env.example
@@ -13,7 +13,7 @@ SLACK_SIGNING_SECRET=your-signing-secret
 # your local AWS profile in dev) — NO API keys. Set the region where the
 # model is enabled.
 AWS_REGION=us-west-2
-LLM_MODEL=anthropic.claude-sonnet-4-6
+LLM_MODEL=us.anthropic.claude-sonnet-5
 LLM_PROVIDER=__LLM_PROVIDER__
 
 # Per-call LLM request timeout in milliseconds
@@ -22,7 +22,7 @@ LLM_REQUEST_TIMEOUT_MS=30000
 # Alternate direct-API providers — only needed when LLM_PROVIDER=anthropic|openai.
 # Leave unset for the Bedrock default.
 # ANTHROPIC_API_KEY=sk-ant-...
-# ANTHROPIC_MODEL=claude-sonnet-4-6
+# ANTHROPIC_MODEL=claude-sonnet-5
 # OPENAI_API_KEY=sk-...
 # OPENAI_MODEL=gpt-4o
 

--- a/templates/slack-bot/skeleton/src/config.ts
+++ b/templates/slack-bot/skeleton/src/config.ts
@@ -17,7 +17,7 @@ const configSchema = z.object({
   LLM_PROVIDER: z.string().default("__LLM_PROVIDER__"),
 
   // Bedrock model id (Converse). Injectable so the model isn't hardcoded.
-  LLM_MODEL: z.string().default("anthropic.claude-sonnet-4-6"),
+  LLM_MODEL: z.string().default("us.anthropic.claude-sonnet-5"),
 
   // Region where the Bedrock model is enabled. Bedrock auth is the AWS
   // credential chain (IRSA on-cluster) — no API keys.

--- a/templates/slack-bot/skeleton/src/providers/anthropic.ts
+++ b/templates/slack-bot/skeleton/src/providers/anthropic.ts
@@ -9,7 +9,7 @@ import type { ChatMessage, LlmProvider } from "./types.js";
 // instead of hanging; the model id is injectable via ANTHROPIC_MODEL.
 
 const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
-const MODEL = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-6";
+const MODEL = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-5";
 
 const client = new Anthropic({ timeout: REQUEST_TIMEOUT_MS, maxRetries: 1 });
 const cb = createCircuitBreaker();

--- a/templates/slack-bot/skeleton/src/providers/bedrock.ts
+++ b/templates/slack-bot/skeleton/src/providers/bedrock.ts
@@ -12,7 +12,7 @@ import type { ChatMessage, LlmProvider } from "./types.js";
 // hung Bedrock socket trips the circuit breaker instead of hanging forever.
 
 const REQUEST_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS ?? 30_000);
-const MODEL = process.env.LLM_MODEL ?? "anthropic.claude-sonnet-4-6";
+const MODEL = process.env.LLM_MODEL ?? "us.anthropic.claude-sonnet-5";
 
 class BedrockProvider implements LlmProvider {
   private readonly client = new BedrockRuntimeClient({

--- a/templates/vscode-ext/skeleton/src/ai/providers/anthropic.ts
+++ b/templates/vscode-ext/skeleton/src/ai/providers/anthropic.ts
@@ -3,7 +3,7 @@ import { registerProvider } from "./registry";
 import type { AiProvider, ChatMessage } from "./types";
 
 class AnthropicProvider implements AiProvider {
-  readonly defaultModel = "claude-sonnet-4-20250514";
+  readonly defaultModel = "claude-sonnet-5";
 
   async sendMessage(messages: ChatMessage[], apiKey: string, model?: string): Promise<string> {
     const client = new Anthropic({ apiKey });


### PR DESCRIPTION
Every Bedrock skeleton in the catalog defaulted to a bare foundation-model ID. Bedrock reports `inferenceTypesSupported: [INFERENCE_PROFILE]` for the whole current Claude family — there is no on-demand path — so `anthropic.claude-sonnet-5` is refused with a `ValidationException` and `us.anthropic.claude-sonnet-5` is what works. Six skeleton defaults, three `.env.example` files and the agent-fleet `ModelId` parameter all shipped the refused form, so a scaffolded Bedrock app failed on its first call.

The LLM policy already said so in prose — "bare foundation-model IDs are refused" — while every example it governed contradicted it.

```
$ aws bedrock list-foundation-models --by-provider anthropic
anthropic.claude-sonnet-5    ['INFERENCE_PROFILE']
anthropic.claude-opus-5      ['INFERENCE_PROFILE']
anthropic.claude-sonnet-4-6  ['INFERENCE_PROFILE']
```

## The IDs

Three classes shipped:

| class | IDs | effect |
|---|---|---|
| Retired 2026-06-15 | `claude-sonnet-4-20250514` ×17, `claude-opus-4-20250514` ×4 | 404 |
| Never existed | `claude-sonnet-4-5-20250514` (4.5 shipped `20250929`), `claude-haiku-4-20250514` / `-20250414` (no Haiku 4) | 404 |
| Live, previous generation | `claude-sonnet-4-6` | works |

All now `claude-sonnet-5` / `claude-opus-5` / `claude-haiku-4-5`, in the form each delivery path needs — `us.`-prefixed profile for Bedrock, bare name for the direct Anthropic API.

The three skeleton pricing tables were wrong beyond their keys: both Haiku rows carried 0.8 / 4 (Claude 3.5 Haiku's price) under a Haiku 4 key, and Opus stayed at the retired Opus 4's 15 / 75. Now 1 / 5 and 5 / 25, with a note on where the numbers come from — a rate copied from a neighbouring row is how the wrong ones got there.

## The gate

`scripts/check-model-ids.mjs`, run by `validate-templates.yml`. A model ID is a plain string, so no compiler, linter or type checker has an opinion about it — a scaffold born on a dead ID fails only on first invocation, in the consumer's project. That is why every one of these survived.

It derives its allowed set from `standards/llm-policy.json` rather than carrying a list, so moving the catalog to a new model is one edit to the standard. Two rules: every Claude ID is one the policy names, and no bare foundation-model ID sits in invoke position — line-scoped, because the bare form is correct as a pricing key or an IAM resource and wrong only as something you call.

Mutation-tested eleven ways. Two cases came out of the mutation run rather than out of writing it: `globSync` does not match a leading dot, so `.env.example` — where a scaffold's model is actually configured — was the one file the first version silently skipped.

## Standard

`llm-policy.json` names inference-profile IDs for all three tiers and gains an `inference-profile-required` requirement. Its `light` tier had named `anthropic.claude-haiku-4-5`, which does not exist in any form — Haiku 4.5 is the one current model whose Bedrock ID keeps a release date. `verify-region` now asks whether the profile is `ACTIVE`, not merely whether the foundation model is listed, because the latter is true for models you cannot invoke.