### PR TITLE
Point the documented CLI at the package that publishes it

### DIFF
--- a/docs/composites-guide.md
+++ b/docs/composites-guide.md
@@ -2,7 +2,7 @@
 
 ## What are composites?
 
-A composite scaffolds multiple templates into one integrated project. Instead of running `npx nanohype scaffold` five times and wiring things together by hand, a composite does it in a single command -- it picks the right templates, nests them into a monorepo (or flat structure), flows shared variables to each one, and respects conditional flags so you only get the pieces you asked for.
+A composite scaffolds multiple templates into one integrated project. Instead of running `npx @nanohype/sdk scaffold` five times and wiring things together by hand, a composite does it in a single command -- it picks the right templates, nests them into a monorepo (or flat structure), flows shared variables to each one, and respects conditional flags so you only get the pieces you asked for.
 
 Individual templates are building blocks. Composites are the blueprints that assemble them into real project architectures.
 
@@ -42,7 +42,7 @@ Individual templates are building blocks. Composites are the blueprints that ass
 ## How to scaffold a composite
 
 ```bash
-npx nanohype scaffold --composite ai-chatbot --var ProjectName=my-bot
+npx @nanohype/sdk scaffold --composite ai-chatbot --var ProjectName=my-bot
 ```
 
 The scaffolder reads the composite YAML, collects composite-level variables once, then distributes them to each template entry. Entry-level overrides can transform variable values -- for example, the `ai-chatbot` composite takes `ProjectName=my-bot` and passes `my-bot-api` to the API service and `my-bot-ai` to the agentic loop.
@@ -50,13 +50,13 @@ The scaffolder reads the composite YAML, collects composite-level variables once
 To see all available composites before scaffolding:
 
 ```bash
-npx nanohype list --composites
+npx @nanohype/sdk list --composites
 ```
 
 Conditional entries are controlled by boolean variables. For example, `production-api` has `IncludeQueue` (default `true`) and `IncludeCache` (default `true`). To skip the queue:
 
 ```bash
-npx nanohype scaffold --composite production-api \
+npx @nanohype/sdk scaffold --composite production-api \
   --var ProjectName=my-api \
   --var IncludeQueue=false
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,13 +33,13 @@ Browse the [full catalog](catalog.md) for decision matrices by client problem, e
 ## Scaffold a template
 
 ```bash
-npx nanohype scaffold <template> --var ProjectName=my-project
+npx @nanohype/sdk scaffold <template> --var ProjectName=my-project
 ```
 
 For example, to scaffold an autonomous AI agent:
 
 ```bash
-npx nanohype scaffold agentic-loop --var ProjectName=my-agent
+npx @nanohype/sdk scaffold agentic-loop --var ProjectName=my-agent
 cd my-agent
 npm install   # or pnpm install — check package.json for the project's package manager
 npm run dev
@@ -50,7 +50,7 @@ Every template declares its variables in `template.yaml`. Pass them with `--var 
 To browse all available templates:
 
 ```bash
-npx nanohype list
+npx @nanohype/sdk list
 ```
 
 ---
@@ -60,7 +60,7 @@ npx nanohype list
 Composites combine multiple templates into a single project. They handle nesting, variable flow, and conditional inclusion.
 
 ```bash
-npx nanohype scaffold --composite ai-chatbot --var ProjectName=my-bot
+npx @nanohype/sdk scaffold --composite ai-chatbot --var ProjectName=my-bot
 ```
 
 This scaffolds the `ai-chatbot` composite, which assembles an `agentic-loop`, `ts-service`, `module-auth-ts`, `module-database-ts`, and `infra-fly` into a ready-to-run stack.
@@ -79,7 +79,7 @@ Available composites:
 | `ai-platform`           | Service + gateway + vectors + auth + billing + monitoring                 |
 | `agent-team`            | Orchestrator + specialized agents + MCP tools + evals                     |
 
-See the full list in `composites/` or run `npx nanohype list --composites`.
+See the full list in `composites/` or run `npx @nanohype/sdk list --composites`.
 
 ---
 


### PR DESCRIPTION
The docs told people to run `npx nanohype`. That name is unclaimed on npm — `npm view nanohype` is a 404 — so the command fails today, and the failure mode gets *worse* rather than better: `npx` on an unclaimed name is a standing invitation for someone else to publish it and have every reader execute their code.

The CLI ships as the `nanohype` bin of `@nanohype/sdk`, so `npx @nanohype/sdk` is the invocation that exists. Verified against the published 0.2.0:

```
$ npx --yes @nanohype/sdk@0.2.0 list
NAME                        DISPLAY                                       TAGS
a2a-agent                   A2A Agent                                     typescript, agent, a2a, ...
```

Nine call sites across `quick-start.md` and `composites-guide.md`.
