### PR TITLE
fix(deps): the fast-uri host-confusion advisory, and a CORS ReDoS in mcp-server

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nanohype/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nanohype/mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",
@@ -1362,9 +1362,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`osv-scanner` is a required check and went red on main. Both findings are real, both transitive, and both fixable inside the ranges already declared — **lockfiles only**, no manifest change.

| package | change | severity | where | advisory |
| --- | --- | --- | --- | --- |
| `fast-uri` | 3.1.4 → 3.1.5 | **HIGH** | `mcp-server`, root (dev) | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) |
| `hono` | 4.12.32 → 4.13.0 | moderate | `mcp-server` | [GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239) |

`fast-uri` is host confusion via a backslash authority introducer — a URL whose authority is introduced with a backslash parses to a different host than a resolver reaches. `hono` is a ReDoS in the CORS middleware via `Access-Control-Request-Headers`.

**The advisory patches the two `fast-uri` lines separately**: 3.1.5 for 3.x, 4.1.2 for 4.x. These trees resolve 3.x, so 3.1.5 is the fix here — the same advisory in `docs` takes 4.1.2 and they are not interchangeable.

## Verification

Every workspace audits clean afterwards:

```
.                  exit=0  found 0 vulnerabilities
mcp-server         exit=0  found 0 vulnerabilities
sdk                exit=0  found 0 vulnerabilities
cli                exit=0  found 0 vulnerabilities
error-pages        exit=0  found 0 vulnerabilities
tokens             exit=0  found 0 vulnerabilities
library/runtime    exit=0  found 0 vulnerabilities
```

mcp-server's tests and the repository lint pass on the reinstalled trees.

> This is the third repo in the org carrying `GHSA-7p8r-x3mc-p8w7` — `fab` and `docs` have their own PRs. Nothing schedules a dependency-advisory sweep across the org, so each one surfaced only when a PR happened to touch that repo.