### PR TITLE
Release @nanohype/tokens 0.1.1

### DIFF
--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanohype/tokens",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Design tokens for nanohype interfaces \u2014 Tailwind v4 theme plus a typed mirror, held together by a parity test.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
A republish through the trusted publisher. **No content change** against 0.1.0 — only the release identity.

`0.1.0` was published interactively, and an interactive publish stamps the account's email address into the version's immutable metadata: `_npmUser` and the per-version `maintainers` entry are both written at publish time and never revisited afterwards. Changing the account email later does not rewrite them — verified against a cache-busted anonymous fetch of the packument.

A trusted-publisher release records `npm-oidc-no-reply@github.com` instead, and attaches provenance linking the tarball to the commit it was built from. `@nanohype/mcp@0.1.1` and `nanohype@0.1.1` already look like this.

## Why now rather than with the next content change

npm's self-service unpublish window is 72 hours from publish. `@nanohype/tokens@0.1.0` is inside it with a few hours to spare; `@nanohype/sdk@0.2.0` and `@nanohype/mcp@0.1.0` are already past. Once the window closes the old metadata is fixed without going through registry support.

A replacement version has to exist before the old one can go — unpublishing the only version of a package removes the package.

Tag `tokens-v0.1.1` after merge.