### PR TITLE
fix: run this repository's own lint, and make it pass

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -95,6 +95,15 @@ jobs:
       - name: Install yq
         uses: mikefarah/yq@v4.53.2
 
+      # This repository's own source — the SDK, the MCP server, the shared
+      # library, and every script under scripts/. `lint:skeletons` below covers
+      # the catalog's scaffolding output, which the root config excludes; nothing
+      # covered what lints the catalog. So `npm run lint` sat failing on main,
+      # which is the same defect the skeleton gate was built for, one level up:
+      # a command the contributing docs tell you to run, that no job runs.
+      - name: Lint this repository
+        run: npm run lint
+
       - name: Run catalog validation
         run: npm run validate:catalog
 

--- a/biome.json
+++ b/biome.json
@@ -55,6 +55,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["sdk/__tests__/resolver.test.ts", "sdk/__tests__/composite.test.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noTemplateCurlyInString": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/library/runtime/src/resilience.test.ts
+++ b/library/runtime/src/resilience.test.ts
@@ -49,7 +49,13 @@ describe("withRetry", () => {
   /** Records requested delays instead of sleeping. */
   function makeSleepRecorder() {
     const delays: number[] = [];
-    return { delays, sleep: (ms: number) => (delays.push(ms), Promise.resolve()) };
+    return {
+      delays,
+      sleep: (ms: number) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    };
   }
 
   it("returns the first successful result without sleeping", async () => {

--- a/mcp-server/__tests__/tools.test.ts
+++ b/mcp-server/__tests__/tools.test.ts
@@ -24,7 +24,13 @@ describe("listTools", () => {
   });
 
   it("get_contract enum reflects the current contract surface", () => {
-    const tool = listTools().find((t) => t.name === "get_contract")!;
+    const tool = listTools().find((t) => t.name === "get_contract");
+    // Narrowed by a throw rather than `!`: if the tool is ever renamed, the next
+    // line would read a property off undefined and report a TypeError instead of
+    // the actual problem, which is that `get_contract` is gone. `expect(...)
+    // .toBeDefined()` reads better but does not narrow the type, so it would
+    // leave the same unchecked access behind it.
+    if (!tool) throw new Error("get_contract is no longer a registered tool");
     const repoEnum = (tool.inputSchema.properties as { repo: { enum: string[] } }).repo.enum;
     expect(repoEnum).toEqual([...KNOWN_CONTRACT_REPOS]);
     expect(repoEnum).toEqual(expect.arrayContaining(["fab", "portal", "eks-fleet"]));

--- a/schemas/standards.schema.json
+++ b/schemas/standards.schema.json
@@ -63,15 +63,7 @@
               "toolchains": {
                 "type": "object",
                 "propertyNames": {
-                  "enum": [
-                    "typescript",
-                    "go",
-                    "python",
-                    "rust",
-                    "java",
-                    "kotlin",
-                    "csharp"
-                  ]
+                  "enum": ["typescript", "go", "python", "rust", "java", "kotlin", "csharp"]
                 },
                 "additionalProperties": {
                   "type": "object",
@@ -434,12 +426,7 @@
         "properties": {
           "content": {
             "type": "object",
-            "required": [
-              "transforms",
-              "reserved_prefixes",
-              "dimensions",
-              "required_by_surface"
-            ],
+            "required": ["transforms", "reserved_prefixes", "dimensions", "required_by_surface"],
             "properties": {
               "transforms": {
                 "type": "object",
@@ -707,12 +694,7 @@
         "properties": {
           "content": {
             "type": "object",
-            "required": [
-              "principles",
-              "slo",
-              "burn_rate_alerts",
-              "dashboard_requirements"
-            ],
+            "required": ["principles", "slo", "burn_rate_alerts", "dashboard_requirements"],
             "properties": {
               "principles": {
                 "type": "object",
@@ -740,12 +722,7 @@
               },
               "slo": {
                 "type": "object",
-                "required": [
-                  "definition",
-                  "window_days",
-                  "sli_types",
-                  "error_budget"
-                ],
+                "required": ["definition", "window_days", "sli_types", "error_budget"],
                 "properties": {
                   "definition": {
                     "type": "string"
@@ -759,11 +736,7 @@
                     "minItems": 1,
                     "items": {
                       "type": "object",
-                      "required": [
-                        "id",
-                        "good_over_valid",
-                        "default_objective"
-                      ],
+                      "required": ["id", "good_over_valid", "default_objective"],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -986,11 +959,7 @@
             "properties": {
               "principles": {
                 "type": "object",
-                "required": [
-                  "neutral_waist",
-                  "one_egress",
-                  "absent_is_not_healthy"
-                ],
+                "required": ["neutral_waist", "one_egress", "absent_is_not_healthy"],
                 "properties": {
                   "neutral_waist": {
                     "type": "string"
@@ -1008,12 +977,7 @@
               },
               "collection_contract": {
                 "type": "object",
-                "required": [
-                  "protocol",
-                  "endpoint",
-                  "topology",
-                  "workload_requirements"
-                ],
+                "required": ["protocol", "endpoint", "topology", "workload_requirements"],
                 "properties": {
                   "protocol": {
                     "type": "string",
@@ -1127,13 +1091,7 @@
                     "minItems": 1,
                     "items": {
                       "type": "object",
-                      "required": [
-                        "detail_type",
-                        "source",
-                        "when",
-                        "detail_fields",
-                        "severity"
-                      ],
+                      "required": ["detail_type", "source", "when", "detail_fields", "severity"],
                       "properties": {
                         "detail_type": {
                           "type": "string",
@@ -1237,13 +1195,7 @@
         "properties": {
           "content": {
             "type": "object",
-            "required": [
-              "canonical_host",
-              "gsc",
-              "required_files",
-              "head_tags",
-              "rules"
-            ],
+            "required": ["canonical_host", "gsc", "required_files", "head_tags", "rules"],
             "properties": {
               "canonical_host": {
                 "type": "object",

--- a/scripts/check-slo-constants.mjs
+++ b/scripts/check-slo-constants.mjs
@@ -37,9 +37,7 @@ const c = JSON.parse(readFileSync(STANDARD, "utf-8")).content;
 // actually implements; ticket-tier (3, 1) are defined but not alerted in prod.
 const windows = c.burn_rate_alerts.windows;
 const allFactors = new Set(windows.map((w) => w.factor));
-const pageFactors = new Set(
-  windows.filter((w) => w.severity === "page").map((w) => w.factor),
-);
+const pageFactors = new Set(windows.filter((w) => w.severity === "page").map((w) => w.factor));
 
 // The full (severity, long, short, factor) tuples, keyed for set comparison
 // against the operator's Go table.
@@ -48,13 +46,9 @@ const standardPairs = new Set(windows.map(windowKey));
 
 // Objective denominators = 1 - objective, rounded to kill float dust (0.999 -> 0.001).
 const round = (n) => Math.round(n * 1e6) / 1e6;
-const denominators = new Set(
-  c.slo.sli_types.map((t) => round(1 - t.default_objective)),
-);
+const denominators = new Set(c.slo.sli_types.map((t) => round(1 - t.default_objective)));
 
-const files = readdirSync(alertDir).filter(
-  (f) => f.endsWith(".yaml") || f.endsWith(".yml"),
-);
+const files = readdirSync(alertDir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
 if (files.length === 0) {
   console.error(`no alert files under ${alertDir}`);
   process.exit(2);
@@ -89,9 +83,7 @@ for (const f of files) {
 // Every page-tier factor must be implemented by at least one alert.
 for (const pf of pageFactors) {
   if (!usedFactors.has(pf)) {
-    errors.push(
-      `page-tier burn-rate factor ${pf} from ${STANDARD} is not used in any alert expr`,
-    );
+    errors.push(`page-tier burn-rate factor ${pf} from ${STANDARD} is not used in any alert expr`);
   }
 }
 

--- a/scripts/lint-skeletons.mjs
+++ b/scripts/lint-skeletons.mjs
@@ -58,7 +58,9 @@ for (const dir of skeletons) {
   const result = spawnSync(BIOME, ["check", "."], { cwd: dir, encoding: "utf8" });
   if (result.status !== 0) {
     failed.push(relative(ROOT, dir));
-    process.stderr.write(`\n══ ${relative(ROOT, dir)}\n${result.stdout ?? ""}${result.stderr ?? ""}`);
+    process.stderr.write(
+      `\n══ ${relative(ROOT, dir)}\n${result.stdout ?? ""}${result.stderr ?? ""}`,
+    );
   }
 }
 

--- a/sdk/__tests__/composite.test.ts
+++ b/sdk/__tests__/composite.test.ts
@@ -11,6 +11,13 @@ import type {
   TemplateManifest,
 } from "../src/types.js";
 
+// `noTemplateCurlyInString` is off for this file in biome.json. The suites here
+// pass `${VarName}` placeholders through as *data* — that is the syntax the
+// resolver is specified to expand — so writing them as JS template literals
+// would interpolate them at parse time and test nothing. The rule is correct in
+// general and wrong here, which is why the exemption is scoped to this file
+// rather than disabled repo-wide.
+
 function mockTemplate(
   name: string,
   variables: TemplateManifest["variables"] = [],

--- a/sdk/__tests__/resolver.test.ts
+++ b/sdk/__tests__/resolver.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { resolveVariables } from "../src/resolver.js";
 import type { TemplateVariable } from "../src/types.js";
 
+// `noTemplateCurlyInString` is off for this file in biome.json. The suites here
+// pass `${VarName}` placeholders through as *data* — that is the syntax the
+// resolver is specified to expand — so writing them as JS template literals
+// would interpolate them at parse time and test nothing. The rule is correct in
+// general and wrong here, which is why the exemption is scoped to this file
+// rather than disabled repo-wide.
+
 function v(overrides: Partial<TemplateVariable> & { name: string }): TemplateVariable {
   return {
     type: "string",


### PR DESCRIPTION
`npm run lint` exited 1 on main. Nothing noticed because **no workflow ran it**.

This is the defect the skeleton gate was built for, one level up. `lint:skeletons` covers the catalog's scaffolding output and CI runs it. Nothing covered the code that *lints* the catalog — the SDK, the MCP server, the shared library, `scripts/`. A command the contributing instructions tell you to run, that no job runs, is a command that is already failing.

## What was failing

`npm run lint` is `biome check .` — formatter and assist actions as well as the linter. Splitting the three apart: `biome lint` was clean apart from real errors, and **`biome format` was the larger half**, which no rule name would have led you to.

Three lint errors, all in test files:

- a comma operator in `resilience.test.ts`
- a non-null assertion in `tools.test.ts` — narrowed with a throw, so renaming the tool reports the actual problem instead of a TypeError. (`expect(...).toBeDefined()` reads better but doesn't narrow the type; the first attempt did that and traded the error for `noUnsafeOptionalChaining`.)
- `noTemplateCurlyInString` ×11 across two SDK suites, **all false positives** — those suites pass `${VarName}` placeholders through as *data*, which is the syntax the resolver is specified to expand. Template literals would interpolate at parse time and test nothing. Scoped off for those two files, reasoning recorded in the files (Biome reads its own config as JSONC but lints it as strict JSON, so a comment in `biome.json` fails the very check being fixed).

Three formatting drifts, all line-width reflow. The JSON schema was compared parsed before/after to confirm semantic identity.

## Deliberately untouched

`library/runtime/src/logger.ts` keeps its two findings. It is vendored byte-identically by competitive-intelligence and incident-response, so editing it turns their drift gates red until each re-syncs. Both are `info` and neither fails the gate — real cost, no benefit. Seven infos remain repo-wide, none failing; sweeping them would bury the four real fixes.

## Verification

`npm run lint` exit 0 · every catalog gate exit 0 (`validate:catalog`, `validate:standards`, `validate:model-ids`, `verify:catalog`, `validate:doc-commands`, `validate:skeleton-toolchain`, `verify:library`) · sdk 140 tests, mcp-server 56, library/runtime 114, all pass.