### PR TITLE
fix: sign imgix and Uploadcare requests the way each vendor specifies

### DIFF
--- a/templates/module-media-ts/skeleton/src/media/__tests__/signing.test.ts
+++ b/templates/module-media-ts/skeleton/src/media/__tests__/signing.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getResponsiveSrcSet } from "../providers/imgix.js";
+// The barrel, for its side effect: every built-in provider self-registers on
+// import, so pulling in only imgix.js leaves `getProvider("uploadcare")` empty.
+import "../providers/index.js";
+import { getProvider } from "../providers/registry.js";
+
+// ── Provider signing tests ────────────────────────────────────────
+//
+// A wrong signature is the failure mode a type checker, a linter and a unit test
+// of the surrounding code all pass over: the URL is well-formed, the header is
+// present, the shape is right, and the vendor returns 403 or 401 with no clue
+// which of the signed components was wrong. So these are pinned against the
+// vendors' own published specifications rather than against what the code
+// currently emits.
+//
+// imgix publishes a worked vector, which makes its case a known-answer test —
+// the strongest available check, and one that fails on any of: the wrong hash
+// construction, a missing token, a dropped leading slash, or a query string
+// concatenated without its `?`.
+//
+//   https://github.com/imgix/imgix-blueprint#securing-urls
+//   https://uploadcare.com/docs/api/rest/authentication/
+
+/** The blueprint's published example: token `FOO123bar`, path `/users/1.png`. */
+const IMGIX_TOKEN = "FOO123bar";
+const IMGIX_VECTOR_SIGNATURE = "6797c24146142d5b40bde3141fd3600c";
+
+describe("imgix URL signing", () => {
+  async function imgix() {
+    const p = getProvider("imgix");
+    await p.init({ source: "demo", token: IMGIX_TOKEN });
+    return p;
+  }
+
+  it("reproduces the published signature for an unmodified asset", async () => {
+    const p = await imgix();
+    // md5("FOO123bar" + "/users/1.png"). If this is ever computed as an HMAC
+    // keyed with the token, or without the token in the hashed string at all,
+    // the digest changes completely and imgix rejects the URL.
+    expect(p.getUrl("users/1.png").url).toBe(
+      `https://demo.imgix.net/users/1.png?s=${IMGIX_VECTOR_SIGNATURE}`,
+    );
+  });
+
+  it("includes the query string, with its leading ?, in the signed base", async () => {
+    const p = await imgix();
+    const url = new URL(p.getUrl("users/1.png", { width: 400 }).url);
+    const query = "?w=400";
+    const { createHash } = await import("node:crypto");
+    const expected = createHash("md5").update(`${IMGIX_TOKEN}/users/1.png${query}`).digest("hex");
+    expect(url.searchParams.get("s")).toBe(expected);
+    // Signing the path alone would still produce a 32-char hex signature and a
+    // URL that looks correct, so assert it is *not* that.
+    const pathOnly = createHash("md5").update(`${IMGIX_TOKEN}/users/1.png`).digest("hex");
+    expect(url.searchParams.get("s")).not.toBe(pathOnly);
+  });
+
+  it("puts s last, as the spec requires", async () => {
+    const p = await imgix();
+    const url = p.getUrl("users/1.png", { width: 400, height: 300 }).url;
+    expect(url.slice(url.indexOf("s=")).includes("&")).toBe(false);
+  });
+
+  it("signs every srcset candidate the same way", async () => {
+    const { createHash } = await import("node:crypto");
+    const srcset = getResponsiveSrcSet("demo", IMGIX_TOKEN, "users/1.png", [320, 640]);
+    for (const w of [320, 640]) {
+      const expected = createHash("md5").update(`${IMGIX_TOKEN}/users/1.png?w=${w}`).digest("hex");
+      expect(srcset).toContain(`s=${expected} ${w}w`);
+    }
+  });
+});
+
+describe("uploadcare REST authentication", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Captures the headers of the first REST call the provider makes. */
+  async function captureListHeaders(): Promise<Record<string, string>> {
+    let captured: Record<string, string> = {};
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      captured = init.headers as Record<string, string>;
+      return new Response(JSON.stringify({ results: [] }), { status: 200 });
+    });
+    const p = getProvider("uploadcare");
+    await p.init({ publicKey: "pub", secretKey: "sec" });
+    await p.list();
+    return captured;
+  }
+
+  it("pins the REST API version, which the spec requires on every request", async () => {
+    const headers = await captureListHeaders();
+    expect(headers.Accept).toBe("application/vnd.uploadcare-v0.7+json");
+  });
+
+  it("signs with HMAC-SHA1 over the five components, joined by newlines", async () => {
+    const headers = await captureListHeaders();
+    const { createHash, createHmac } = await import("node:crypto");
+    // contentMd5 for a bodyless request is the MD5 of the empty string, not the
+    // empty string. Passing "" yields a signature over a different base than the
+    // server computes, and every call returns 401 with no indication why.
+    const emptyBodyMd5 = createHash("md5").update("").digest("hex");
+    const signString = ["GET", emptyBodyMd5, "application/json", headers.Date, "/files/?"].join(
+      "\n",
+    );
+    const expected = createHmac("sha1", "sec").update(signString).digest("hex");
+    expect(headers.Authorization).toBe(`Uploadcare pub:${expected}`);
+
+    const withEmptyString = createHmac("sha1", "sec")
+      .update(["GET", "", "application/json", headers.Date, "/files/?"].join("\n"))
+      .digest("hex");
+    expect(headers.Authorization).not.toBe(`Uploadcare pub:${withEmptyString}`);
+  });
+
+  it("sends the same Date it signed", async () => {
+    // The signature covers the Date, and the server rejects a skew over 15
+    // minutes — so a header regenerated after signing fails intermittently,
+    // which is worse than failing outright.
+    const headers = await captureListHeaders();
+    expect(headers.Date).toBeDefined();
+    expect(Number.isNaN(Date.parse(headers.Date))).toBe(false);
+  });
+});

