### PR TITLE
Bring the nanohype CLI into the repo

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,61 @@
+name: CLI
+
+on:
+  push:
+    branches: [main]
+    paths: ['cli/**']
+  pull_request:
+    paths: ['cli/**']
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test cli
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      # The package is a wrapper whose entire job is reaching the SDK's bin, and
+      # every check above passes on a wrapper that resolves to nothing: the unit
+      # tests exercise the path arithmetic against strings, not a real tree.
+      # Running the built binary against the installed SDK is what proves the
+      # two agree — a subcommand that works and one that does not, so a wrapper
+      # swallowing the exit code fails here too.
+      - name: The built binary reaches the SDK
+        run: |
+          set -euo pipefail
+          node dist/bin/nanohype.js list > /dev/null
+          if node dist/bin/nanohype.js definitely-not-a-command > /dev/null 2>&1; then
+            echo "::error::a bad subcommand exited 0 — the wrapper is swallowing the child's exit code"
+            exit 1
+          fi
+          echo "the CLI resolves the SDK and propagates its exit codes"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,14 @@ on:
       - 'sdk-v*'
       - 'mcp-v*'
       - 'tokens-v*'
+      - 'cli-v*'
   workflow_dispatch:
     inputs:
       package:
         description: Which package to publish
         required: true
         type: choice
-        options: [sdk, mcp, tokens]
+        options: [sdk, mcp, tokens, cli]
 
 permissions:
   contents: read
@@ -56,9 +57,9 @@ jobs:
           cache: 'npm'
 
       # sdk-v* → sdk (@nanohype/sdk); mcp-v* → mcp-server (@nanohype/mcp);
-      # tokens-v* → tokens (@nanohype/tokens). The tag key, the directory and
-      # the package name all differ, so the mapping is resolved here rather
-      # than assumed downstream.
+      # tokens-v* → tokens (@nanohype/tokens); cli-v* → cli (nanohype — the
+      # unscoped one). The tag key, the directory and the package name all
+      # differ, so the mapping is resolved here rather than assumed downstream.
       - name: Resolve the target
         id: target
         run: |
@@ -74,7 +75,8 @@ jobs:
             sdk) dir=sdk ;;
             mcp) dir=mcp-server ;;
             tokens) dir=tokens ;;
-            *) echo "::error::unrecognised release key '$key' (expected sdk, mcp or tokens)"; exit 1 ;;
+            cli) dir=cli ;;
+            *) echo "::error::unrecognised release key '$key' (expected sdk, mcp, tokens or cli)"; exit 1 ;;
           esac
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
           echo "tag_version=$tag_version" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,15 @@ coverage/
 # runners). The blanket bin/ rule above targets compiled build output, so
 # re-include template sources explicitly.
 !templates/**/bin/
