### PR TITLE
Release @nanohype/mcp 0.1.2 and nanohype 0.1.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanohype",
-  "version": "0.1.1",
-  "description": "The nanohype CLI — scaffold templates and composites from the nanohype catalog. Thin entry point over @nanohype/sdk.",
+  "version": "0.1.2",
+  "description": "The nanohype CLI \u2014 scaffold templates and composites from the nanohype catalog. Thin entry point over @nanohype/sdk.",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanohype/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server exposing the nanohype Platform Reference (catalog + standards + per-repo contracts) as resources and tools",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Both packages already carry `@nanohype/sdk: ^0.2.1` in the repo. This publishes manifests that say so.

## Why

The published `0.1.1` of each still declares `^0.2.0`, and that declaration is what's holding `@nanohype/sdk@0.2.0` on the registry:

```
npm error 405 Method Not Allowed - You can no longer unpublish this package.
npm error Failed criteria:
npm error   has dependent packages in the registry
```

`0.2.0` is worth removing — it was published interactively, which writes the account's email into per-version metadata (`_npmUser`, per-version `maintainers`) that nothing later rewrites.

**Whether this frees it depends on how npm evaluates that criterion**, and the error message doesn't say. If it asks *does any published range still admit 0.2.0*, then removing the `0.1.1`s after this lands clears it. If it asks *does anything depend on this package at all*, it won't — mcp and the CLI depend on the SDK by design, and no version bump changes that.

Cutting these is worth it either way: the `0.1.0` of each carries the same address and comes off regardless.