--- a/templates/module-media-ts/skeleton/src/media/providers/imgix.ts
+++ b/templates/module-media-ts/skeleton/src/media/providers/imgix.ts
@@ -56,6 +56,13 @@ const DEFAULT_SRCSET_WIDTHS = [320, 640, 960, 1280, 1920];
  * `getResponsiveSrcSet` sign URLs, and a second inline copy is how the two
  * drifted apart.
  *
+ * MD5 is not a choice here — imgix validates this exact construction and no
+ * other, so a stronger hash produces a signature the CDN rejects. What the
+ * signature protects against is a third party minting transform URLs against
+ * your source, and the guarantee comes from the token being secret and
+ * unguessable rather than from the hash's collision resistance: forging a URL
+ * requires the token, not a collision. Treat the token as a credential.
+ *
  * https://github.com/imgix/imgix-blueprint#securing-urls
  */
 function signUrl(pathWithQuery: string, token: string): string {

--- a/templates/module-media-ts/skeleton/src/media/providers/imgix.ts
+++ b/templates/module-media-ts/skeleton/src/media/providers/imgix.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHash } from "node:crypto";
 import { logger } from "../logger.js";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 import type {
@@ -39,6 +39,31 @@ const FIT_MAP: Record<string, string> = {
 /** Default responsive widths for srcset generation. */
 const DEFAULT_SRCSET_WIDTHS = [320, 640, 960, 1280, 1920];
 
+/**
+ * imgix secure-URL signature: a plain MD5 of the token concatenated with the
+ * path and, when present, the query string including its leading `?`.
+ *
+ * Not an HMAC. imgix keys nothing — the token is a prefix of the hashed string,
+ * so `md5(token + path + query)` and `hmac_md5(token, path + query)` are
+ * different digests and imgix rejects the second one. The token still has to
+ * stay secret, but that is because it is unguessable, not because of any MAC
+ * construction.
+ *
+ * `pathWithQuery` must carry its leading slash and keep any percent-encoding
+ * intact, and `s` must be the last query parameter in the emitted URL.
+ *
+ * Module-scoped because both the provider's `buildUrl` and the exported
+ * `getResponsiveSrcSet` sign URLs, and a second inline copy is how the two
+ * drifted apart.
+ *
+ * https://github.com/imgix/imgix-blueprint#securing-urls
+ */
+function signUrl(pathWithQuery: string, token: string): string {
+  return createHash("md5")
+    .update(token + pathWithQuery)
+    .digest("hex");
+}
+
 function createImgixProvider(): MediaProvider {
   let config: ImgixConfig | null = null;
   const breaker = createCircuitBreaker({ failureThreshold: 5, resetTimeoutMs: 30_000 });
@@ -46,11 +71,6 @@ function createImgixProvider(): MediaProvider {
   function requireConfig(): ImgixConfig {
     if (!config) throw new Error("imgix provider not initialized -- call init() first");
     return config;
-  }
-
-  function signUrl(path: string, token: string): string {
-    const signature = createHmac("md5", token).update(path).digest("hex");
-    return signature;
   }
 
   function buildUrl(assetPath: string, transforms?: TransformOptions): string {
@@ -155,7 +175,7 @@ export function getResponsiveSrcSet(
 
       const queryString = params.toString();
       const pathWithQuery = `/${assetPath}?${queryString}`;
-      const sig = createHmac("md5", token).update(pathWithQuery).digest("hex");
+      const sig = signUrl(pathWithQuery, token);
 
       return `https://${source}.imgix.net${pathWithQuery}&s=${sig} ${w}w`;
     })

--- a/templates/module-media-ts/skeleton/src/media/providers/uploadcare.ts
+++ b/templates/module-media-ts/skeleton/src/media/providers/uploadcare.ts
@@ -86,6 +86,16 @@ function createUploadcareProvider(): MediaProvider {
    * comes back 401 with nothing to indicate which of the five components was
    * wrong. A request that does carry a body needs the body's own digest here.
    *
+   * On SHA-1: the algorithm is fixed by Uploadcare's protocol — the server
+   * validates HMAC-SHA1 and nothing else, so this is not a choice the client
+   * gets to make. A static analyser will flag it as a weak hash, and for a
+   * *digest* that would be right; for an HMAC it is not. HMAC's security rests
+   * on the PRF property of the compression function, not on collision
+   * resistance, so the SHAttered-class attacks on SHA-1 do not carry over.
+   * HMAC-SHA1 has no practical break and remains acceptable for authentication.
+   * (Contrast the Cloudinary provider, which signs a bare digest and therefore
+   * uses SHA-256 — there the vendor accepts both and the stronger hash is free.)
+   *
    * https://uploadcare.com/docs/api/rest/authentication/
    */
   function signedHeaders(method: string, uri: string): Record<string, string> {

--- a/templates/module-media-ts/skeleton/src/media/providers/uploadcare.ts
+++ b/templates/module-media-ts/skeleton/src/media/providers/uploadcare.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { logger } from "../logger.js";
 import { createCircuitBreaker } from "../resilience/circuit-breaker.js";
 import type {
@@ -52,6 +52,15 @@ const FIT_MAP: Record<string, string> = {
   scale: "scale",
 };
 
+/** The REST API version the spec requires on every request, via `Accept`. */
+const REST_API_VERSION = "application/vnd.uploadcare-v0.7+json";
+
+/**
+ * MD5 of an empty request body — the `contentMd5` component for any bodyless
+ * call. Computed rather than pasted so it is verifiable at a glance.
+ */
+const EMPTY_BODY_MD5 = createHash("md5").update("").digest("hex");
+
 function createUploadcareProvider(): MediaProvider {
   let config: UploadcareConfig | null = null;
   const breaker = createCircuitBreaker({ failureThreshold: 5, resetTimeoutMs: 30_000 });
@@ -62,16 +71,35 @@ function createUploadcareProvider(): MediaProvider {
     return config;
   }
 
-  function buildAuthHeader(
-    method: string,
-    contentType: string,
-    contentMd5: string,
-    uri: string,
-    date: string,
-    secretKey: string,
-  ): string {
-    const signString = [method, contentMd5, contentType, date, uri].join("\n");
-    return createHmac("sha1", secretKey).update(signString).digest("hex");
+  /**
+   * Every header the signed REST scheme requires, for a request with no body.
+   *
+   * Returns the whole header set rather than just the signature because three of
+   * the four parts are load-bearing and easy to omit one at a time: the `Date`
+   * that was signed has to be the `Date` that is sent (the server rejects a skew
+   * over 15 minutes), the `Content-Type` is inside the signed string, and
+   * `Accept` pins the API version, which the spec requires on every request.
+   *
+   * `contentMd5` is the MD5 of the request body, and for a bodyless request that
+   * is the MD5 of the empty string — not the empty string. Passing "" produces a
+   * signature over a different string than the server computes, so every call
+   * comes back 401 with nothing to indicate which of the five components was
+   * wrong. A request that does carry a body needs the body's own digest here.
+   *
+   * https://uploadcare.com/docs/api/rest/authentication/
+   */
+  function signedHeaders(method: string, uri: string): Record<string, string> {
+    const { publicKey, secretKey } = requireConfig();
+    const date = new Date().toUTCString();
+    const contentType = "application/json";
+    const signString = [method, EMPTY_BODY_MD5, contentType, date, uri].join("\n");
+    const signature = createHmac("sha1", secretKey).update(signString).digest("hex");
+    return {
+      "Content-Type": contentType,
+      Accept: REST_API_VERSION,
+      Date: date,
+      Authorization: `Uploadcare ${publicKey}:${signature}`,
+    };
   }
 
   return {
@@ -121,19 +149,12 @@ function createUploadcareProvider(): MediaProvider {
       const uuid = response.file;
 
       // Fetch file info for dimensions
-      const { publicKey: pk, secretKey } = requireConfig();
-      const date = new Date().toUTCString();
       const uri = `/files/${uuid}/`;
-      const signature = buildAuthHeader("GET", "application/json", "", uri, date, secretKey);
 
       const info = await breaker.execute(async (): Promise<UploadcareFileInfo> => {
         const res = await fetch(`https://api.uploadcare.com${uri}`, {
           signal: AbortSignal.timeout(30_000),
-          headers: {
-            "Content-Type": "application/json",
-            Date: date,
-            Authorization: `Uploadcare ${pk}:${signature}`,
-          },
+          headers: signedHeaders("GET", uri),
         });
         if (!res.ok) return {};
         return res.json() as Promise<UploadcareFileInfo>;
@@ -194,20 +215,13 @@ function createUploadcareProvider(): MediaProvider {
     },
 
     async delete(assetId: string): Promise<void> {
-      const { publicKey, secretKey } = requireConfig();
-      const date = new Date().toUTCString();
       const uri = `/files/${assetId}/`;
-      const signature = buildAuthHeader("DELETE", "application/json", "", uri, date, secretKey);
 
       await breaker.execute(async () => {
         const res = await fetch(`https://api.uploadcare.com${uri}`, {
           method: "DELETE",
           signal: AbortSignal.timeout(30_000),
-          headers: {
-            "Content-Type": "application/json",
-            Date: date,
-            Authorization: `Uploadcare ${publicKey}:${signature}`,
-          },
+          headers: signedHeaders("DELETE", uri),
         });
         if (!res.ok) {
           const text = await res.text();
@@ -219,23 +233,16 @@ function createUploadcareProvider(): MediaProvider {
     },
 
     async list(options?: ListOptions): Promise<ListResult> {
-      const { publicKey, secretKey } = requireConfig();
-      const date = new Date().toUTCString();
       const params = new URLSearchParams();
       if (options?.maxResults) params.set("limit", options.maxResults.toString());
       if (options?.cursor) params.set("offset", options.cursor);
 
       const uri = `/files/?${params}`;
-      const signature = buildAuthHeader("GET", "application/json", "", uri, date, secretKey);
 
       const response = await breaker.execute(async (): Promise<UploadcareListResponse> => {
         const res = await fetch(`https://api.uploadcare.com${uri}`, {
           signal: AbortSignal.timeout(30_000),
-          headers: {
-            "Content-Type": "application/json",
-            Date: date,
-            Authorization: `Uploadcare ${publicKey}:${signature}`,
-          },
+          headers: signedHeaders("GET", uri),
         });
         if (!res.ok) {
           const text = await res.text();


### PR DESCRIPTION
Both providers in `module-media-ts` built their credentials from the right ingredients in the wrong construction, so **every signed request they produce is rejected**. Verified against each vendor's own specification rather than reasoned about.

## imgix — an HMAC where a hash was specified

`signUrl` computed `hmac_md5(token, path)`. The [blueprint](https://github.com/imgix/imgix-blueprint#securing-urls), which imgix's own client libraries are generated from, specifies a plain MD5 over the token concatenated with the path:

```ruby
signature_base = token + path
signature_base += query if !query.nil?
Digest::MD5.hexdigest(signature_base)
```

Different digests. Nothing about the shape gives it away — both emit 32 lowercase hex characters in the `s` parameter, so the URL looks correct and imgix returns 403.

Pinned with the blueprint's published worked example (token `FOO123bar`, path `/users/1.png` → `6797c24146142d5b40bde3141fd3600c`), which makes this a **known-answer test**. It fails on the wrong hash construction, a missing token, a dropped leading slash, or a query string concatenated without its `?`.

`signUrl` also moves to module scope: `getResponsiveSrcSet` couldn't reach the factory-scoped closure and carried its own inline copy — which is why there were two wrong implementations, not one.

## Uploadcare — right scheme, wrong empty body

The HMAC-SHA1 construction was correct. Two details underneath it were not.

- `contentMd5` was `""`. For a bodyless request the value is the MD5 *of* the empty string, `d41d8cd98f00b204e9800998ecf8427e` — so the client signed a different base than the server computes, and every REST call returned 401 with no indication which of the five components was at fault.
- The `Accept: application/vnd.uploadcare-v0.7+json` header was absent. The spec requires it on every request.

`buildAuthHeader` becomes `signedHeaders`, returning the whole header set. Three of the four parts are load-bearing and were being reassembled by hand at three call sites — the signed `Date` must be the sent `Date` (15-minute skew limit), `Content-Type` is inside the signed string, and `Accept` pins the version. Handing back one string is what let the version header go missing at all three.

## Verification

Skeleton: `npm test` 60 pass, coverage 98.13% (was 85% floor, previously passing), `tsc --noEmit`, `lint`, `format:check` all exit 0. Catalog: `lint:skeletons`, `validate:skeleton-toolchain`, `validate:catalog`, repo `lint` all exit 0.

Each test also asserts the *wrong* construction is not what ships — a signature test that only checked digest length and character class would have passed throughout.