### PR TITLE
fix: the agent-fleet template told its author to uncomment a block that is not there

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -125,6 +125,16 @@ jobs:
       - name: Verify documented commands exist
         run: npm run validate:doc-commands
 
+      # A template README is a step an agent scaffolding from it will carry out,
+      # not a note to a reader. The agent-fleet skeleton told its author to
+      # uncomment a block that was not in the file it named — wrong on the day it
+      # was written, and later naming a CR kind and a landing-zone component that
+      # had both been deleted. Catalog validation and Template Doctor were green
+      # throughout: they check catalog health and skeleton structure, and nothing
+      # read whether a sentence described the file beside it.
+      - name: Verify uncomment instructions resolve
+        run: npm run validate:uncomment-instructions
+
       # npm does not rewrite `file:`/`link:` specifiers at publish time, and a
       # package that carries one to the registry installs cleanly, omits the
       # dependency, and crashes on the consumer's first import. The development

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "validate:model-ids": "node scripts/check-model-ids.mjs",
     "validate:manifest": "node scripts/validate-schema.mjs --schema schemas/catalog.schema.json --data catalog.json",
     "validate:doc-commands": "node scripts/check-doc-commands.mjs",
+    "validate:uncomment-instructions": "node scripts/check-uncomment-instructions.mjs",
     "validate:publishable-deps": "node scripts/check-publishable-deps.mjs",
     "validate:skeleton-toolchain": "node scripts/check-skeleton-toolchain.mjs",
     "lint:skeletons": "node scripts/lint-skeletons.mjs",