+
+# Same problem, one level up: `bin/` is unanchored, so it also swallowed the
+# packages' own CLI entry points under src/. sdk/src/bin/nanohype.ts sat
+# untracked for months while the published @nanohype/sdk shipped it — the
+# tarball carried 12kB of source that existed in no repository, and a CI
+# rebuild would have produced a package with no CLI in it.
+#
+# src/ is source by definition; only dist/bin is build output.
+!**/src/bin/
 !templates/**/bin/**
 
 # Environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,27 @@ same directory, against the same config a consumer gets.
 - LF line endings everywhere
 - No trailing whitespace (except Markdown for line breaks)
 
+## CLI
+
+`cli/` contains `nanohype` — the unscoped package, and the one `npx nanohype`
+resolves to. It holds no scaffolding logic: it locates the `nanohype` bin
+inside `@nanohype/sdk` and runs it as a child process, so argv, exit codes and
+signals belong to the SDK.
+
+It exists because npm's unscoped namespace is separate from the `@nanohype`
+scope — owning the scope does not reserve the bare name, and `npx nanohype` is
+what people reach for. A name left unclaimed there is a name someone else can
+publish under.
+
+The path arithmetic lives in `src/resolve.ts` rather than in the entry point,
+because that is the part which breaks silently if the SDK moves its bin — the
+SDK's `exports` map declares only `"."`, so the bin is reached as a filesystem
+path rather than a subpath import. `cli.yml` runs the built binary against the
+installed SDK, since every other check passes on a wrapper that resolves to
+nothing.
+
+Released on a `cli-v*` tag through the shared `release.yml`.
+
 ## SDK
 
 `sdk/` contains `@nanohype/sdk` — the reference implementation of the template rendering contract. It's a standalone TypeScript package with no dependencies on any consumer.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,36 @@
+# nanohype
+
+The CLI for the [nanohype](https://github.com/nanohype/nanohype) template
+catalog — scaffold a template or a composite into a new project.
+
+```sh
+npx nanohype list
+npx nanohype scaffold agentic-loop --var ProjectName=my-agent
+npx nanohype scaffold --composite ai-chatbot --var ProjectName=my-bot
+```
+
+## What this package is
+
+A thin entry point. The CLI, the rendering contract and the catalog loaders all
+live in [`@nanohype/sdk`](https://www.npmjs.com/package/@nanohype/sdk), which
+this package depends on and delegates to.
+
+It exists because npm's unscoped namespace is separate from the `@nanohype`
+scope: owning the scope does not reserve the bare name, and `npx nanohype` is
+what people reach for. Running the SDK directly works identically:
+
+```sh
+npx @nanohype/sdk list
+```
+
+## What nanohype is
+
+A public, tool-agnostic template catalog for AI-focused projects, plus the
+platform contracts a factory needs to ship them: templates, composites, the
+published standards, and the Platform Reference.
+
+Full documentation at [github.com/nanohype/nanohype](https://github.com/nanohype/nanohype).
+
+## License
+
+Apache-2.0

--- a/cli/__tests__/resolve.test.ts
+++ b/cli/__tests__/resolve.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { missingSdkMessage, resolveSdkCli } from "../src/resolve.js";
+
+describe("resolveSdkCli", () => {
+  it("derives the bin path from the SDK's resolved entry", () => {
+    // The shape npm produces for a normal install. Written out rather than
+    // taken from a live resolve, so this fails if the SDK moves its bin —
+    // which is the change that would break `npx nanohype` and nothing else.
+    const resolved = resolveSdkCli(() => "/app/node_modules/@nanohype/sdk/dist/index.js");
+    expect(resolved).toBe("/app/node_modules/@nanohype/sdk/dist/bin/nanohype.js");
+  });
+
+  it("follows the entry wherever it resolves, including a hoisted or linked tree", () => {
+    // pnpm stores, npm workspaces and `npm link` all put the package somewhere
+    // other than a flat node_modules. The bin is located relative to the entry
+    // for exactly this reason, so the layout is not assumed.
+    expect(
+      resolveSdkCli(() => "/w/.pnpm/@nanohype+sdk@0.2.0/node_modules/@nanohype/sdk/dist/index.js"),
+    ).toBe("/w/.pnpm/@nanohype+sdk@0.2.0/node_modules/@nanohype/sdk/dist/bin/nanohype.js");
+  });
+
+  it("propagates a resolution failure rather than returning a bad path", () => {
+    // A wrong path would surface later as a confusing "cannot find module" from
+    // node, naming a file the user never asked for. Failing here is what lets
+    // the entry point print an instruction instead.
+    expect(() =>
+      resolveSdkCli(() => {
+        throw new Error("Cannot find module '@nanohype/sdk'");
+      }),
+    ).toThrow(/Cannot find module/);
+  });
+});
+
+describe("missingSdkMessage", () => {
+  it("names the cause and both ways out", () => {
+    const msg = missingSdkMessage(new Error("Cannot find module '@nanohype/sdk'"));
+    expect(msg).toContain("@nanohype/sdk");
+    expect(msg).toContain("npx @nanohype/sdk");
+    expect(msg).toContain("Cannot find module");
+  });
+
+  it("renders a thrown object as JSON, not [object Object]", () => {
+    // require.resolve throws Errors, but this is the failure path and nothing
+    // on it is guaranteed. "[object Object]" is worse than useless at the
+    // moment someone most needs the detail.
+    const msg = missingSdkMessage({ code: "MODULE_NOT_FOUND" });
+    expect(msg).toContain('{"code":"MODULE_NOT_FOUND"}');
+    expect(msg).not.toContain("[object Object]");
+  });
+
+  it("survives a value JSON cannot represent", () => {
+    // A cyclic object would make JSON.stringify throw, replacing the real
+    // failure with a second one raised while reporting the first.
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => missingSdkMessage(cyclic)).not.toThrow();
+    expect(missingSdkMessage(cyclic)).toContain("[object Object]");
+  });
+
+  it("renders a thrown primitive as itself", () => {
+    expect(missingSdkMessage("plain string")).toContain("plain string");
+  });
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,1556 @@
+{
+  "name": "nanohype",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nanohype",
+      "version": "0.1.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nanohype/sdk": "^0.2.0"
+      },
+      "bin": {
+        "nanohype": "dist/bin/nanohype.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.5.6",
+        "@types/node": "^25.8.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
+      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.6",
+        "@biomejs/cli-darwin-x64": "2.5.6",
+        "@biomejs/cli-linux-arm64": "2.5.6",
+        "@biomejs/cli-linux-arm64-musl": "2.5.6",
+        "@biomejs/cli-linux-x64": "2.5.6",
+        "@biomejs/cli-linux-x64-musl": "2.5.6",
+        "@biomejs/cli-win32-arm64": "2.5.6",
+        "@biomejs/cli-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
+      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
+      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nanohype/sdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@nanohype/sdk/-/sdk-0.2.0.tgz",
+      "integrity": "sha512-dTuDdLhq/5xbWG1cduhVI4fok7FaAnggTUUF7lgDBznYF64RJZheizg1+zyx004BfcZBrXOhToDCVxrwWFOz7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "js-yaml": "^5.2.1"
+      },
+      "bin": {
+        "nanohype": "dist/bin/nanohype.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "nanohype",
+  "version": "0.1.1",
+  "description": "The nanohype CLI — scaffold templates and composites from the nanohype catalog. Thin entry point over @nanohype/sdk.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "nanohype": "dist/bin/nanohype.js"
+  },
+  "files": [
+    "dist",
+    "src",
+    "tsconfig.json"
+  ],
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome check --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@nanohype/sdk": "^0.2.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.6",
+    "@types/node": "^25.8.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nanohype/nanohype.git",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/nanohype/nanohype/tree/main/cli#readme",
+  "bugs": {
+    "url": "https://github.com/nanohype/nanohype/issues"
+  },
+  "keywords": [
+    "nanohype",
+    "cli",
+    "scaffolding",
+    "templates",
+    "ai",
+    "agents",
+    "kubernetes"
+  ]
+}

--- a/cli/src/bin/nanohype.ts
+++ b/cli/src/bin/nanohype.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * `nanohype` — the unscoped entry point for the nanohype CLI.
+ *
+ * The command itself lives in @nanohype/sdk. This package exists so
+ * `npx nanohype` reaches it: npm's unscoped namespace is separate from the
+ * @nanohype scope, and a name left unclaimed there is a name someone else can
+ * publish under.
+ *
+ * Runs the SDK's bin as a child process rather than importing it, so its argv,
+ * exit code and signals are its own and this wrapper stays invisible.
+ */
+
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { missingSdkMessage, resolveSdkCli } from "../resolve.js";
+
+const require = createRequire(import.meta.url);
+
+let cli: string;
+try {
+  cli = resolveSdkCli(require.resolve);
+} catch (err) {
+  console.error(missingSdkMessage(err));
+  process.exit(1);
+}
+
+const child = spawn(process.execPath, [cli, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+child.on("error", (err) => {
+  console.error(`nanohype: failed to start the CLI: ${err.message}`);
+  process.exit(1);
+});
+
+// Re-raise the child's signal rather than translating it into an exit code, so
+// a caller that killed the pipeline sees the death it asked for.
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/cli/src/resolve.ts
+++ b/cli/src/resolve.ts
@@ -1,0 +1,62 @@
+/**
+ * Locating the CLI inside @nanohype/sdk.
+ *
+ * The SDK publishes the actual command as its `nanohype` bin, and its `exports`
+ * map declares only `"."` — so the bin is not reachable as a subpath import.
+ * Resolving the package's own entry and walking to the bin beside it uses a
+ * filesystem path, which `exports` does not gate.
+ *
+ * Split out from the entry point so the path arithmetic is testable without
+ * spawning anything: that arithmetic is the whole of what can silently break
+ * when the SDK changes its layout.
+ */
+
+import { dirname, join } from "node:path";
+
+/** Resolves a module specifier to a file path — `require.resolve` in practice. */
+export type Resolver = (specifier: string) => string;
+
+/**
+ * The SDK's bin, derived from wherever its entry point resolved to.
+ *
+ * `.../@nanohype/sdk/dist/index.js` → `.../@nanohype/sdk/dist/bin/nanohype.js`
+ */
+export function resolveSdkCli(resolve: Resolver): string {
+  return join(dirname(resolve("@nanohype/sdk")), "bin", "nanohype.js");
+}
+
+/**
+ * What to tell someone whose install is missing the SDK. Named rather than
+ * inlined so the entry point stays about process control, and so the message
+ * itself can be asserted — an install-repair instruction that goes stale is
+ * worse than none.
+ */
+export function missingSdkMessage(err: unknown): string {
+  const detail = describeThrown(err);
+  return [
+    "nanohype: could not locate @nanohype/sdk, which provides the CLI.",
+    "Reinstall this package, or run the SDK directly with `npx @nanohype/sdk`.",
+    `Underlying error: ${detail}`,
+  ].join("\n");
+}
+
+/**
+ * Render a thrown value for a human.
+ *
+ * `require.resolve` throws Errors, but this is the failure path and nothing on
+ * it is guaranteed. `String(value)` on a plain object yields "[object Object]",
+ * which is worse than useless at the moment someone most needs the detail — so
+ * objects go through JSON, and anything JSON cannot represent (a cycle, a
+ * BigInt) falls back rather than throwing a second error over the first.
+ */
+function describeThrown(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "object" && err !== null) {
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return Object.prototype.toString.call(err);
+    }
+  }
+  return String(err);
+}

