### PR TITLE
Release @nanohype/sdk 0.2.1

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanohype/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reference implementation of the nanohype template rendering contract, catalog discovery, and Platform Reference loaders",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Version bump so the CLI entry point fix can ship.

`0.2.0`'s tarball carries `src/bin/nanohype.ts` and a `dist/bin/nanohype.js` built from it — a file that was never in this repository until #194. No gate here had ever read it: not the formatter, not the linter, not the type-aware promise rules rolled out across the org.

**The fix that matters:** `main()` was a floating promise. Its inner try/catch covers the three subcommands but not `parseArgs`, and not a throw from the handler itself. On those paths the exit code was whatever Node's `--unhandled-rejections` mode happened to be rather than anything this package stated. It now carries a `.catch` mirroring the inner handler.

The rest of the diff against 0.2.0 is formatting and one computed key.

First SDK release through the trusted publisher, so the tarball carries provenance and the release identity is the workflow rather than an individual account.

Tag `sdk-v0.2.1` after merge.