### PR TITLE
test: lift six skeletons to the coverage floor the catalog publishes

### DIFF
--- a/scripts/template-doctor/checks/standards.mjs
+++ b/scripts/template-doctor/checks/standards.mjs
@@ -41,37 +41,13 @@ const FLOOR = JSON.parse(readFileSync(join(ROOT, "standards", "testing-rubric.js
  * close the distance. Raising a number here without writing the tests puts the
  * gate back to decorative, which is the exact failure this check exists to
  * prevent.
+ *
+ * Empty: every TypeScript skeleton now meets the published floor. The check
+ * below reports a stale entry as an error precisely so this does not quietly
+ * become a permanent allowlist — an exception that outlives its reason reads as
+ * a standard with a carve-out rather than a standard.
  */
-const BELOW_FLOOR = {
-  "ci-eval": {
-    lines: 55,
-    functions: 72,
-    statements: 55,
-    why: "assertions.ts and runner.ts carry the evaluation logic and are largely untested",
-  },
-  "eval-harness": {
-    lines: 72,
-    functions: 69,
-    statements: 72,
-    why: "assertions.ts is the reusable half and sits around two thirds covered",
-  },
-  "module-queue-ts": {
-    functions: 63,
-    lines: 73,
-    statements: 73,
-    why: "job.ts has no tests for its handler surface",
-  },
-  "module-webhook-ts": {
-    functions: 61,
-    why: "hmac-sha1.ts and the mock transport have no function-level coverage",
-  },
-  "multimodal-pipeline": {
-    lines: 52,
-    functions: 70,
-    statements: 52,
-    why: "the per-modality processors and the pipeline stage runner are untested",
-  },
-};
+const BELOW_FLOOR = {};
 
 /** Go skeletons gate through a Makefile COVERAGE_MIN, pinned the same way. */
 const GO_BELOW_FLOOR = {

--- a/templates/ci-eval/skeleton/src/__tests__/assertions.test.ts
+++ b/templates/ci-eval/skeleton/src/__tests__/assertions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { evaluateAssertion, registerAssertion } from "../ci-eval/assertions.js";
+
+// ── Assertion registry tests ──────────────────────────────────────
+//
+// These are what decides whether an eval case passed, so a broken
+// evaluator does not fail loudly — it silently grades every run wrong in
+// one direction. Each built-in type is checked on both outcomes, because
+// an evaluator stuck on `true` and a correct one are indistinguishable
+// from the passing case alone.
+
+describe("evaluateAssertion", () => {
+  it("reports an unknown type as a failure rather than throwing", () => {
+    // A typo in a YAML suite must fail the case, not crash the runner
+    // mid-suite and lose every result after it.
+    const r = evaluateAssertion("contians", "x", "x");
+    expect(r.pass).toBe(false);
+    expect(r.message).toContain("Unknown assertion type");
+    expect(r.type).toBe("contians");
+  });
+
+  describe("contains", () => {
+    it("passes when the substring is present", () => {
+      const r = evaluateAssertion("contains", "needle", "a needle in a haystack");
+      expect(r.pass).toBe(true);
+      expect(r.message).toContain("needle");
+    });
+
+    it("fails when it is absent", () => {
+      expect(evaluateAssertion("contains", "needle", "just hay").pass).toBe(false);
+    });
+
+    it("coerces a non-string value before comparing", () => {
+      // Suite files are YAML, so a bare `value: 200` arrives as a number.
+      expect(evaluateAssertion("contains", 200, "status 200 ok").pass).toBe(true);
+    });
+  });
+
+  describe("not-contains", () => {
+    it("passes when the substring is absent", () => {
+      expect(evaluateAssertion("not-contains", "sorry", "here is the answer").pass).toBe(true);
+    });
+
+    it("fails when it is present", () => {
+      const r = evaluateAssertion("not-contains", "sorry", "sorry, I cannot help");
+      expect(r.pass).toBe(false);
+      expect(r.message).toContain("unexpectedly");
+    });
+  });
+
+  describe("matches-pattern", () => {
+    it("passes on a match", () => {
+      expect(evaluateAssertion("matches-pattern", "^\\d{3}-\\d{4}$", "555-1234").pass).toBe(true);
+    });
+
+    it("fails on no match", () => {
+      expect(evaluateAssertion("matches-pattern", "^\\d+$", "abc").pass).toBe(false);
+    });
+
+    it("treats the value as a regex, not a literal", () => {
+      // `.` matching any character is the difference between this and
+      // `contains`; if the pattern were escaped this would fail.
+      expect(evaluateAssertion("matches-pattern", "a.c", "abc").pass).toBe(true);
+    });
+  });
+
+  describe("max-length", () => {
+    it("passes at exactly the limit", () => {
+      // The boundary is the whole point of the assertion, and `<=` vs `<`
+      // is a one-character bug that only this case catches.
+      const r = evaluateAssertion("max-length", 5, "12345");
+      expect(r.pass).toBe(true);
+      expect(r.message).toContain("within limit");
+    });
+
+    it("fails one over the limit", () => {
+      const r = evaluateAssertion("max-length", 5, "123456");
+      expect(r.pass).toBe(false);
+      expect(r.message).toContain("exceeds limit");
+    });
+  });
+});
+
+describe("registerAssertion", () => {
+  it("makes a custom type dispatchable by name", () => {
+    registerAssertion("is-json", (_value, output) => {
+      try {
+        JSON.parse(output);
+        return { type: "is-json", pass: true, message: "Output parsed as JSON" };
+      } catch {
+        return { type: "is-json", pass: false, message: "Output is not JSON" };
+      }
+    });
+
+    expect(evaluateAssertion("is-json", null, '{"ok":true}').pass).toBe(true);
+    expect(evaluateAssertion("is-json", null, "not json").pass).toBe(false);
+  });
+
+  it("lets a later registration replace an earlier one", () => {
+    // The registry is a Map, so re-registering overrides. Worth pinning:
+    // it is how a project overrides a built-in, and it would equally be
+    // how an accidental duplicate silently changes grading.
+    registerAssertion("contains-once", () => ({
+      type: "contains-once",
+      pass: false,
+      message: "first",
+    }));
+    registerAssertion("contains-once", () => ({
+      type: "contains-once",
+      pass: true,
+      message: "second",
+    }));
+    expect(evaluateAssertion("contains-once", "x", "x").message).toBe("second");
+  });
+});

--- a/templates/ci-eval/skeleton/src/__tests__/runner-cases.test.ts
+++ b/templates/ci-eval/skeleton/src/__tests__/runner-cases.test.ts
@@ -1,0 +1,170 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../ci-eval/config.js";
+import { createLogger } from "../ci-eval/logger.js";
+import { registerProvider } from "../ci-eval/providers/registry.js";
+import { createEvalRunner } from "../ci-eval/runner.js";
+
+// ── Runner execution tests ────────────────────────────────────────
+//
+// The sibling runner test covers suite discovery. This covers what happens
+// once a suite is found: scoring, the per-case failure path, and bounded
+// concurrency.
+//
+// A fake provider registered by name is the seam — the registry exists for
+// exactly this, so no module mocking is needed and the real scoring,
+// assertion dispatch, and concurrency gate all run.
+
+const logger = createLogger("error");
+
+function makeConfig(evalPath: string, provider: string, concurrency = 5): Config {
+  return {
+    evalPath,
+    regressionThreshold: 0.05,
+    llmProvider: provider,
+    baselinePath: ".eval-baseline.json",
+    concurrency,
+    logLevel: "error",
+  };
+}
+
+describe("running a discovered suite", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `ci-eval-run-${process.hrtime.bigint()}`);
+    await mkdir(dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("scores a suite where some assertions fail", async () => {
+    registerProvider("echo", () => ({
+      name: "echo",
+      async complete(prompt: string) {
+        return prompt;
+      },
+    }));
+
+    await writeFile(
+      join(dir, "suite.yaml"),
+      [
+        "name: echo-suite",
+        "cases:",
+        "  - name: passing",
+        "    input: hello world",
+        "    assertions:",
+        "      - type: contains",
+        "        value: hello",
+        "  - name: failing",
+        "    input: hello world",
+        "    assertions:",
+        "      - type: contains",
+        "        value: goodbye",
+      ].join("\n"),
+    );
+
+    const [score] = await createEvalRunner(makeConfig(dir, "echo"), logger).run();
+
+    expect(score.suite).toBe("echo-suite");
+    expect(score.total).toBe(2);
+    expect(score.passed).toBe(1);
+    expect(score.passRate).toBe(0.5);
+    // Per-case score is the fraction of assertions that passed, so the
+    // suite average is the mean of 1 and 0 — not the same number as the
+    // pass rate in general, which is why both are asserted.
+    expect(score.averageScore).toBe(0.5);
+    expect(score.cases.map((c) => c.name).sort()).toEqual(["failing", "passing"]);
+  });
+
+  it("records a provider error as a failed case instead of aborting the suite", async () => {
+    registerProvider("explodes", () => ({
+      name: "explodes",
+      async complete() {
+        throw new Error("upstream 503");
+      },
+    }));
+
+    await writeFile(
+      join(dir, "suite.yaml"),
+      [
+        "name: error-suite",
+        "cases:",
+        "  - name: first",
+        "    input: a",
+        "    assertions: []",
+        "  - name: second",
+        "    input: b",
+        "    assertions: []",
+      ].join("\n"),
+    );
+
+    const [score] = await createEvalRunner(makeConfig(dir, "explodes"), logger).run();
+
+    // Both cases must be reported. A throw that escaped runCase would lose
+    // the second case entirely and the suite would look half its size.
+    expect(score.total).toBe(2);
+    expect(score.passed).toBe(0);
+    expect(score.cases.every((c) => c.error === "upstream 503")).toBe(true);
+    expect(score.cases.every((c) => c.score === 0)).toBe(true);
+  });
+
+  it("treats a case with no assertions as a pass", async () => {
+    registerProvider("quiet", () => ({
+      name: "quiet",
+      async complete() {
+        return "anything";
+      },
+    }));
+
+    await writeFile(
+      join(dir, "suite.yaml"),
+      ["cases:", "  - name: smoke", "    input: a", "    assertions: []"].join("\n"),
+    );
+
+    const [score] = await createEvalRunner(makeConfig(dir, "quiet"), logger).run();
+    // `every` on an empty array is true, so this would pass by accident even
+    // if the intent were the opposite — pinned so the intent is recorded.
+    expect(score.passed).toBe(1);
+    expect(score.cases[0]?.score).toBe(1);
+    // No `name:` in the file, so the suite name falls back to the basename.
+    expect(score.suite).toBe("suite");
+  });
+
+  it("never exceeds the configured concurrency", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    registerProvider("counting", () => ({
+      name: "counting",
+      async complete(prompt: string) {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+        return prompt;
+      },
+    }));
+
+    const cases = Array.from({ length: 8 }, (_, i) =>
+      [`  - name: case-${i}`, "    input: x", "    assertions: []"].join("\n"),
+    );
+    await writeFile(join(dir, "suite.yaml"), ["cases:", ...cases].join("\n"));
+
+    const [score] = await createEvalRunner(makeConfig(dir, "counting", 2), logger).run();
+
+    expect(score.total).toBe(8);
+    // The gate is a hand-rolled slot queue rather than a library, so this is
+    // the only thing standing between "bounded" and "all eight at once
+    // against a rate-limited API".
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  it("returns no scores when the eval path holds no suites", async () => {
+    const scores = await createEvalRunner(makeConfig(dir, "echo"), logger).run();
+    expect(scores).toEqual([]);
+  });
+});

--- a/templates/ci-eval/skeleton/src/ci-eval/runner.ts
+++ b/templates/ci-eval/skeleton/src/ci-eval/runner.ts
@@ -35,7 +35,12 @@ const CaseSchema = z.object({
 });
 
 const SuiteFileSchema = z.object({
-  name: z.string(),
+  // Optional, because `runSuite` already falls back to the file's basename —
+  // and while this was required, that fallback was unreachable: Zod rejected a
+  // nameless suite before the runner ever got to default it. A filename is a
+  // fine suite name, so the field earns its keep only when you want a different
+  // one.
+  name: z.string().optional(),
   description: z.string().optional(),
   model: z.string().optional(),
   cases: z.array(CaseSchema),

--- a/templates/ci-eval/skeleton/vitest.config.ts
+++ b/templates/ci-eval/skeleton/vitest.config.ts
@@ -23,15 +23,16 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Below the floor published in nanohype/standards/testing-rubric.json
-      // (lines/functions/statements 75, branches 60). These are the measured
-      // values, now actually enforced: closing the gap needs tests for the
-      // scaffolding this skeleton ships, not a higher number here.
+      // At or above the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). Branches sits well over the
+      // published number because the gated surface is assertion dispatch and
+      // scoring, which is mostly branching — lowering it to 60 here would let a
+      // real regression through.
       thresholds: {
-        lines: 55,
-        functions: 72,
-        statements: 55,
-        branches: 85,
+        lines: 100,
+        functions: 100,
+        statements: 100,
+        branches: 90,
       },
     },
   },

--- a/templates/eval-harness/skeleton/src/__tests__/assertions-registry.test.ts
+++ b/templates/eval-harness/skeleton/src/__tests__/assertions-registry.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  ASSERTION_REGISTRY,
+  matchesJsonSchema,
+  resolveAssertion,
+  satisfies,
+  semanticSimilarity,
+} from "../assertions.js";
+
+// ── Registry + schema/similarity assertions ───────────────────────
+//
+// The sibling suite covers the string assertions. These are the three that
+// carry real logic — a declarative-schema translator, an async predicate,
+// and a TF-IDF similarity score — plus the registry that a YAML suite
+// reaches them through.
+//
+// An assertion is what decides pass or fail, so a broken one does not
+// surface as an error; it silently grades every case the same way. Each
+// case below asserts both outcomes for that reason.
+
+describe("matchesJsonSchema", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      count: { type: "number" },
+      done: { type: "boolean" },
+      tags: { type: "array" },
+      extra: {},
+    },
+    required: ["name", "count"],
+  };
+
+  it("passes a payload satisfying every declared field", () => {
+    const r = matchesJsonSchema(schema)(
+      JSON.stringify({ name: "a", count: 1, done: true, tags: [], extra: null }),
+    );
+    expect(r.pass).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("passes when only the required fields are present", () => {
+    // Non-required fields become `.optional()`, so omitting them must not
+    // fail — this is the branch that distinguishes required from optional.
+    expect(matchesJsonSchema(schema)(JSON.stringify({ name: "a", count: 1 })).pass).toBe(true);
+  });
+
+  it("fails when a required field is missing", () => {
+    const r = matchesJsonSchema(schema)(JSON.stringify({ name: "a" }));
+    expect(r.pass).toBe(false);
+    expect(r.message).toContain("JSON schema validation failed");
+  });
+
+  it("fails when a field has the wrong type", () => {
+    expect(matchesJsonSchema(schema)(JSON.stringify({ name: "a", count: "1" })).pass).toBe(false);
+  });
+
+  it("reports unparseable output as not-JSON rather than as a schema failure", () => {
+    // Two different problems for whoever reads the eval report: the model
+    // emitted prose, versus it emitted JSON of the wrong shape.
+    const r = matchesJsonSchema(schema)("I cannot do that");
+    expect(r.pass).toBe(false);
+    expect(r.message).toBe("Output is not valid JSON");
+  });
+
+  it("accepts anything when the schema is not an object type", () => {
+    // `schema.type !== "object"` falls back to `z.unknown()`, which accepts
+    // any parsed value — worth pinning so the permissiveness is deliberate.
+    expect(matchesJsonSchema({ type: "array" })("[1,2,3]").pass).toBe(true);
+  });
+});
+
+describe("satisfies", () => {
+  it("passes on a synchronous predicate returning true", async () => {
+    const r = await satisfies((o) => o.length > 3, "long enough")("hello");
+    expect(r.pass).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("awaits an async predicate", async () => {
+    const r = await satisfies(async (o) => o.startsWith("{"))('{"a":1}');
+    expect(r.pass).toBe(true);
+  });
+
+  it("fails and names the label", async () => {
+    const r = await satisfies(() => false, "the house rule")("x");
+    expect(r.pass).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.message).toContain("the house rule");
+  });
+});
+
+describe("semanticSimilarity", () => {
+  it("scores identical text at the top of the range", () => {
+    const r = semanticSimilarity("the quick brown fox", 0.9)("the quick brown fox");
+    expect(r.pass).toBe(true);
+    expect(r.score).toBeGreaterThan(0.99);
+  });
+
+  it("scores unrelated text below a default threshold", () => {
+    const r = semanticSimilarity("database migration rollback")("a poem about the sea");
+    expect(r.pass).toBe(false);
+    expect(r.score).toBeLessThan(0.8);
+    expect(r.message).toContain("<");
+  });
+
+  it("lands partial overlap strictly between the extremes", () => {
+    // The distinguishing check. Textbook IDF over a two-document corpus gives a
+    // shared term log(2/2) = 0 weight, which zeroes the only signal there is and
+    // returns 0 for *every* input — identical strings included. A score that is
+    // neither 0 nor 1 is what proves the weighting survived.
+    const r = semanticSimilarity("alpha beta", 0.9)("alpha gamma");
+    expect(r.score).toBeGreaterThan(0);
+    expect(r.score).toBeLessThan(1);
+    expect(r.pass).toBe(false);
+  });
+
+  it("is insensitive to case and punctuation", () => {
+    // Tokenization lowercases and splits on punctuation, so these should
+    // land on the same vectors — if they did not, every real-world output
+    // would score lower than it should for reasons unrelated to meaning.
+    const r = semanticSimilarity("Deploy the service.", 0.9)("deploy the service");
+    expect(r.pass).toBe(true);
+  });
+});
+
+describe("resolveAssertion", () => {
+  it("resolves every type the registry advertises", async () => {
+    // The registry keys are the vocabulary a YAML suite is written against,
+    // so a key present but unresolvable is a suite that fails at run time
+    // with a type error rather than at parse time with a clear message.
+    for (const type of Object.keys(ASSERTION_REGISTRY)) {
+      const value =
+        type === "matchesJsonSchema"
+          ? { type: "object", properties: {} }
+          : type === "maxTokens"
+            ? 100
+            : type === "semanticSimilarity"
+              ? { reference: "hello" }
+              : "hello";
+      expect(typeof resolveAssertion(type, value)).toBe("function");
+    }
+  });
+
+  it("carries the threshold through the semanticSimilarity factory", async () => {
+    // The registry unpacks a config object for this one type. A dropped
+    // threshold would silently fall back to the 0.8 default, which passes
+    // more than the suite asked for.
+    const strict = resolveAssertion("semanticSimilarity", {
+      reference: "alpha beta",
+      threshold: 0.99,
+    });
+    const r = await strict("alpha gamma");
+    expect(r.pass).toBe(false);
+  });
+
+  it("throws on an unknown type and lists what is available", () => {
+    expect(() => resolveAssertion("doesNotExist", null)).toThrow(/Unknown assertion type/);
+    expect(() => resolveAssertion("doesNotExist", null)).toThrow(/contains/);
+  });
+});

--- a/templates/eval-harness/skeleton/src/assertions.ts
+++ b/templates/eval-harness/skeleton/src/assertions.ts
@@ -239,11 +239,22 @@ function tfidfCosineSimilarity(a: string, b: string): number {
   // Build vocabulary (union of both token sets)
   const vocab = new Set<string>([...tfA.keys(), ...tfB.keys()]);
 
-  // IDF: log(N / df) where N = 2 (two documents), df = number of docs containing the term
+  // Smoothed IDF: log((1 + N) / (1 + df)) + 1, with N = 2 (two documents).
+  //
+  // Textbook IDF is log(N / df), and with a two-document corpus that is fatal
+  // rather than merely imprecise: a term in both documents has df = 2, so
+  // log(2 / 2) = 0. Every *shared* term gets zero weight — and shared terms are
+  // the entire similarity signal. Two identical strings then produce two
+  // all-zero vectors, magnitude 0, and a similarity of 0. The assertion scored
+  // every comparison, identical text included, as completely dissimilar.
+  //
+  // The `+ 1` (scikit-learn's smooth_idf) keeps a term that appears everywhere
+  // at weight 1 instead of 0, and the `1 +` on both terms keeps the ratio finite.
+  // Identical input now scores 1, unrelated input 0, partial overlap in between.
   const idf = new Map<string, number>();
   for (const term of vocab) {
     const df = (tfA.has(term) ? 1 : 0) + (tfB.has(term) ? 1 : 0);
-    idf.set(term, Math.log(2 / df));
+    idf.set(term, Math.log((1 + 2) / (1 + df)) + 1);
   }
 
   // Build TF-IDF vectors and compute cosine similarity in one pass

--- a/templates/eval-harness/skeleton/vitest.config.ts
+++ b/templates/eval-harness/skeleton/vitest.config.ts
@@ -23,15 +23,16 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Below the floor published in nanohype/standards/testing-rubric.json
-      // (lines/functions/statements 75, branches 60). These are the measured
-      // values, now actually enforced: closing the gap needs tests for the
-      // scaffolding this skeleton ships, not a higher number here.
+      // Above the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). Branches sits over the
+      // published number because the gated surface is assertion evaluation and
+      // suite orchestration, which is mostly branching — dropping it to 60 would
+      // let a real regression through.
       thresholds: {
-        lines: 72,
-        functions: 69,
-        statements: 72,
-        branches: 77,
+        lines: 95,
+        functions: 95,
+        statements: 95,
+        branches: 85,
       },
     },
   },

--- a/templates/module-queue-ts/skeleton/src/queue/__tests__/job.test.ts
+++ b/templates/module-queue-ts/skeleton/src/queue/__tests__/job.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildJob, defineJob, resolveJobOptions } from "../job.js";
+
+// ── Job helper tests ──────────────────────────────────────────────
+//
+// These decide what a job actually carries once it reaches a provider, and
+// they are provider-agnostic — so a wrong default here is wrong in every
+// backend at once, and shows up as "why did that job only retry once".
+
+describe("resolveJobOptions", () => {
+  it("applies every default when called with nothing", () => {
+    expect(resolveJobOptions()).toEqual({ maxRetries: 3, delay: 0, priority: 0, id: "" });
+  });
+
+  it("keeps a caller value that happens to equal a falsy default", () => {
+    // `??` rather than `||` is the whole correctness question here: with `||`,
+    // an explicit `maxRetries: 0` ("do not retry this") would silently become
+    // 3, and a `delay: 0` would be indistinguishable from unset.
+    expect(resolveJobOptions({ maxRetries: 0, delay: 0, priority: 0 })).toEqual({
+      maxRetries: 0,
+      delay: 0,
+      priority: 0,
+      id: "",
+    });
+  });
+
+  it("overrides only what is supplied", () => {
+    expect(resolveJobOptions({ priority: 9 })).toEqual({
+      maxRetries: 3,
+      delay: 0,
+      priority: 9,
+      id: "",
+    });
+  });
+});
+
+describe("buildJob", () => {
+  it("carries the name, payload and resolved options", () => {
+    const job = buildJob("send-email", { to: "a@b.com" }, { maxRetries: 5, priority: 2 });
+    expect(job.name).toBe("send-email");
+    expect(job.data).toEqual({ to: "a@b.com" });
+    expect(job.maxRetries).toBe(5);
+    expect(job.priority).toBe(2);
+    expect(job.attempts).toBe(0);
+    expect(Number.isNaN(Date.parse(job.createdAt))).toBe(false);
+  });
+
+  it("uses the caller's id when one is given", () => {
+    expect(buildJob("j", null, { id: "explicit-id" }).id).toBe("explicit-id");
+  });
+
+  it("synthesises a placeholder id when none is given", () => {
+    // The id is `pending-` prefixed on purpose: the provider assigns the real
+    // one, and a caller logging this value should be able to tell it apart
+    // from a persisted id rather than chase a job that never had it.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-02T03:04:05.678Z"));
+    try {
+      expect(buildJob("j", null).id).toBe(`pending-${Date.parse("2026-01-02T03:04:05.678Z")}`);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("defineJob", () => {
+  it("bakes the job name in and forwards data and options unchanged", async () => {
+    const enqueue = vi.fn(async () => "job-1");
+    const sendEmail = defineJob<{ to: string }>("send-email");
+
+    const id = await sendEmail(enqueue, { to: "a@b.com" }, { priority: 4 });
+
+    expect(id).toBe("job-1");
+    // The point of the factory is that the call site cannot get the name
+    // wrong, so the name is asserted positionally rather than loosely.
+    expect(enqueue).toHaveBeenCalledWith("send-email", { to: "a@b.com" }, { priority: 4 });
+  });
+
+  it("passes no options through when the caller supplies none", async () => {
+    const enqueue = vi.fn(async () => "job-2");
+    await defineJob("reindex")(enqueue, { id: 7 });
+    expect(enqueue).toHaveBeenCalledWith("reindex", { id: 7 }, undefined);
+  });
+
+  it("propagates an enqueue failure rather than swallowing it", async () => {
+    const enqueue = vi.fn(async () => {
+      throw new Error("broker unreachable");
+    });
+    await expect(defineJob("j")(enqueue, null)).rejects.toThrow("broker unreachable");
+  });
+});

--- a/templates/module-queue-ts/skeleton/vitest.config.ts
+++ b/templates/module-queue-ts/skeleton/vitest.config.ts
@@ -22,15 +22,15 @@ export default defineConfig({
         "src/queue/providers/index.ts",
         "src/**/types.ts",
       ],
-      // Below the floor published in nanohype/standards/testing-rubric.json
-      // (lines/functions/statements 75, branches 60). These are the measured
-      // values, now actually enforced: closing the gap needs tests for the
-      // scaffolding this skeleton ships, not a higher number here.
+      // Above the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). Branches sits over the
+      // published number because the gated surface is option resolution and
+      // worker dispatch, which is mostly branching.
       thresholds: {
-        lines: 73,
-        functions: 63,
-        statements: 73,
-        branches: 85,
+        lines: 94,
+        functions: 85,
+        statements: 94,
+        branches: 90,
       },
     },
   },

--- a/templates/module-webhook-ts/skeleton/src/webhook/__tests__/signature-providers.test.ts
+++ b/templates/module-webhook-ts/skeleton/src/webhook/__tests__/signature-providers.test.ts
@@ -1,0 +1,89 @@
+import { createHash, createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import "../signatures/index.js";
+import { getSignatureProvider } from "../signatures/registry.js";
+
+// ── The other two signature providers ─────────────────────────────
+//
+// hmac-sha256 has its own suite. These are the two that did not: the
+// legacy-compatibility provider and the keyless test double.
+//
+// A signature provider that always returns true is the one bug here that
+// matters, and it is invisible from the passing case alone — so every
+// provider is checked on a good signature, a tampered signature, and a
+// wrong secret.
+
+describe("hmac-sha1 provider", () => {
+  const p = getSignatureProvider("hmac-sha1");
+
+  it("produces the documented HMAC-SHA1 hex digest", () => {
+    // Pinned against the construction rather than against itself, so a
+    // switch to a different hash or a plain digest fails here.
+    expect(p.sign("payload", "secret")).toBe(
+      createHmac("sha1", "secret").update("payload").digest("hex"),
+    );
+  });
+
+  it("verifies a signature it produced", () => {
+    expect(p.verify("payload", p.sign("payload", "secret"), "secret")).toBe(true);
+  });
+
+  it("rejects a tampered payload", () => {
+    expect(p.verify("payload!", p.sign("payload", "secret"), "secret")).toBe(false);
+  });
+
+  it("rejects the wrong secret", () => {
+    expect(p.verify("payload", p.sign("payload", "secret"), "other-secret")).toBe(false);
+  });
+
+  it("rejects a wrong-length signature without throwing", () => {
+    // `timingSafeEqual` throws on unequal lengths, so the length guard is
+    // load-bearing: without it a truncated signature crashes the request
+    // handler instead of failing verification.
+    expect(() => p.verify("payload", "short", "secret")).not.toThrow();
+    expect(p.verify("payload", "short", "secret")).toBe(false);
+    expect(p.verify("payload", "", "secret")).toBe(false);
+  });
+});
+
+describe("mock provider", () => {
+  const p = getSignatureProvider("mock");
+
+  it("hashes the payload and ignores the secret", () => {
+    // Deliberately keyless — that is the whole point of the double, and it
+    // is also why it must never be reachable in production. Pinned so the
+    // property is a stated fact rather than an accident.
+    const digest = createHash("sha256").update("payload").digest("hex");
+    expect(p.sign("payload", "any-secret")).toBe(digest);
+    expect(p.sign("payload", "different-secret")).toBe(digest);
+  });
+
+  it("verifies regardless of the secret supplied", () => {
+    const sig = p.sign("payload", "");
+    expect(p.verify("payload", sig, "whatever")).toBe(true);
+  });
+
+  it("still rejects a tampered payload", () => {
+    // Keyless does not mean it accepts anything — a double that passed every
+    // signature would make the sender's tests meaningless.
+    expect(p.verify("payload!", p.sign("payload", ""), "")).toBe(false);
+  });
+});
+
+describe("provider identity", () => {
+  it("registers each provider under the name it reports", () => {
+    // The registry keys on `provider.name`, so a mismatch between the key and
+    // the field is how a config asking for one algorithm quietly gets another.
+    for (const name of ["hmac-sha1", "hmac-sha256", "mock"]) {
+      expect(getSignatureProvider(name).name).toBe(name);
+    }
+  });
+
+  it("does not sign identically across algorithms", () => {
+    // Cheap guard against every provider being wired to the same function.
+    const sigs = ["hmac-sha1", "hmac-sha256", "mock"].map((n) =>
+      getSignatureProvider(n).sign("payload", "secret"),
+    );
+    expect(new Set(sigs).size).toBe(3);
+  });
+});

--- a/templates/module-webhook-ts/skeleton/vitest.config.ts
+++ b/templates/module-webhook-ts/skeleton/vitest.config.ts
@@ -19,15 +19,15 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Below the floor published in nanohype/standards/testing-rubric.json
-      // (lines/functions/statements 75, branches 60). These are the measured
-      // values, now actually enforced: closing the gap needs tests for the
-      // scaffolding this skeleton ships, not a higher number here.
+      // Above the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). Branches sits over the
+      // published number because the gated surface is signature verification,
+      // where each rejection path is a branch that must stay covered.
       thresholds: {
-        lines: 85,
-        functions: 61,
-        statements: 85,
-        branches: 76,
+        lines: 97,
+        functions: 100,
+        statements: 97,
+        branches: 82,
       },
     },
   },

--- a/templates/monorepo/skeleton/packages/shared-ui/package.json
+++ b/templates/monorepo/skeleton/packages/shared-ui/package.json
@@ -16,13 +16,16 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "lint": "biome lint .",
-    "test": "echo \"no tests yet\"",
+    "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo",
     "format": "biome format --write .",
-    "format:check": "biome format ."
+    "format:check": "biome format .",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
-    "typescript": "^5.8.0"
+    "@vitest/coverage-v8": "^4.1.10",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/templates/monorepo/skeleton/packages/shared-ui/src/index.test.ts
+++ b/templates/monorepo/skeleton/packages/shared-ui/src/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { type Component, tokens } from "./index.js";
+
+// ── shared-ui ─────────────────────────────────────────────────────
+//
+// This package is a starting point: a `Component` type to be replaced by a real
+// framework's, and the design tokens every other package renders against. There
+// is no behaviour to test yet, so what is worth pinning is the token contract —
+// tokens are consumed by string interpolation into CSS, where a malformed value
+// produces no error at all, just a rule the browser drops.
+
+describe("design tokens", () => {
+  it("exposes the three token groups packages consume", () => {
+    expect(Object.keys(tokens).sort()).toEqual(["colors", "radii", "spacing"]);
+  });
+
+  it("declares every colour as a six-digit hex value", () => {
+    // `#0f172a` and `#0f172` are both truthy strings, and only one of them is a
+    // colour. CSS silently ignores the other.
+    for (const [name, value] of Object.entries(tokens.colors)) {
+      expect(value, `colors.${name}`).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it("declares every spacing and radius with a CSS unit", () => {
+    // A bare number is the mistake this catches: `spacing.md: "1"` interpolates
+    // into `padding: 1`, which is invalid and dropped, so the layout is subtly
+    // wrong with nothing logged anywhere.
+    for (const [name, value] of Object.entries(tokens.spacing)) {
+      expect(value, `spacing.${name}`).toMatch(/^\d*\.?\d+(rem|em|px|%)$/);
+    }
+    for (const [name, value] of Object.entries(tokens.radii)) {
+      expect(value, `radii.${name}`).toMatch(/^\d*\.?\d+(rem|em|px|%)$/);
+    }
+  });
+
+  it("orders the spacing scale monotonically", () => {
+    // A scale is only a scale if it increases. Swapping two values is easy to do
+    // and impossible to see in a diff of a token file.
+    const rem = (v: string) => Number.parseFloat(v);
+    const scale = [
+      tokens.spacing.xs,
+      tokens.spacing.sm,
+      tokens.spacing.md,
+      tokens.spacing.lg,
+      tokens.spacing.xl,
+    ].map(rem);
+    for (let i = 1; i < scale.length; i++) {
+      expect(scale[i], `step ${i}`).toBeGreaterThan(scale[i - 1] as number);
+    }
+  });
+
+  it("keeps radii.full effectively unbounded", () => {
+    // The pill-shape idiom. A small number here rounds corners slightly instead
+    // of producing a pill, which reads as a design choice rather than a bug.
+    expect(Number.parseFloat(tokens.radii.full)).toBeGreaterThanOrEqual(9999);
+  });
+});
+
+describe("Component", () => {
+  it("types a props-taking function", () => {
+    // The placeholder type is what downstream packages import until a real
+    // framework lands. This asserts it still accepts the shape it advertises,
+    // so replacing it is a deliberate edit rather than a silent widening.
+    const Greeting: Component<{ name: string }> = (props) => `hello ${props.name}`;
+    expect(Greeting({ name: "world" })).toBe("hello world");
+
+    const Empty: Component = () => null;
+    expect(Empty({})).toBeNull();
+  });
+});

--- a/templates/monorepo/skeleton/packages/shared-ui/vitest.config.ts
+++ b/templates/monorepo/skeleton/packages/shared-ui/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      // Enabled here rather than behind a flag, so `npm test` is the gate. A
+      // threshold that only applies when someone remembers `--coverage` is a
+      // decoration, not a floor.
+      enabled: true,
+      provider: "v8",
+      reporter: ["text"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+      // The floor published in nanohype/standards/testing-rubric.json. This
+      // package is small enough to hold every line, so it does.
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        statements: 100,
+        branches: 100,
+      },
+    },
+  },
+});

--- a/templates/monorepo/skeleton/packages/shared-utils/package.json
+++ b/templates/monorepo/skeleton/packages/shared-utils/package.json
@@ -16,13 +16,16 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "lint": "biome lint .",
-    "test": "echo \"no tests yet\"",
+    "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo",
     "format": "biome format --write .",
-    "format:check": "biome format ."
+    "format:check": "biome format .",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
-    "typescript": "^5.8.0"
+    "@vitest/coverage-v8": "^4.1.10",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/templates/monorepo/skeleton/packages/shared-utils/src/index.test.ts
+++ b/templates/monorepo/skeleton/packages/shared-utils/src/index.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { invariant, omit, randomId, sleep } from "./index.js";
+
+// ── shared-utils ──────────────────────────────────────────────────
+//
+// Small functions that every package in the monorepo depends on, which is
+// exactly why they get a suite: a wrong `omit` or an `invariant` that never
+// throws is a defect that surfaces somewhere else entirely.
+
+describe("invariant", () => {
+  it("passes on a truthy condition", () => {
+    expect(() => invariant(1, "should not throw")).not.toThrow();
+    expect(() => invariant("text", "should not throw")).not.toThrow();
+  });
+
+  it("throws on every falsy value", () => {
+    // Enumerated rather than sampled: an implementation using `== null` or
+    // `=== false` instead of `!condition` would pass on 0 and "" and let a
+    // zero-length result through as valid.
+    for (const falsy of [false, 0, "", null, undefined, Number.NaN]) {
+      expect(() => invariant(falsy, "must be present")).toThrow(
+        "Invariant violation: must be present",
+      );
+    }
+  });
+
+  it("narrows the type for callers after the call", () => {
+    const value: string | undefined = "present";
+    invariant(value, "value is required");
+    // Reachable only if the `asserts condition` signature holds — this line
+    // would not compile if the assertion signature were dropped.
+    expect(value.length).toBe(7);
+  });
+});
+
+describe("sleep", () => {
+  it("resolves after the requested delay", async () => {
+    vi.useFakeTimers();
+    try {
+      let done = false;
+      const p = sleep(1000).then(() => {
+        done = true;
+      });
+      await vi.advanceTimersByTimeAsync(999);
+      expect(done).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await p;
+      expect(done).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resolves immediately for a zero delay", async () => {
+    await expect(sleep(0)).resolves.toBeUndefined();
+  });
+});
+
+describe("randomId", () => {
+  it("defaults to twelve characters", () => {
+    expect(randomId()).toHaveLength(12);
+  });
+
+  it("honours an explicit length, including 1", () => {
+    expect(randomId(1)).toHaveLength(1);
+    expect(randomId(32)).toHaveLength(32);
+  });
+
+  it("returns an empty string for a length of zero", () => {
+    expect(randomId(0)).toBe("");
+  });
+
+  it("emits only lowercase alphanumerics", () => {
+    // These ids end up in URLs and log lines, so the character set is part of
+    // the contract rather than an implementation detail.
+    expect(randomId(200)).toMatch(/^[a-z0-9]+$/);
+  });
+
+  it("does not return the same id twice in a row", () => {
+    // Weak by nature, but it catches the one real failure: a generator that
+    // picks an index once and reuses it for every position.
+    const ids = new Set(Array.from({ length: 50 }, () => randomId()));
+    expect(ids.size).toBeGreaterThan(45);
+  });
+});
+
+describe("omit", () => {
+  it("removes the listed keys and keeps the rest", () => {
+    expect(omit({ a: 1, b: 2, c: 3 }, ["b"])).toEqual({ a: 1, c: 3 });
+  });
+
+  it("does not mutate the input", () => {
+    // It shallow-clones then deletes, so a missing spread would quietly strip
+    // fields from the caller's object.
+    const input = { a: 1, secret: "x" };
+    omit(input, ["secret"]);
+    expect(input.secret).toBe("x");
+  });
+
+  it("ignores keys that are not present", () => {
+    const input = { a: 1 } as Record<string, unknown>;
+    expect(omit(input, ["missing"])).toEqual({ a: 1 });
+  });
+
+  it("returns an equal-but-distinct object for an empty key list", () => {
+    const input = { a: 1 };
+    const out = omit(input, []);
+    expect(out).toEqual(input);
+    expect(out).not.toBe(input);
+  });
+});

--- a/templates/monorepo/skeleton/packages/shared-utils/vitest.config.ts
+++ b/templates/monorepo/skeleton/packages/shared-utils/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      // Enabled here rather than behind a flag, so `npm test` is the gate. A
+      // threshold that only applies when someone remembers `--coverage` is a
+      // decoration, not a floor.
+      enabled: true,
+      provider: "v8",
+      reporter: ["text"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+      // The floor published in nanohype/standards/testing-rubric.json. This
+      // package is small enough to hold every line, so it does.
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        statements: 100,
+        branches: 100,
+      },
+    },
+  },
+});

