### PR TITLE
Consume @nanohype/sdk 0.2.1 from mcp-server and cli

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nanohype/sdk": "^0.2.0"
+        "@nanohype/sdk": "^0.2.1"
       },
       "bin": {
         "nanohype": "dist/bin/nanohype.js"
@@ -241,9 +241,9 @@
       "license": "MIT"
     },
     "node_modules/@nanohype/sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@nanohype/sdk/-/sdk-0.2.0.tgz",
-      "integrity": "sha512-dTuDdLhq/5xbWG1cduhVI4fok7FaAnggTUUF7lgDBznYF64RJZheizg1+zyx004BfcZBrXOhToDCVxrwWFOz7w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@nanohype/sdk/-/sdk-0.2.1.tgz",
+      "integrity": "sha512-uSRx1nVaMYeMtfn6PKlnegRCafMb4JOUlFtpTbnGnjP3NihbI1rLtdO3QotwxtS/D30+9/t3MUTONejoxfJrkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^5.2.1"

--- a/cli/package.json
+++ b/cli/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@nanohype/sdk": "^0.2.0"
+    "@nanohype/sdk": "^0.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",
-        "@nanohype/sdk": "^0.2.0"
+        "@nanohype/sdk": "^0.2.1"
       },
       "bin": {
         "nanohype-mcp": "dist/index.js"
@@ -376,9 +376,9 @@
       }
     },
     "node_modules/@nanohype/sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@nanohype/sdk/-/sdk-0.2.0.tgz",
-      "integrity": "sha512-dTuDdLhq/5xbWG1cduhVI4fok7FaAnggTUUF7lgDBznYF64RJZheizg1+zyx004BfcZBrXOhToDCVxrwWFOz7w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@nanohype/sdk/-/sdk-0.2.1.tgz",
+      "integrity": "sha512-uSRx1nVaMYeMtfn6PKlnegRCafMb4JOUlFtpTbnGnjP3NihbI1rLtdO3QotwxtS/D30+9/t3MUTONejoxfJrkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^5.2.1"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.0",
-    "@nanohype/sdk": "^0.2.0"
+    "@nanohype/sdk": "^0.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",


### PR DESCRIPTION
Both packages resolved `^0.2.0` to **0.2.0** in their lockfiles, pinning them to the SDK build whose CLI entry point had never been linted — the floating `main()` promise that 0.2.1 fixes.

The range moves to `^0.2.1` rather than staying `^0.2.0`. A caret on 0.2.0 installs 0.2.1 today, but it also *permits resolving back to* 0.2.0 — and 0.2.0 is going to be unpublished. Its per-version metadata carries a personal email address that a trusted-publisher release doesn't, and npm writes that metadata once at publish time and never revisits it.

Raising the floor is what makes these lockfiles survive the removal instead of depending on nobody regenerating them.

## Context

npm's self-service unpublish isn't limited to 72 hours, which is where I had this wrong earlier. Past 72h an owner can still unpublish provided all three hold: no registry package depends on it, under 300 downloads in the last week, single maintainer. Every package in the `@nanohype` scope clears the last two comfortably (69–84 downloads/week, one maintainer).

This PR clears the first condition for `@nanohype/sdk@0.2.0` by moving its only two registry dependents off it.