--- a/cli/tsconfig.build.json
+++ b/cli/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "__tests__"]
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    // Unlike the sibling packages, node types are needed by src/ too: the entry
+    // point is a CLI that spawns a child process and reads process.argv.
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src", "__tests__"],
+  "exclude": ["dist"]
+}

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text"],
+      include: ["src/**/*.ts"],
+      // src/bin/nanohype.ts is the entry point: it spawns a child process and
+      // calls process.exit at module load, so importing it under the runner
+      // would kill the run. Its logic lives in src/resolve.ts, which is
+      // covered here; what remains in the entry is process control, exercised
+      // by actually running the binary rather than by importing it.
+      exclude: ["src/bin/**"],
+      thresholds: { lines: 100, functions: 100, branches: 100, statements: 100 },
+    },
+  },
+});

--- a/docs/composites-guide.md
+++ b/docs/composites-guide.md
@@ -2,7 +2,7 @@
 
 ## What are composites?
 
-A composite scaffolds multiple templates into one integrated project. Instead of running `npx @nanohype/sdk scaffold` five times and wiring things together by hand, a composite does it in a single command -- it picks the right templates, nests them into a monorepo (or flat structure), flows shared variables to each one, and respects conditional flags so you only get the pieces you asked for.
+A composite scaffolds multiple templates into one integrated project. Instead of running `npx nanohype scaffold` five times and wiring things together by hand, a composite does it in a single command -- it picks the right templates, nests them into a monorepo (or flat structure), flows shared variables to each one, and respects conditional flags so you only get the pieces you asked for.
 
 Individual templates are building blocks. Composites are the blueprints that assemble them into real project architectures.
 
@@ -42,7 +42,7 @@ Individual templates are building blocks. Composites are the blueprints that ass
 ## How to scaffold a composite
 
 ```bash
-npx @nanohype/sdk scaffold --composite ai-chatbot --var ProjectName=my-bot
+npx nanohype scaffold --composite ai-chatbot --var ProjectName=my-bot
 ```
 
 The scaffolder reads the composite YAML, collects composite-level variables once, then distributes them to each template entry. Entry-level overrides can transform variable values -- for example, the `ai-chatbot` composite takes `ProjectName=my-bot` and passes `my-bot-api` to the API service and `my-bot-ai` to the agentic loop.
@@ -50,13 +50,13 @@ The scaffolder reads the composite YAML, collects composite-level variables once
 To see all available composites before scaffolding:
 
 ```bash
-npx @nanohype/sdk list --composites
+npx nanohype list --composites
 ```
 
 Conditional entries are controlled by boolean variables. For example, `production-api` has `IncludeQueue` (default `true`) and `IncludeCache` (default `true`). To skip the queue:
 
 ```bash
-npx @nanohype/sdk scaffold --composite production-api \
+npx nanohype scaffold --composite production-api \
   --var ProjectName=my-api \
   --var IncludeQueue=false
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,13 +33,13 @@ Browse the [full catalog](catalog.md) for decision matrices by client problem, e
 ## Scaffold a template
 
 ```bash
-npx @nanohype/sdk scaffold <template> --var ProjectName=my-project
+npx nanohype scaffold <template> --var ProjectName=my-project
 ```
 
 For example, to scaffold an autonomous AI agent:
 
 ```bash