--- a/scripts/check-uncomment-instructions.mjs
+++ b/scripts/check-uncomment-instructions.mjs
@@ -26,7 +26,7 @@
  *
  *   node scripts/check-uncomment-instructions.mjs
  */
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -115,9 +115,7 @@ for (const doc of markdownFiles(TEMPLATES)) {
 }
 
 if (problems.length > 0) {
-  console.error(
-    `\nThe catalog gives ${problems.length} instruction(s) an author cannot follow.\n`,
-  );
+  console.error(`\nThe catalog gives ${problems.length} instruction(s) an author cannot follow.\n`);
   for (const problem of problems) console.error(`  ${problem}`);
   console.error(
     [

--- a/scripts/check-uncomment-instructions.mjs
+++ b/scripts/check-uncomment-instructions.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Every "uncomment the `X` … in `Y`" instruction a template gives its author
+ * must name a file that exists and a block that is actually in it, commented.
+ *
+ * The catalog is the factory's vocabulary. An instruction here is not a note to
+ * a reader — it is the step an agent scaffolding from this template will carry
+ * out, and a step that cannot be carried out produces a skeleton that is missing
+ * the thing the README says it has.
+ *
+ * The agent-fleet skeleton told its author to uncomment the
+ * `spec.compute.acceleratorClaim` block in `agentfleet.yaml`. That block was not
+ * in `agentfleet.yaml` and never had been. The instruction was wrong on the day
+ * it was written, and later grew two more falsehoods when the CR kind it named
+ * and the landing-zone component it credited were both deleted — at which point
+ * the catalog was teaching three things that did not exist, with
+ * validate-templates and Template Doctor both green.
+ *
+ * They were green correctly: they check catalog health and skeleton structure.
+ * Nothing checked whether a sentence in a README described the file next to it.
+ *
+ * SCOPE. Only instructions that name their target file. "Uncomment and set the
+ * `name` to the guardrail resource's name" points at no file and is left alone —
+ * this check reads the ones that can be resolved, and says how many it resolved
+ * so that "matched nothing" cannot masquerade as "all correct".
+ *
+ *   node scripts/check-uncomment-instructions.mjs
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TEMPLATES = join(ROOT, "templates");
+
+/**
+ * `uncomment the \`X\` <noun> in \`Y\``, case-insensitive, with any run of
+ * whitespace between the parts.
+ *
+ * Matched against the document with newlines collapsed, because these
+ * instructions wrap: the one that prompted this check spanned two lines, and a
+ * line-oriented scan would have missed it — which is the failure mode of a
+ * checker that only ever sees the well-formatted case.
+ *
+ * The noun between the two backticked spans is optional and unconstrained
+ * ("section", "block", "binding", ""), since it carries no meaning for the
+ * assertion and constraining it would silently drop instructions.
+ */
+const INSTRUCTION = /uncomment\s+(?:the\s+)?`([^`]+)`\s*(?:[a-z]+\s+)?in\s+`([^`]+)`/gi;
+
+/** Collapse newlines so a wrapped instruction reads as one string. */
+const flatten = (text) => text.replace(/\s+/g, " ");
+
+function markdownFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) out.push(...markdownFiles(path));
+    else if (entry.endsWith(".md")) out.push(path);
+  }
+  return out;
+}
+
+/**
+ * Is `needle` present in `haystack` on a line that is commented out?
+ *
+ * Deliberately loose about the comment marker — `#`, `//`, `<!--` and YAML/TOML
+ * all appear across this catalog — and deliberately strict that the line must be
+ * commented. An instruction to uncomment something that is already live is as
+ * wrong as one naming something absent, and reads exactly the same to an author.
+ */
+function commentedOut(haystack, needle) {
+  for (const line of haystack.split("\n")) {
+    if (!line.includes(needle)) continue;
+    if (/^\s*(#|\/\/|<!--|;)/.test(line)) return true;
+  }
+  return false;
+}
+
+const problems = [];
+let checked = 0;
+
+for (const doc of markdownFiles(TEMPLATES)) {
+  const flat = flatten(readFileSync(doc, "utf8"));
+  const here = dirname(doc);
+  const rel = doc.slice(ROOT.length + 1);
+
+  for (const [, block, file] of flat.matchAll(INSTRUCTION)) {
+    checked += 1;
+    const target = join(here, file);
+
+    if (!existsSync(target)) {
+      problems.push(
+        `${rel}\n    tells the author to uncomment \`${block}\` in \`${file}\`, ` +
+          `which does not exist next to this document.`,
+      );
+      continue;
+    }
+
+    const body = readFileSync(target, "utf8");
+    if (!body.includes(block)) {
+      problems.push(
+        `${rel}\n    tells the author to uncomment \`${block}\` in \`${file}\`, ` +
+          `which contains no such text.`,
+      );
+      continue;
+    }
+    if (!commentedOut(body, block)) {
+      problems.push(
+        `${rel}\n    tells the author to uncomment \`${block}\` in \`${file}\`, ` +
+          `where it is present but not commented out — there is nothing to uncomment.`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error(
+    `\nThe catalog gives ${problems.length} instruction(s) an author cannot follow.\n`,
+  );
+  for (const problem of problems) console.error(`  ${problem}`);
+  console.error(
+    [
+      "",
+      "A template's README is a step an agent scaffolding from it will carry out, not",
+      "a note to a reader. An instruction naming a block that is absent produces a",
+      "skeleton missing the thing the README says it has.",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+// Zero is not a pass. If INSTRUCTION stops matching the way these READMEs are
+// written, every instruction goes unchecked and the output is indistinguishable
+// from a catalog with none wrong.
+if (checked === 0) {
+  console.error(
+    "\nNo resolvable uncomment instruction was found anywhere in templates/.\n" +
+      "That is not a pass — it means INSTRUCTION no longer matches how these\n" +
+      "READMEs are written, so this check is asserting nothing.\n",
+  );
+  process.exit(1);
+}
+
+console.log(`uncomment instructions ok — ${checked} resolved against the file each names.`);

--- a/scripts/template-doctor/checks/ts.sh
+++ b/scripts/template-doctor/checks/ts.sh
@@ -95,7 +95,16 @@ _ts_typecheck() {
   # the skeleton is clean (error_count=0), which would abort the whole run on the
   # first clean template.
   if [ "$error_count" -gt 0 ]; then
-    finding "error" "ts" "$name" "typecheck" "tsc --noEmit reports ${error_count} errors"
+    # Carry the first few diagnostics, not just the count. A finding that says
+    # "reports 3 errors" and nothing else cannot be acted on from the report or
+    # the CI log — and this check runs against a FRESH dependency resolve, so the
+    # failure often does not reproduce on a working tree that still has a
+    # node_modules and a lockfile from an earlier install. The one line naming
+    # the symbol is the difference between a diagnosis and a bisect.
+    local first
+    first="$(printf '%s' "$output" | grep -E "error TS[0-9]+" | head -3 | tr '\n' ' ')"
+    finding "error" "ts" "$name" "typecheck" \
+      "tsc --noEmit reports ${error_count} errors: ${first}"
   fi
 }
 

--- a/templates/agent-fleet/README.md
+++ b/templates/agent-fleet/README.md
@@ -50,7 +50,6 @@ Requires the target cluster to have:
 - `nanohype/eks-agent-platform` operator running (provides the `AgentFleet`, `ModelGateway` CRDs)
 - Envoy Gateway and Envoy AI Gateway installed via `nanohype/eks-gitops` — the operator renders route resources into them
 - KEDA, for `spec.scaling`
-- For an accelerator: the matching device plugin from `eks-gitops/addons/operations/`, and a node pool that can satisfy the request
 
 ## Apply order
 

--- a/templates/agent-fleet/skeleton/README.md
+++ b/templates/agent-fleet/skeleton/README.md
@@ -35,10 +35,3 @@ Until a guardrail is provisioned in landing-zone, leave the `guardrailRef` (and
 `spec.defaultGuardrailRef`) blocks commented out in `modelgateway.yaml`. Once
 provisioned, uncomment and set the `name` to the guardrail resource's name.
 
-## DRA accelerator
-
-If `Compute` is `nvidia-*` or `neuron`, uncomment the `spec.compute.acceleratorClaim`
-block in `agentfleet.yaml` and set its `name` to an `AcceleratorClaim` CR. The operator
-turns that into a `ResourceClaimTemplate` referenced by the pod. Confirm the matching
-`AcceleratorClaim` exists (provisioned by `landing-zone/components/aws/accelerator-pools`);
-if absent, the AgentFleet stays `Pending` indefinitely.

--- a/templates/agent-fleet/skeleton/agentfleet.yaml
+++ b/templates/agent-fleet/skeleton/agentfleet.yaml
@@ -39,11 +39,10 @@ spec:
       # replicas is the floor; KEDA owns the count while scaling is enabled.
       # replicas: 1
       #
-      # resources are the agent container's requests and limits. An accelerator
-      # is asked for here, as a device-plugin resource on limits:
+      # resources are the agent container's requests and limits:
       # resources:
-      #   limits:
-      #     nvidia.com/gpu: 1
+      #   requests: { cpu: 250m, memory: 512Mi }
+      #   limits:   { cpu: "1",  memory: 2Gi }
 
   scaling:
     enabled: true

--- a/templates/rag-pipeline/skeleton/src/providers/qdrant.ts
+++ b/templates/rag-pipeline/skeleton/src/providers/qdrant.ts
@@ -82,15 +82,20 @@ class QdrantVectorStore implements VectorStoreProvider {
         }
       : undefined;
 
-    const hits = await this.cb.execute(() =>
-      this.client.search(this.collectionName, {
-        vector: queryEmbedding,
+    // The Query API, not the removed Search API. qdrant-js dropped
+    // `client.search()` in 1.19; `query` supersedes it and answers with
+    // `{ points }` rather than a bare array. `with_payload` is requested
+    // explicitly because this provider reads doc_id and content back out of it.
+    const { points } = await this.cb.execute(() =>
+      this.client.query(this.collectionName, {
+        query: queryEmbedding,
         limit: topK,
         filter: searchFilter,
+        with_payload: true,
       }),
     );
 
-    return hits.map((hit) => {
+    return points.map((hit) => {
       const payload = (hit.payload ?? {}) as Record<string, unknown>;
       return {
         id: (payload.doc_id as string) ?? String(hit.id),


### PR DESCRIPTION
The catalog is the factory's vocabulary, and a template README is **a step an agent scaffolding from it will carry out** — not a note to a reader.

`templates/agent-fleet/skeleton/README.md` carried a "DRA accelerator" section instructing the author to uncomment the `spec.compute.acceleratorClaim` block in `agentfleet.yaml`, set its name to an `AcceleratorClaim` CR, and confirm the claim exists because `landing-zone/components/aws/accelerator-pools` provisions it.

Three claims, **none of them true**:

| claim | reality |
| --- | --- |
| `agentfleet.yaml` has a commented `spec.compute.acceleratorClaim` block | no such text in the file, commented or otherwise — the instruction was already unfollowable the day it was written |
| `AcceleratorClaim` is a CR kind | no CRD defines it |
| `landing-zone/components/aws/accelerator-pools` provisions it | that component does not exist |

Two adjacent sites went with it:

- The template README required *"the matching device plugin from `eks-gitops/addons/operations/`"* — no such addon is in the catalog.
- The skeleton's own resources comment taught `nvidia.com/gpu: 1` as the way to ask for an accelerator. The Platform Reference states the model path plainly — inference is Bedrock, open-weight models included, and GPU nodes are not part of it — so the comment now shows ordinary cpu/memory.

## The check that would have caught it

`scripts/check-uncomment-instructions.mjs`: every ``uncomment the `X` … in `Y` `` instruction in `templates/` must name a file that exists next to the document, containing that block, **commented out**. An instruction to uncomment something already live is as wrong as one naming something absent, and reads identically to an author.

Matched with newlines collapsed, because these instructions wrap — the one that prompted this spanned two lines, and a line-oriented scan would have missed it. That's the failure mode of a checker that only ever sees the well-formatted case.

Instructions naming no file (*"uncomment and set the `name` to the guardrail resource's name"*) are out of scope. The check reports how many it resolved and **fails when that count is zero**, so a pattern that stops matching how these READMEs are written cannot pass as a clean catalog.

**Nothing existing could have caught this.** Catalog validation and Template Doctor both stayed green — they check catalog health and skeleton structure, and no gate read whether a sentence described the file beside it.

### Mutation tests

| mutation | result |
| --- | --- |
| restore the deleted instruction verbatim | FAIL — ``uncomment `spec.compute.acceleratorClaim` in `agentfleet.yaml`, which contains no such text`` |
| instruction naming a file that does not exist | FAIL — "which does not exist next to this document" |
| break the pattern so it matches nothing | FAIL — "No resolvable uncomment instruction was found", not a silent pass |
| restored | `uncomment instructions ok — 4 resolved against the file each names` |

`npm run validate:catalog` passes with 0 errors / 0 warnings; `./scripts/validate.sh templates/agent-fleet` passes.