--- a/templates/multimodal-pipeline/skeleton/src/__tests__/process-file.test.ts
+++ b/templates/multimodal-pipeline/skeleton/src/__tests__/process-file.test.ts
@@ -1,0 +1,161 @@
+/**
+ * End-to-end tests for the pipeline over real files, plus the mock vision
+ * provider it routes to.
+ *
+ * The sibling suites cover modality detection and the registries in isolation.
+ * What was untested is the part that composes them: `processFile` reading a
+ * file, resolving its MIME type, picking a processor, and choosing between
+ * `analyze` and `analyzeFrames`. That last choice is the one worth pinning —
+ * routing a video down the single-image path costs frames silently, and the
+ * result still looks well-formed.
+ *
+ * Real files on disk rather than mocked `fs`: the processors exist to read
+ * bytes, and mocking that away would leave nothing under test.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { loadConfig } from "../config.js";
+import { processFile } from "../pipeline.js";
+import "../processors/index.js";
+import "../providers/index.js";
+import { getProcessorByMimeType } from "../processors/registry.js";
+import { getProvider } from "../providers/registry.js";
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"></svg>';
+
+/**
+ * A 1x1 opaque PNG, inlined.
+ *
+ * Small enough to read at a glance and to stay well under any configured
+ * maximum dimension, so the raster path runs without the test having to
+ * generate an image. Generating one would pull an image-processing library into
+ * the test just to produce bytes the processor is going to re-read anyway.
+ */
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+let dir: string;
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), "multimodal-"));
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/**
+ * Config pointed at the mock provider.
+ *
+ * The skeleton's default is the unrendered `__LLM_PROVIDER__` placeholder, which
+ * a scaffolded project replaces — so a test must name a provider explicitly
+ * rather than rely on the default, and `mock` is the one that needs no API key.
+ */
+function config() {
+  process.env.LLM_PROVIDER = "mock";
+  return loadConfig();
+}
+
+describe("processFile", () => {
+  it("runs an image end to end and reports usage from the provider", async () => {
+    const png = join(dir, "small.png");
+    await writeFile(png, PNG_1X1);
+
+    const result = await processFile(png, config());
+
+    expect(result.source).toBe(png);
+    expect(result.modality).toBe("image");
+    expect(result.mimeType).toBe("image/png");
+    expect(result.usage.total_tokens).toBeGreaterThan(0);
+    expect(result.model).toBeTruthy();
+  });
+
+  it("handles an SVG, which bypasses raster processing entirely", async () => {
+    // The `mimeType !== "image/svg+xml"` guard means sharp is never invoked
+    // here. Without this case that branch is only ever taken one way, and
+    // handing an SVG to sharp is the kind of thing that throws in production
+    // on the one file type nobody tested.
+    const svg = join(dir, "icon.svg");
+    await writeFile(svg, SVG);
+
+    const result = await processFile(svg, config());
+    expect(result.modality).toBe("image");
+    expect(result.mimeType).toBe("image/svg+xml");
+  });
+
+  it("rejects a path that does not exist", async () => {
+    // `stat` first, so the failure names the missing file rather than
+    // surfacing later as an unreadable-buffer error from a processor.
+    await expect(processFile(join(dir, "nope.png"), config())).rejects.toThrow();
+  });
+
+  it("rejects a file type no processor claims", async () => {
+    const bin = join(dir, "notes.txt");
+    await writeFile(bin, "plain text");
+    await expect(processFile(bin, config())).rejects.toThrow();
+  });
+});
+
+describe("image processor", () => {
+  it("leaves an image within the maximum untouched", async () => {
+    const small = join(dir, "within.png");
+    await writeFile(small, PNG_1X1);
+
+    const out = await getProcessorByMimeType("image/png").process(small, "image/png");
+    expect(out.metadata?.width).toBe(1);
+    // Under the maximum, so the resize branch is skipped and the bytes pass
+    // through untouched.
+    expect(out.metadata?.processedSize).toBe(out.metadata?.originalSize);
+    expect(out.base64?.length ?? 0).toBeGreaterThan(0);
+  });
+});
+
+describe("mock vision provider", () => {
+  const p = getProvider("mock");
+
+  it("returns a modality-appropriate analysis for each input kind", async () => {
+    const call = (modality: "image" | "audio" | "video") =>
+      p.analyze(
+        { modality, mimeType: "x/y", source: "s", base64: "", metadata: {} },
+        "system",
+        "model",
+        0,
+        100,
+      );
+
+    const [image, audio, video] = await Promise.all([call("image"), call("audio"), call("video")]);
+
+    // Three distinct payloads. A double that returned one shape for everything
+    // would let a modality-routing bug pass every test that used it.
+    const contents = [image.content, audio.content, video.content];
+    expect(new Set(contents).size).toBe(3);
+    for (const r of [image, audio, video]) {
+      expect(() => JSON.parse(r.content)).not.toThrow();
+      expect(r.usage.total_tokens).toBe(r.usage.input_tokens + r.usage.output_tokens);
+    }
+  });
+
+  it("scales frame analysis with the number of frames given", async () => {
+    const two = await p.analyzeFrames(["a", "b"], "system", "model", 0, 100);
+    const six = await p.analyzeFrames(["a", "b", "c", "d", "e", "f"], "system", "model", 0, 100);
+
+    expect(JSON.parse(two.content).frames_analyzed).toBe(2);
+    expect(JSON.parse(six.content).frames_analyzed).toBe(6);
+    // Token cost has to move with frame count, or a cost estimate built on
+    // this double is meaningless for the one modality that is expensive.
+    expect(six.usage.input_tokens).toBeGreaterThan(two.usage.input_tokens);
+  });
+
+  it("does not mutate its shared fixture between calls", async () => {
+    // The provider spreads module-level constants. A missed spread would make
+    // the second call inherit the first call's frame count.
+    await p.analyzeFrames(["a", "b", "c"], "system", "model", 0, 100);
+    const after = await p.analyzeFrames(["a"], "system", "model", 0, 100);
+    expect(JSON.parse(after.content).frames_analyzed).toBe(1);
+  });
+});

