### PR TITLE
Release @nanohype/tokens 0.2.0 — a brand gradient

### DIFF
--- a/tokens/__tests__/parity.test.ts
+++ b/tokens/__tests__/parity.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { colors, duration, easing, fonts, light, radius } from "../src/tokens.js";
+import { colors, duration, easing, fonts, gradient, light, radius } from "../src/tokens.js";
 
 const CSS = readFileSync(
   join(dirname(fileURLToPath(import.meta.url)), "..", "src", "tokens.css"),
@@ -63,6 +63,7 @@ describe.each([
   ["fonts", scoped(themeDecls, "font"), fonts as Record<string, string>],
   ["easing", scoped(themeDecls, "ease"), easing as Record<string, string>],
   ["duration", scoped(themeDecls, "duration"), duration as Record<string, string>],
+  ["gradient", scoped(themeDecls, "gradient"), gradient as Record<string, string>],
   ["light colors", scoped(lightDecls, "color"), light as Record<string, string>],
 ])("%s parity", (_name, css, ts) => {
   it("has the same token names in the stylesheet and the mirror", () => {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanohype/tokens",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Design tokens for nanohype interfaces \u2014 Tailwind v4 theme plus a typed mirror, held together by a parity test.",
   "license": "MIT",
   "type": "module",

--- a/tokens/src/index.ts
+++ b/tokens/src/index.ts
@@ -7,6 +7,8 @@ export {
   easing,
   type FontToken,
   fonts,
+  type GradientToken,
+  gradient,
   light,
   type RadiusToken,
   radius,

--- a/tokens/src/tokens.css
+++ b/tokens/src/tokens.css
@@ -66,6 +66,12 @@
   --duration-fast: 120ms;
   --duration-base: 180ms;
   --duration-slow: 260ms;
+
+  /* Brand gradient. No html.light counterpart on purpose: a gradient used as a
+     text fill or accent wash reads on either theme, and a per-theme variant
+     would be a second value nobody compares. Stops are the two primaries plus
+     a lighter tint of the same hue. */
+  --gradient-brand: linear-gradient(135deg, #2f7a6e 0%, #3e8e82 52%, #7fc4b8 100%);
 }
 
 html.light {

--- a/tokens/src/tokens.ts
+++ b/tokens/src/tokens.ts
@@ -105,11 +105,25 @@ export const duration = {
   slow: "260ms",
 } as const;
 
+/**
+ * Brand gradients.
+ *
+ * Mode-independent, which is why there is no `light` counterpart: a gradient
+ * used as a text fill or an accent wash reads on either theme, and giving it a
+ * per-theme variant would mean two values nobody compares. The stops are the
+ * two `primary` values — light and dark — plus a lighter tint of the same hue,
+ * so a change to the brand colour has one obvious place to follow.
+ */
+export const gradient = {
+  brand: "linear-gradient(135deg, #2f7a6e 0%, #3e8e82 52%, #7fc4b8 100%)",
+} as const;
+
 export type ColorToken = keyof typeof colors;
 export type RadiusToken = keyof typeof radius;
 export type FontToken = keyof typeof fonts;
 export type EasingToken = keyof typeof easing;
 export type DurationToken = keyof typeof duration;
+export type GradientToken = keyof typeof gradient;
 
 /** Every token, grouped — the shape a consumer usually wants. */
-export const tokens = { colors, light, radius, fonts, easing, duration } as const;
+export const tokens = { colors, light, radius, fonts, easing, duration, gradient } as const;


### PR DESCRIPTION
Adds `gradient.brand` — the one token an error page needs that this package didn't have: a diagonal wash used as the text fill behind a large status numeral.

Its stops are the two `primary` values (`#2f7a6e` light, `#3e8e82` dark) plus a lighter tint of the same hue, so a change to the brand colour has one obvious place to follow rather than a second palette to remember.

**No `html.light` counterpart, deliberately.** A gradient used as a text fill or accent wash reads on either theme, and a per-theme variant would be a second value nobody compares — the exact drift this package exists to prevent.

## The gate

The parity test covers it like every other group: `--gradient-brand` in the stylesheet against `gradient.brand` in the mirror.

Verified by **breaking the CSS value and watching the new row fail**, not by observing that the suite still passes:

```
FAIL  __tests__/parity.test.ts > gradient parity > has the same value for every token
-   "brand": "linear-gradient(135deg, #ff0000 0%, ...)"
+   "brand": "linear-gradient(135deg, #2f7a6e 0%, ...)"
```

A `scoped()` prefix that matched nothing would have produced two empty objects and passed — which is the failure mode this repo keeps finding elsewhere.

## Why now

First of two PRs. `@nanohype/error-pages` renders from these tokens and imports `gradient`, so this has to be published before that package can build — its `tsc` fails today with `Module '@nanohype/tokens' has no exported member 'gradient'` against the released 0.1.1.

Minor rather than patch: new public export.

Tag `tokens-v0.2.0` after merge.