-npx @nanohype/sdk scaffold agentic-loop --var ProjectName=my-agent
+npx nanohype scaffold agentic-loop --var ProjectName=my-agent
 cd my-agent
 npm install   # or pnpm install — check package.json for the project's package manager
 npm run dev
@@ -50,7 +50,7 @@ Every template declares its variables in `template.yaml`. Pass them with `--var 
 To browse all available templates:
 
 ```bash
-npx @nanohype/sdk list
+npx nanohype list
 ```
 
 ---
@@ -60,7 +60,7 @@ npx @nanohype/sdk list
 Composites combine multiple templates into a single project. They handle nesting, variable flow, and conditional inclusion.
 
 ```bash
-npx @nanohype/sdk scaffold --composite ai-chatbot --var ProjectName=my-bot
+npx nanohype scaffold --composite ai-chatbot --var ProjectName=my-bot
 ```
 
 This scaffolds the `ai-chatbot` composite, which assembles an `agentic-loop`, `ts-service`, `module-auth-ts`, `module-database-ts`, and `infra-fly` into a ready-to-run stack.
@@ -79,7 +79,7 @@ Available composites:
 | `ai-platform`           | Service + gateway + vectors + auth + billing + monitoring                 |
 | `agent-team`            | Orchestrator + specialized agents + MCP tools + evals                     |
 
-See the full list in `composites/` or run `npx @nanohype/sdk list --composites`.
+See the full list in `composites/` or run `npx nanohype list --composites`.
 
 ---
 

--- a/sdk/src/bin/nanohype.ts
+++ b/sdk/src/bin/nanohype.ts
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve, dirname } from 'node:path';
+import { createInterface } from 'node:readline';
+import * as yaml from 'js-yaml';
+
+import { LocalSource } from '../sources/local.js';
+import { GitHubSource } from '../sources/github.js';
+import { renderTemplate } from '../renderer.js';
+import { renderComposite } from '../composite.js';
+import { validateManifest, validateCompositeManifest } from '../validator.js';
+import type { CatalogSource } from '../source.js';
+import type { TemplateManifest, CompositeManifest } from '../types.js';
+
+// ── Arg parsing ──────────────────────────────────────────────────────
+
+interface ParsedArgs {
+  command: string;
+  positional: string;
+  vars: Record<string, string>;
+  output?: string;
+  local?: string;
+  token?: string;
+  composite: boolean;
+  composites: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  const result: ParsedArgs = {
+    command: '',
+    positional: '',
+    vars: {},
+    composite: false,
+    composites: false,
+    help: false,
+  };
+
+  let i = 0;
+  // First non-flag arg is the command
+  while (i < args.length && args[i].startsWith('-')) {
+    if (args[i] === '--help' || args[i] === '-h') {
+      result.help = true;
+      i++;
+      continue;
+    }
+    if (args[i] === '--composite') {
+      result.composite = true;
+      i++;
+      continue;
+    }
+    if (args[i] === '--composites') {
+      result.composites = true;
+      i++;
+      continue;
+    }
+    if (args[i] === '--var') {
+      if (i + 1 >= args.length) {
+        console.error('Error: --var requires a Key=value argument');
+        process.exit(1);
+      }
+      parseVar(result.vars, args[++i]);
+      i++;
+      continue;
+    }
+    if ((args[i] === '--output' || args[i] === '-o') && i + 1 < args.length) {
+      result.output = args[++i];
+      i++;
+      continue;
+    }
+    if (args[i] === '--local' && i + 1 < args.length) {
+      result.local = args[++i];
+      i++;
+      continue;
+    }
+    if (args[i] === '--token' && i + 1 < args.length) {
+      result.token = args[++i];
+      i++;
+      continue;
+    }
+    i++;
+  }
+
+  if (i < args.length) result.command = args[i++];
+  // Remaining args: positional and flags interleaved
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+      i++;
+      continue;
+    }
+    if (arg === '--composite') {
+      result.composite = true;
+      i++;
+      continue;
+    }
+    if (arg === '--composites') {
+      result.composites = true;
+      i++;
+      continue;
+    }
+    if (arg === '--var') {
+      if (i + 1 >= args.length) {
+        console.error('Error: --var requires a Key=value argument');
+        process.exit(1);
+      }
+      parseVar(result.vars, args[++i]);
+      i++;
+      continue;
+    }
+    if ((arg === '--output' || arg === '-o') && i + 1 < args.length) {
+      result.output = args[++i];
+      i++;
+      continue;
+    }
+    if (arg === '--local' && i + 1 < args.length) {
+      result.local = args[++i];
+      i++;
+      continue;
+    }
+    if (arg === '--token' && i + 1 < args.length) {
+      result.token = args[++i];
+      i++;
+      continue;
+    }
+    if (!result.positional) result.positional = arg;
+    i++;
+  }
+
+  return result;
+}
+
+function parseVar(vars: Record<string, string>, raw: string): void {
+  const eq = raw.indexOf('=');
+  if (eq === -1) {
+    console.error(`Invalid --var format: ${raw} (expected Key=value)`);
+    process.exit(1);
+  }
+  vars[raw.slice(0, eq)] = raw.slice(eq + 1);
+}
+
+// ── Source resolution ────────────────────────────────────────────────
+
+function resolveSource(args: ParsedArgs): CatalogSource {
+  if (args.local) {
+    return new LocalSource({ rootDir: resolve(args.local) });
+  }
+  const token = args.token || process.env.GITHUB_TOKEN;
+  return new GitHubSource({ token });
+}
+
+// ── Interactive prompt ───────────────────────────────────────────────
+
+function prompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((res) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      res(answer.trim());
+    });
+  });
+}
+
+// ── Commands ─────────────────────────────────────────────────────────
+
+async function scaffold(args: ParsedArgs): Promise<void> {
+  const name = args.positional;
+  if (!name) {
+    console.error('Usage: nanohype scaffold <name> [--composite] [--var K=V] [-o dir]');
+    process.exit(1);
+  }
+
+  const source = resolveSource(args);
+  const isInteractive = process.stdin.isTTY ?? false;
+
+  if (args.composite) {
+    // Composite scaffold
+    const manifest = await source.fetchComposite(name);
+    const values: Record<string, string | boolean | number> = { ...args.vars };
+
+    // Prompt for missing required variables
+    for (const v of manifest.variables) {
+      if (v.name in values) continue;
+      if (v.default !== undefined) continue;
+      if (!v.required) continue;
+      if (isInteractive) {
+        const answer = await prompt(`${v.prompt || v.name} (${v.description}): `);
+        values[v.name] =
+          v.type === 'bool' ? answer === 'true' : v.type === 'int' ? parseInt(answer, 10) : answer;
+      } else {
+        console.error(`Missing required variable: ${v.name}`);
+        process.exit(1);
+      }
+    }
+
+    const result = await renderComposite(manifest, values, source);
+    const outDir = resolve(args.output || `./${name}`);
+
+    for (const file of result.files) {
+      const dest = join(outDir, file.path);
+      await mkdir(dirname(dest), { recursive: true });
+      await writeFile(dest, file.content, 'utf-8');
+    }
+
+    console.log(`${result.files.length} files written to ${outDir}`);
+    if (result.entries.length > 0) {
+      console.log(
+        `Composed ${result.entries.length} templates: ${result.entries.map((e) => e.template).join(', ')}`,
+      );
+    }
+    for (const w of result.warnings) console.log(`  warn: ${w}`);
+    for (const h of result.hooks.post) console.log(`  Run post-scaffold hook: ${h.run}`);
+  } else {
+    // Single template scaffold
+    const { manifest, files } = await source.fetchTemplate(name);
+    const values: Record<string, string | boolean | number> = { ...args.vars };
+
+    // Prompt for missing required variables
+    for (const v of manifest.variables) {
+      if (v.name in values) continue;
+      if (v.default !== undefined) continue;
+      if (!v.required) continue;
+      if (isInteractive) {
+        const answer = await prompt(`${v.prompt || v.name} (${v.description}): `);
+        values[v.name] =
+          v.type === 'bool' ? answer === 'true' : v.type === 'int' ? parseInt(answer, 10) : answer;
+      } else {
+        console.error(`Missing required variable: ${v.name}`);
+        process.exit(1);
+      }
+    }
+
+    const result = renderTemplate(manifest, files, values);
+    const defaultDir = String(values['ProjectName'] || name);
+    const outDir = resolve(args.output || `./${defaultDir}`);
+
+    for (const file of result.files) {
+      const dest = join(outDir, file.path);
+      await mkdir(dirname(dest), { recursive: true });
+      await writeFile(dest, file.content, 'utf-8');
+    }
+
+    console.log(`${result.files.length} files written to ${outDir}`);
+    for (const w of result.warnings) console.log(`  warn: ${w}`);
+    for (const h of result.hooks.post) console.log(`  Run post-scaffold hook: ${h.run}`);
+  }
+}
+
+async function list(args: ParsedArgs): Promise<void> {
+  const source = resolveSource(args);
+
+  if (args.composites) {
+    const entries = await source.listComposites();
+    if (entries.length === 0) {
+      console.log('No composites found.');
+      return;
+    }
+    const nameW = Math.max(4, ...entries.map((e) => e.name.length));
+    const dispW = Math.max(7, ...entries.map((e) => e.displayName.length));
+    console.log(`${'NAME'.padEnd(nameW)}  ${'DISPLAY'.padEnd(dispW)}  TEMPLATES  TAGS`);
+    for (const e of entries) {
+      console.log(
+        `${e.name.padEnd(nameW)}  ${e.displayName.padEnd(dispW)}  ${String(e.templateCount).padStart(9)}  ${e.tags.join(', ')}`,
+      );
+    }
+  } else {
+    const entries = await source.listTemplates();
+    if (entries.length === 0) {
+      console.log('No templates found.');
+      return;
+    }
+    const nameW = Math.max(4, ...entries.map((e) => e.name.length));
+    const dispW = Math.max(7, ...entries.map((e) => e.displayName.length));
+    console.log(`${'NAME'.padEnd(nameW)}  ${'DISPLAY'.padEnd(dispW)}  TAGS`);
+    for (const e of entries) {
+      console.log(`${e.name.padEnd(nameW)}  ${e.displayName.padEnd(dispW)}  ${e.tags.join(', ')}`);
+    }
+  }
+}
+
+async function validate(args: ParsedArgs): Promise<void> {
+  const filePath = args.positional;
+  if (!filePath) {
+    console.error('Usage: nanohype validate <path-to-template.yaml>');
+    process.exit(1);
+  }
+
+  const absPath = resolve(filePath);
+  let text: string;
+  try {
+    text = await readFile(absPath, 'utf-8');
+  } catch {
+    console.error(`Cannot read file: ${absPath}`);
+    process.exit(1);
+  }
+
+  const doc = yaml.load(text) as Record<string, unknown>;
+
+  try {
+    if (doc.kind === 'composite') {
+      validateCompositeManifest(doc as unknown as CompositeManifest);
+      console.log(`PASS  ${absPath} (composite)`);
+    } else {
+      validateManifest(doc as unknown as TemplateManifest);
+      console.log(`PASS  ${absPath}`);
+    }
+  } catch (err) {
+    console.error(`FAIL  ${absPath}`);
+    console.error(`  ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+function printHelp(): void {
+  console.log(`nanohype — scaffold projects from nanohype templates
+
+USAGE
+  nanohype scaffold <name>                  Scaffold a template
+  nanohype scaffold --composite <name>      Scaffold a composite
+  nanohype list                             List available templates
+  nanohype list --composites                List available composites
+  nanohype validate <path>                  Validate a template.yaml
+
+FLAGS
+  --var Key=value       Set a template variable (repeatable)
+  --output, -o <dir>    Output directory (default: ./<ProjectName> or ./<name>)
+  --local <path>        Use local filesystem source instead of GitHub
+  --token <token>       GitHub token (or set GITHUB_TOKEN env var)
+  --help, -h            Show this help message
+
+EXAMPLES
+  nanohype list --local /path/to/nanohype
+  nanohype scaffold agentic-loop --local .. --var ProjectName=my-agent -o ./out
+  nanohype scaffold --composite ai-web-app --local .. --var ProjectName=myapp
+  nanohype validate templates/go-cli/template.yaml`);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+
+  if (args.help || (!args.command && !args.help)) {
+    printHelp();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  try {
+    switch (args.command) {
+      case 'scaffold':
+        await scaffold(args);
+        break;
+      case 'list':
+        await list(args);
+        break;
+      case 'validate':
+        await validate(args);
+        break;
+      default:
+        console.error(`Unknown command: ${args.command}`);
+        printHelp();
+        process.exit(1);
+    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+main();

--- a/sdk/src/bin/nanohype.ts
+++ b/sdk/src/bin/nanohype.ts
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
 
-import { readFile, mkdir, writeFile } from 'node:fs/promises';
-import { join, resolve, dirname } from 'node:path';
-import { createInterface } from 'node:readline';
-import * as yaml from 'js-yaml';
-
-import { LocalSource } from '../sources/local.js';
-import { GitHubSource } from '../sources/github.js';
-import { renderTemplate } from '../renderer.js';
-import { renderComposite } from '../composite.js';
-import { validateManifest, validateCompositeManifest } from '../validator.js';
-import type { CatalogSource } from '../source.js';
-import type { TemplateManifest, CompositeManifest } from '../types.js';
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import * as yaml from "js-yaml";
+import { renderComposite } from "../composite.js";
+import { renderTemplate } from "../renderer.js";
+import type { CatalogSource } from "../source.js";
+import { GitHubSource } from "../sources/github.js";
+import { LocalSource } from "../sources/local.js";
+import type { CompositeManifest, TemplateManifest } from "../types.js";
+import { validateCompositeManifest, validateManifest } from "../validator.js";
 
 // ── Arg parsing ──────────────────────────────────────────────────────
 
@@ -30,8 +29,8 @@ interface ParsedArgs {
 function parseArgs(argv: string[]): ParsedArgs {
   const args = argv.slice(2);
   const result: ParsedArgs = {
-    command: '',
-    positional: '',
+    command: "",
+    positional: "",
     vars: {},
     composite: false,
     composites: false,
@@ -40,42 +39,42 @@ function parseArgs(argv: string[]): ParsedArgs {
 
   let i = 0;
   // First non-flag arg is the command
-  while (i < args.length && args[i].startsWith('-')) {
-    if (args[i] === '--help' || args[i] === '-h') {
+  while (i < args.length && args[i].startsWith("-")) {
+    if (args[i] === "--help" || args[i] === "-h") {
       result.help = true;
       i++;
       continue;
     }
-    if (args[i] === '--composite') {
+    if (args[i] === "--composite") {
       result.composite = true;
       i++;
       continue;
     }
-    if (args[i] === '--composites') {
+    if (args[i] === "--composites") {
       result.composites = true;
       i++;
       continue;
     }
-    if (args[i] === '--var') {
+    if (args[i] === "--var") {
       if (i + 1 >= args.length) {
-        console.error('Error: --var requires a Key=value argument');
+        console.error("Error: --var requires a Key=value argument");
         process.exit(1);
       }
       parseVar(result.vars, args[++i]);
       i++;
       continue;
     }
-    if ((args[i] === '--output' || args[i] === '-o') && i + 1 < args.length) {
+    if ((args[i] === "--output" || args[i] === "-o") && i + 1 < args.length) {
       result.output = args[++i];
       i++;
       continue;
     }
-    if (args[i] === '--local' && i + 1 < args.length) {
+    if (args[i] === "--local" && i + 1 < args.length) {
       result.local = args[++i];
       i++;
       continue;
     }
-    if (args[i] === '--token' && i + 1 < args.length) {
+    if (args[i] === "--token" && i + 1 < args.length) {
       result.token = args[++i];
       i++;
       continue;
@@ -87,41 +86,41 @@ function parseArgs(argv: string[]): ParsedArgs {
   // Remaining args: positional and flags interleaved
   while (i < args.length) {
     const arg = args[i];
-    if (arg === '--help' || arg === '-h') {
+    if (arg === "--help" || arg === "-h") {
       result.help = true;
       i++;
       continue;
     }
-    if (arg === '--composite') {
+    if (arg === "--composite") {
       result.composite = true;
       i++;
       continue;
     }
-    if (arg === '--composites') {
+    if (arg === "--composites") {
       result.composites = true;
       i++;
       continue;
     }
-    if (arg === '--var') {
+    if (arg === "--var") {
       if (i + 1 >= args.length) {
-        console.error('Error: --var requires a Key=value argument');
+        console.error("Error: --var requires a Key=value argument");
         process.exit(1);
       }
       parseVar(result.vars, args[++i]);
       i++;
       continue;
     }
-    if ((arg === '--output' || arg === '-o') && i + 1 < args.length) {
+    if ((arg === "--output" || arg === "-o") && i + 1 < args.length) {
       result.output = args[++i];
       i++;
       continue;
     }
-    if (arg === '--local' && i + 1 < args.length) {
+    if (arg === "--local" && i + 1 < args.length) {
       result.local = args[++i];
       i++;
       continue;
     }
-    if (arg === '--token' && i + 1 < args.length) {
+    if (arg === "--token" && i + 1 < args.length) {
       result.token = args[++i];
       i++;
       continue;
@@ -134,7 +133,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 }
 
 function parseVar(vars: Record<string, string>, raw: string): void {
-  const eq = raw.indexOf('=');
+  const eq = raw.indexOf("=");
   if (eq === -1) {
     console.error(`Invalid --var format: ${raw} (expected Key=value)`);
     process.exit(1);
@@ -169,7 +168,7 @@ function prompt(question: string): Promise<string> {
 async function scaffold(args: ParsedArgs): Promise<void> {
   const name = args.positional;
   if (!name) {
-    console.error('Usage: nanohype scaffold <name> [--composite] [--var K=V] [-o dir]');
+    console.error("Usage: nanohype scaffold <name> [--composite] [--var K=V] [-o dir]");
     process.exit(1);
   }
 
@@ -189,7 +188,7 @@ async function scaffold(args: ParsedArgs): Promise<void> {
       if (isInteractive) {
         const answer = await prompt(`${v.prompt || v.name} (${v.description}): `);
         values[v.name] =
-          v.type === 'bool' ? answer === 'true' : v.type === 'int' ? parseInt(answer, 10) : answer;
+          v.type === "bool" ? answer === "true" : v.type === "int" ? parseInt(answer, 10) : answer;
       } else {
         console.error(`Missing required variable: ${v.name}`);
         process.exit(1);
@@ -202,13 +201,13 @@ async function scaffold(args: ParsedArgs): Promise<void> {
     for (const file of result.files) {
       const dest = join(outDir, file.path);
       await mkdir(dirname(dest), { recursive: true });
-      await writeFile(dest, file.content, 'utf-8');
+      await writeFile(dest, file.content, "utf-8");
     }
 
     console.log(`${result.files.length} files written to ${outDir}`);
     if (result.entries.length > 0) {
       console.log(
-        `Composed ${result.entries.length} templates: ${result.entries.map((e) => e.template).join(', ')}`,
+        `Composed ${result.entries.length} templates: ${result.entries.map((e) => e.template).join(", ")}`,
       );
     }
     for (const w of result.warnings) console.log(`  warn: ${w}`);
@@ -226,7 +225,7 @@ async function scaffold(args: ParsedArgs): Promise<void> {
       if (isInteractive) {
         const answer = await prompt(`${v.prompt || v.name} (${v.description}): `);
         values[v.name] =
-          v.type === 'bool' ? answer === 'true' : v.type === 'int' ? parseInt(answer, 10) : answer;
+          v.type === "bool" ? answer === "true" : v.type === "int" ? parseInt(answer, 10) : answer;
       } else {
         console.error(`Missing required variable: ${v.name}`);
         process.exit(1);
@@ -234,13 +233,13 @@ async function scaffold(args: ParsedArgs): Promise<void> {
     }
 
     const result = renderTemplate(manifest, files, values);
-    const defaultDir = String(values['ProjectName'] || name);
+    const defaultDir = String(values["ProjectName"] || name);
     const outDir = resolve(args.output || `./${defaultDir}`);
 
     for (const file of result.files) {
       const dest = join(outDir, file.path);
       await mkdir(dirname(dest), { recursive: true });
-      await writeFile(dest, file.content, 'utf-8');
+      await writeFile(dest, file.content, "utf-8");
     }
 
     console.log(`${result.files.length} files written to ${outDir}`);
@@ -255,28 +254,28 @@ async function list(args: ParsedArgs): Promise<void> {
   if (args.composites) {
     const entries = await source.listComposites();
     if (entries.length === 0) {
-      console.log('No composites found.');
+      console.log("No composites found.");
       return;
     }
     const nameW = Math.max(4, ...entries.map((e) => e.name.length));
     const dispW = Math.max(7, ...entries.map((e) => e.displayName.length));
-    console.log(`${'NAME'.padEnd(nameW)}  ${'DISPLAY'.padEnd(dispW)}  TEMPLATES  TAGS`);
+    console.log(`${"NAME".padEnd(nameW)}  ${"DISPLAY".padEnd(dispW)}  TEMPLATES  TAGS`);
     for (const e of entries) {
       console.log(
-        `${e.name.padEnd(nameW)}  ${e.displayName.padEnd(dispW)}  ${String(e.templateCount).padStart(9)}  ${e.tags.join(', ')}`,
+        `${e.name.padEnd(nameW)}  ${e.displayName.padEnd(dispW)}  ${String(e.templateCount).padStart(9)}  ${e.tags.join(", ")}`,
       );
     }
   } else {
     const entries = await source.listTemplates();
     if (entries.length === 0) {
-      console.log('No templates found.');
+      console.log("No templates found.");
       return;
     }
     const nameW = Math.max(4, ...entries.map((e) => e.name.length));
     const dispW = Math.max(7, ...entries.map((e) => e.displayName.length));
-    console.log(`${'NAME'.padEnd(nameW)}  ${'DISPLAY'.padEnd(dispW)}  TAGS`);
+    console.log(`${"NAME".padEnd(nameW)}  ${"DISPLAY".padEnd(dispW)}  TAGS`);
     for (const e of entries) {
-      console.log(`${e.name.padEnd(nameW)}  ${e.displayName.padEnd(dispW)}  ${e.tags.join(', ')}`);
+      console.log(`${e.name.padEnd(nameW)}  ${e.displayName.padEnd(dispW)}  ${e.tags.join(", ")}`);
     }
   }
 }
@@ -284,14 +283,14 @@ async function list(args: ParsedArgs): Promise<void> {
 async function validate(args: ParsedArgs): Promise<void> {
   const filePath = args.positional;
   if (!filePath) {
-    console.error('Usage: nanohype validate <path-to-template.yaml>');
+    console.error("Usage: nanohype validate <path-to-template.yaml>");
     process.exit(1);
   }
 
   const absPath = resolve(filePath);
   let text: string;
   try {
-    text = await readFile(absPath, 'utf-8');
+    text = await readFile(absPath, "utf-8");
   } catch {
     console.error(`Cannot read file: ${absPath}`);
     process.exit(1);
@@ -300,7 +299,7 @@ async function validate(args: ParsedArgs): Promise<void> {
   const doc = yaml.load(text) as Record<string, unknown>;
 
   try {
-    if (doc.kind === 'composite') {
+    if (doc.kind === "composite") {
       validateCompositeManifest(doc as unknown as CompositeManifest);
       console.log(`PASS  ${absPath} (composite)`);
     } else {
@@ -350,13 +349,13 @@ async function main(): Promise<void> {
 
   try {
     switch (args.command) {
-      case 'scaffold':
+      case "scaffold":
         await scaffold(args);
         break;
-      case 'list':
+      case "list":
         await list(args);
         break;
-      case 'validate':
+      case "validate":
         await validate(args);
         break;
       default:
@@ -370,4 +369,11 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+// The inner try/catch covers the subcommands; this covers everything outside
+// it — argument parsing, and a throw from the handler itself. Without it the
+// exit code on that path is Node's default for an unhandled rejection, which
+// is a flag away from being 0.
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
`nanohype` — the unscoped package `npx nanohype` resolves to — was published 0.1.0 from a directory that lives in no repository. It pins `@nanohype/sdk@^0.2.0` and will need a version bump the first time the SDK takes a breaking change, and until now there was no way to cut that release.

It joins `sdk`, `mcp-server` and `tokens` as `cli/`, same shape: TypeScript, `lint` / `typecheck` / `test` / `build`, its own lockfile, published through the shared `release.yml` on a `cli-v*` tag.

Bringing it in surfaced something larger, covered at the bottom.

## What it is

A wrapper. The scaffolder lives in `@nanohype/sdk`, which publishes it as a `nanohype` bin; this package locates that bin and runs it as a child process, so argv, exit codes and signals stay the SDK's.

It exists because npm's unscoped namespace is separate from the `@nanohype` scope. Owning the scope doesn't reserve the bare name, `npx nanohype` is what people reach for, and an unclaimed name is one someone else can publish under — which the docs were pointing at until this week.

## Why the path arithmetic is its own module

The SDK's `exports` map declares only `"."`, so its bin can't be reached as a subpath import. Resolving the package entry and walking to the bin beside it uses a filesystem path, which `exports` doesn't gate.

That arithmetic is the whole of what breaks silently if the SDK moves its bin, so it lives in `src/resolve.ts` where it can be tested against strings rather than buried in a spawn. Tests cover a flat install, a pnpm store path, and a resolution failure — the last being what lets the entry point print an instruction instead of node's "cannot find module" naming a file the user never asked for.

`missingSdkMessage` renders a thrown object as JSON rather than through `String()`. This is the failure path, nothing on it is guaranteed, and `[object Object]` is worse than useless at the moment someone needs the detail. A value JSON can't represent falls back rather than raising a second error over the first.

## The check that matters

`cli.yml` runs the built binary against the installed SDK: one subcommand that works, one that doesn't.

Every other check passes on a wrapper that resolves to nothing — the unit tests exercise path arithmetic against strings, and lint/typecheck/build never execute it. Running it is the only thing that proves the two packages agree, and asserting the bad subcommand exits non-zero catches a wrapper swallowing the child's status.

It earned its keep immediately: it's what caught the next part.

## `.gitignore` was swallowing both packages' CLI entry points

`bin/` in `.gitignore` is unanchored, so it matches a directory named `bin` at any depth — including `src/bin`. The repo already had one negation for this (`!templates/**/bin/`, from when template skeletons hit it); the packages' own sources were never covered.

**`sdk/src/bin/nanohype.ts` was never in this repository.** 12kB, dated 9 July, untracked — while the published `@nanohype/sdk@0.2.0` ships both `dist/bin/nanohype.js` and `src/bin/nanohype.ts`. The tarball carried source that existed on one machine and nowhere else.

A release cut from a clean checkout would have produced a package with no CLI in it, and the build would have succeeded — there'd have been nothing to compile and nothing to fail. `npx nanohype` and `npx @nanohype/sdk` would both have stopped working with no failing job to point at.

`cli/src/bin/nanohype.ts` went the same way in the first commit here, which is how it was found: CI failed on `Cannot find module cli/dist/bin/nanohype.js` at the step above. Lint, typecheck, test and build all passed on a package whose entry point didn't exist.

Fixed with `!**/src/bin/` — `src/` is source by definition, only `dist/bin` is build output. `dist/` is a separate rule and still ignores everything beneath it; verified with `git check-ignore`.

## What the SDK's entry point looked like once a linter could see it

Never formatted, never linted, and never read by the type-aware promise rules rolled out across the org — it was invisible to all of them.

`main()` was a floating promise. The inner try/catch covers the three subcommands but not `parseArgs`, and not a throw from the handler itself; on those paths the exit code was whatever Node's `--unhandled-rejections` mode happened to be. It now carries a `.catch` mirroring the inner handler, so this file states its own exit code instead of inheriting it from the runtime's configuration.

The rest was mechanical — quote style, import order, one computed key — applied by `biome check --write`.

## Also

- Docs go back to `npx nanohype` from `npx @nanohype/sdk`. They were moved off it because the name was unclaimed and squattable; it's claimed now and verified end to end from the registry.
- Published bin path is `dist/bin/nanohype.js`, no `./` prefix — npm's normalizer rejects that form and rewrites it at publish with a warning, and the entry deciding whether `npx nanohype` resolves is not one to leave to an auto-correction.
- `check-publishable-deps.mjs` picked this package up with no change: it reads every manifest that isn't `private: true`, so the list has nothing to fall out of date. It now reports 4.