--- a/templates/multimodal-pipeline/skeleton/vitest.config.ts
+++ b/templates/multimodal-pipeline/skeleton/vitest.config.ts
@@ -24,14 +24,15 @@ export default defineConfig({
         "src/**/index.ts",
         "src/**/types.ts",
       ],
-      // Below the floor published in nanohype/standards/testing-rubric.json
-      // (lines/functions/statements 75, branches 60). These are the measured
-      // values, now actually enforced: closing the gap needs tests for the
-      // scaffolding this skeleton ships, not a higher number here.
+      // Above the floor published in nanohype/standards/testing-rubric.json
+      // (lines/functions/statements 75, branches 60). The remaining gap is the
+      // video path: `analyzeFrames` needs a real video and an ffmpeg binary, so
+      // it is exercised against the mock provider directly rather than through
+      // `processFile`. It is not excluded — it counts against these numbers.
       thresholds: {
-        lines: 52,
-        functions: 70,
-        statements: 52,
+        lines: 79,
+        functions: 90,
+        statements: 79,
         branches: 81,
       },
     },


### PR DESCRIPTION
The gate that made these floors *bind* landed earlier; the numbers it enforced were the measured ones. This raises them to the floor in `standards/testing-rubric.json` (lines/functions/statements 75, branches 60) by covering the scaffolding each skeleton ships — the stated remaining work.

| skeleton | before | after |
|---|---|---|
| ci-eval | 58.73 / 94.23 / 73.33 / 58.73 | 100 / 94 / 100 / 100 |
| multimodal-pipeline | 57.55 / 86.27 / 75.00 / 57.55 | 80 / 83 / 92 / 80 |
| eval-harness | 76.35 / 82.05 / 74.07 / 76.35 | 97 / 88 / 96 / 97 |
| module-queue-ts | 77.51 / 92.10 / 68.75 / 77.51 | 96 / 94 / 88 / 96 |
| module-webhook-ts | 91.11 / 81.08 / 66.66 / 91.11 | 98 / 83 / 100 / 98 |
| monorepo | *no runner at all* | 100 / 100 / 100 / 100 |

## Two real defects, found by writing the tests

**`eval-harness`'s `semanticSimilarity` scored everything zero — identical text included.** IDF was `log(N / df)` with N = 2, so a term in *both* documents got `log(2/2)` = 0 weight, and shared terms are the entire similarity signal. Identical strings produced two all-zero vectors, magnitude 0, similarity 0. **The assertion could not pass for any input.** Now smoothed (`log((1+N)/(1+df)) + 1`). The regression test is the partial-overlap case — a score that is neither 0 nor 1 is what proves the weighting survived.

**`ci-eval`'s suite-name fallback was unreachable.** `runSuite` defaults the suite name to the file basename, but the Zod schema required `name`, so a nameless suite was rejected before the default applied. The schema now matches what the code documented.

## What the tests cover

Each is aimed at the failure that would otherwise be silent, and asserts the wrong behaviour is *not* what ships — an evaluator stuck on `true`, a verifier that accepts anything, and a similarity function returning a constant all look identical from the passing case alone.

- **ci-eval** — every assertion type on both outcomes; an unknown type failing the case rather than crashing the run; the runner's scoring, per-case error path (a provider throw must not lose the remaining cases), and its hand-rolled concurrency gate.
- **eval-harness** — the JSON-schema translator incl. required-vs-optional, the async predicate, similarity, and the registry YAML suites reach them through.
- **module-queue-ts** — option defaults, where `??` vs `||` is the whole question: with `||`, an explicit `maxRetries: 0` becomes 3.
- **module-webhook-ts** — the two signature providers that had none, each on a good signature, a tampered payload, and a wrong secret; plus the length guard, without which `timingSafeEqual` throws on a truncated signature instead of rejecting it.
- **multimodal-pipeline** — `processFile` end to end over real files, incl. the SVG path that bypasses raster processing. A 1×1 PNG is inlined rather than generated, so no image library is pulled into a test just to make bytes the processor re-reads.
- **monorepo** — both packages declared `test: echo "no tests yet"`, so the workspace test task passed over nothing while exiting 0. Both now run vitest with the floor enforced from `npm test`, not behind a `--coverage` flag.

Mutation-checked where the assertion had to be trusted: reverting `invariant` to never throw, and making `omit` mutate its input, each fail exactly the case written for them.

## Verification

Per skeleton: `npm test`, `tsc --noEmit`, `lint`, `format:check` all exit 0. Catalog: `lint`, `validate:catalog`, `validate:skeleton-toolchain`, `lint:skeletons`, `verify:library` all exit 0.