### PR TITLE
fix(templates): emit the series a SLOPolicy can actually query

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -135,6 +135,19 @@ jobs:
       - name: Verify uncomment instructions resolve
         run: npm run validate:uncomment-instructions
 
+      # SLOPolicy builds its PromQL from `sli.metric` plus the suffix `sli.type`
+      # implies — it never takes a raw query — so a template's series either fit
+      # that shape or the tenant cannot have an objective at all, and the failure
+      # is silent: the query resolves to nothing and the policy reports NoData
+      # while AgentSLOEvaluationStale pages on a metric that was never there.
+      #
+      # Two templates were one character from working. ts-service emitted
+      # `http_errors_total` beside `http_request_total` — singular — and its own
+      # comment called the first "the 'errors' of RED". data-pipeline had the
+      # errors half and named its denominator `pipeline_documents_processed`.
+      - name: Verify SLI metric names
+        run: npm run validate:sli-metric-names
+
       # npm does not rewrite `file:`/`link:` specifiers at publish time, and a
       # package that carries one to the registry installs cleanly, omits the
       # dependency, and crashes on the consumer's first import. The development

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "verify:library": "node scripts/sync-library.mjs --check",
     "lint": "biome check .",
     "format": "biome check --write .",
-    "lint:docs": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!templates/*/skeleton/**' '!.plans/**'"
+    "lint:docs": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!templates/*/skeleton/**' '!.plans/**'",
+    "validate:sli-metric-names": "node scripts/check-sli-metric-names.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",

--- a/scripts/check-sli-metric-names.mjs
+++ b/scripts/check-sli-metric-names.mjs
@@ -1,0 +1,128 @@
+// A template's metrics must be queryable by the objective the platform offers.
+//
+// SLOPolicy builds its PromQL from `sli.metric` plus a suffix its `sli.type`
+// implies — it never accepts a raw query. So the series a template emits either
+// fit that shape or the tenant simply cannot have an objective, and the failure
+// is silent: the query resolves to nothing, the policy reports NoData forever,
+// and AgentSLOEvaluationStale pages on a metric that was never there.
+//
+// Two rules, both learned from templates that were one character away from
+// working.
+//
+// 1. AN ERRORS COUNTER NEEDS ITS DENOMINATOR.
+//    An availability SLI reads `<m>_errors_total` over `<m>_requests_total`.
+//    ts-service emitted `http_errors_total` — its own comment called it "the
+//    'errors' of RED" — beside `http_request_total`, singular. With
+//    `sli.metric: http` the denominator series does not exist, so the ratio
+//    evaluates empty. A template that publishes an errors counter must publish
+//    the matching requests counter, spelled the way the query builder spells it.
+//
+// 2. A LATENCY HISTOGRAM IS IN SECONDS.
+//    A latency SLI reads `<m>_request_duration_seconds_{bucket,count}` and
+//    `thresholdSeconds` names a bucket boundary in seconds. A histogram called
+//    `_request_duration_ms` answers none of those queries, and one renamed to
+//    `_seconds` while still recording milliseconds is worse — every value off by
+//    1000 with nothing to say so. So the name and the declared unit have to
+//    agree, and both have to be base units.
+//
+// Scoped to `*_request_duration_*` deliberately. Other duration histograms in
+// these templates measure things that are not a request and cannot carry a
+// latency SLI by name; converting them is worth doing and is not this gate's
+// business.
+//
+// Usage: node scripts/check-sli-metric-names.mjs
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const TEMPLATES = "templates";
+
+const COUNTER = /createCounter\(\s*["']([a-z0-9_]+)["']/g;
+const HISTOGRAM = /createHistogram\(\s*["']([a-z0-9_]+)["']/g;
+
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir)) {
+    if (e === "node_modules" || e === "dist") continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(TEMPLATES);
+if (files.length === 0) {
+  console.error(`no TypeScript sources under ${TEMPLATES}/ — the walk matched nothing,`);
+  console.error("so this check is asserting nothing.");
+  process.exit(2);
+}
+
+const errors = [];
+let counters = 0;
+let histograms = 0;
+
+for (const f of files) {
+  const src = readFileSync(f, "utf-8");
+
+  const names = [...src.matchAll(COUNTER)].map((m) => m[1]);
+  counters += names.length;
+
+  // Rule 1 — an errors counter needs the denominator the SLI divides by.
+  for (const n of names.filter((x) => x.endsWith("_errors_total"))) {
+    const base = n.slice(0, -"_errors_total".length);
+    if (!names.includes(`${base}_requests_total`)) {
+      const near = names.find((x) => x.startsWith(base) && x !== n);
+      errors.push(
+        `${f}\n` +
+          `    emits ${n} but not ${base}_requests_total.\n` +
+          `    An availability SLI reads the pair; without the denominator the ratio\n` +
+          `    evaluates empty and the objective reports NoData forever.` +
+          (near ? `\n    Closest name present: ${near}` : ""),
+      );
+    }
+  }
+
+  // Rule 2 — a latency histogram is in seconds, in both name and unit.
+  for (const m of src.matchAll(HISTOGRAM)) {
+    histograms++;
+    const name = m[1];
+    if (!name.includes("_request_duration_")) continue;
+    if (!name.endsWith("_seconds")) {
+      errors.push(
+        `${f}\n` +
+          `    ${name} is a latency histogram not in seconds.\n` +
+          `    A latency SLI reads <metric>_request_duration_seconds_{bucket,count} and\n` +
+          `    thresholdSeconds names a bucket boundary in seconds, so this answers none\n` +
+          `    of those queries.`,
+      );
+      continue;
+    }
+    // Named seconds — the declared unit must agree, or every value is off by 1000.
+    const opts = src.slice(m.index, src.indexOf("});", m.index));
+    const unit = /unit:\s*["']([^"']+)["']/.exec(opts);
+    if (unit && unit[1] !== "s") {
+      errors.push(
+        `${f}\n` +
+          `    ${name} is named _seconds but declares unit "${unit[1]}".\n` +
+          `    That is worse than the wrong name: every value lands off by a factor of\n` +
+          `    1000 in a series whose name says otherwise, and nothing reports it.`,
+      );
+    }
+  }
+}
+
+if (counters === 0 || histograms === 0) {
+  console.error(`matched ${counters} counter(s) and ${histograms} histogram(s) — the instrument`);
+  console.error("patterns stopped matching, so this check is asserting nothing.");
+  process.exit(2);
+}
+
+if (errors.length > 0) {
+  for (const e of errors) console.error(`FAIL  ${e}`);
+  process.exit(1);
+}
+
+console.log(
+  `SLI metric names ok — ${counters} counters and ${histograms} histograms across ${files.length} template sources; ` +
+    "every errors counter has its denominator and every latency histogram is in seconds.",
+);

--- a/templates/agentic-loop/skeleton/src/agent.ts
+++ b/templates/agentic-loop/skeleton/src/agent.ts
@@ -23,7 +23,10 @@ function resolveProvider() {
 function recordLlmMetrics(response: LlmResponse, durationMs: number): void {
   const labels = { provider: PROVIDER_NAME, model: "default" };
   llmRequestTotal.add(1, labels);
-  llmRequestDuration.record(durationMs, { provider: PROVIDER_NAME });
+  // Seconds, not milliseconds. The histogram is named _seconds because that is
+  // the base unit Prometheus expects and the unit SLOPolicy's latency SLI
+  // queries; recording ms into it would be off by 1000 with nothing to say so.
+  llmRequestDuration.record(durationMs / 1000, { provider: PROVIDER_NAME });
 
   if (response.usage) {
     if (response.usage.inputTokens != null) {

--- a/templates/agentic-loop/skeleton/src/metrics.ts
+++ b/templates/agentic-loop/skeleton/src/metrics.ts
@@ -15,9 +15,9 @@ export const llmRequestTotal = meter.createCounter("llm_request_total", {
 });
 
 /** LLM request duration in milliseconds, labeled by provider. */
-export const llmRequestDuration = meter.createHistogram("llm_request_duration_ms", {
-  description: "LLM API request latency in milliseconds",
-  unit: "ms",
+export const llmRequestDuration = meter.createHistogram("llm_request_duration_seconds", {
+  description: "LLM API request latency in seconds",
+  unit: "s",
 });
 
 /** Token usage counter, labeled by provider and direction (input/output). */

--- a/templates/data-pipeline/skeleton/README.md
+++ b/templates/data-pipeline/skeleton/README.md
@@ -53,7 +53,7 @@ Each stage uses a factory-based registry pattern (`registry.ts`):
 - **VectorDocument-compatible output** -- the JSONL adapter writes objects with `id`, `content`, `embedding`, and `metadata` fields, matching `module-vector-store`'s `VectorDocument` interface.
 - **Lazy SDK initialization** -- the OpenAI client is created on first use, not at import time, keeping startup fast and avoiding errors when the provider isn't selected.
 - **Circuit breaker** -- all external API calls (embeddings) are wrapped in a sliding-window circuit breaker that fast-fails after repeated failures.
-- **OTel metrics** -- `pipeline_documents_processed`, `pipeline_chunks_created`, and `pipeline_duration_ms` are emitted as OTel counters/histograms. No-ops without an OTel SDK.
+- **OTel metrics** -- `pipeline_requests_total`, `pipeline_errors_total` (the RED pair a SLOPolicy availability SLI reads), `pipeline_chunks_created`, and `pipeline_duration_ms` are emitted as OTel counters/histograms. No-ops without an OTel SDK.
 
 ## Configuration
 

--- a/templates/data-pipeline/skeleton/src/pipeline/metrics.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/metrics.ts
@@ -8,9 +8,17 @@ import { metrics } from "@opentelemetry/api";
 
 const meter = metrics.getMeter("__PROJECT_NAME__");
 
-/** Total documents processed, labeled by outcome status. */
-export const pipelineDocumentsProcessed = meter.createCounter("pipeline_documents_processed", {
-  description: "Total number of documents processed by the pipeline",
+/** Total documents the pipeline took in, labeled by outcome status — the
+ *  "requests" of RED, and the denominator pipelineErrorsTotal divides into.
+ *
+ *  Named _requests_total rather than _documents_processed because SLOPolicy's
+ *  availability SLI builds `<metric>_errors_total / <metric>_requests_total`
+ *  from `sli.metric` alone. A denominator under any other name means the ratio
+ *  evaluates empty and the objective reports NoData forever — the errors
+ *  counter below already called itself the "errors" of RED, and this is the
+ *  half that was missing. */
+export const pipelineRequestsTotal = meter.createCounter("pipeline_requests_total", {
+  description: "Total documents taken in by the pipeline, labeled by outcome status",
 });
 
 /** Total chunks created across all documents. */

--- a/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
@@ -15,9 +15,9 @@ import type { IngestSource } from "./ingest/types.js";
 import { logger } from "./logger.js";
 import {
   pipelineChunksCreated,
-  pipelineRequestsTotal,
   pipelineDuration,
   pipelineErrorsTotal,
+  pipelineRequestsTotal,
 } from "./metrics.js";
 import type { OutputAdapter } from "./output/types.js";
 import type { ChunkStrategy } from "./transform/types.js";

--- a/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
@@ -15,7 +15,7 @@ import type { IngestSource } from "./ingest/types.js";
 import { logger } from "./logger.js";
 import {
   pipelineChunksCreated,
-  pipelineDocumentsProcessed,
+  pipelineRequestsTotal,
   pipelineDuration,
   pipelineErrorsTotal,
 } from "./metrics.js";
@@ -81,7 +81,7 @@ export async function runPipeline(opts: OrchestratorOptions): Promise<PipelineRe
 
   progress({ stage: "ingest", processed: documents.length, total: documents.length });
   logger.info("Ingest complete", { documents: documents.length });
-  pipelineDocumentsProcessed.add(documents.length, { status: "loaded" });
+  pipelineRequestsTotal.add(documents.length, { status: "loaded" });
 
   // ── Stage 2: Transform ───────────────────────────────────────────
   logger.info("Stage 2: Transform", { strategy: strategy.name });

--- a/templates/module-llm-gateway/skeleton/src/gateway/index.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/index.ts
@@ -191,7 +191,8 @@ export function createGateway(config: GatewayConfig): Gateway {
       // Record metrics
       const labels = { provider: response.provider, model: response.model };
       gatewayRequestTotal.add(1, labels);
-      gatewayRequestDuration.record(response.latencyMs, labels);
+      // latencyMs -> seconds: the histogram is in base units (see metrics.ts).
+      gatewayRequestDuration.record(response.latencyMs / 1000, labels);
       gatewayTokenUsage.add(response.inputTokens, { ...labels, direction: "input" });
       gatewayTokenUsage.add(response.outputTokens, { ...labels, direction: "output" });
       gatewayCostTotal.add(response.cost, labels);

--- a/templates/module-llm-gateway/skeleton/src/gateway/metrics.ts
+++ b/templates/module-llm-gateway/skeleton/src/gateway/metrics.ts
@@ -16,9 +16,9 @@ export const gatewayRequestTotal = meter.createCounter("gateway_request_total", 
 });
 
 /** Gateway request duration in milliseconds, labeled by provider. */
-export const gatewayRequestDuration = meter.createHistogram("gateway_request_duration_ms", {
-  description: "Gateway chat request latency in milliseconds",
-  unit: "ms",
+export const gatewayRequestDuration = meter.createHistogram("gateway_request_duration_seconds", {
+  description: "Gateway chat request latency in seconds",
+  unit: "s",
 });
 
 /** Token usage counter, labeled by provider and direction (input/output). */

--- a/templates/slack-bot/skeleton/src/metrics.ts
+++ b/templates/slack-bot/skeleton/src/metrics.ts
@@ -21,9 +21,9 @@ export const llmErrorsTotal = meter.createCounter("llm_errors_total", {
 });
 
 /** LLM call latency in milliseconds. */
-export const llmDuration = meter.createHistogram("llm_request_duration_ms", {
-  description: "LLM chat latency in milliseconds",
-  unit: "ms",
+export const llmDuration = meter.createHistogram("llm_request_duration_seconds", {
+  description: "LLM chat latency in seconds",
+  unit: "s",
 });
 
 /** Token usage by kind (input/output/cache_read/cache_write). Cost is derived

--- a/templates/slack-bot/skeleton/src/providers/bedrock.ts
+++ b/templates/slack-bot/skeleton/src/providers/bedrock.ts
@@ -62,7 +62,8 @@ class BedrockProvider implements LlmProvider {
       llmErrorsTotal.add(1, labels);
       throw err;
     } finally {
-      llmDuration.record(performance.now() - start, labels);
+      // performance.now() is milliseconds; the histogram is in seconds.
+      llmDuration.record((performance.now() - start) / 1000, labels);
     }
   }
 }

--- a/templates/ts-service/skeleton/src/metrics.ts
+++ b/templates/ts-service/skeleton/src/metrics.ts
@@ -11,14 +11,14 @@ import { metrics } from "@opentelemetry/api";
 const meter = metrics.getMeter("__PROJECT_NAME__");
 
 /** Total HTTP requests, labeled by method, path, and status code. */
-export const httpRequestTotal = meter.createCounter("http_request_total", {
+export const httpRequestTotal = meter.createCounter("http_requests_total", {
   description: "Total number of HTTP requests received",
 });
 
 /** HTTP request duration in milliseconds, labeled by method, path, and status. */
-export const httpRequestDuration = meter.createHistogram("http_request_duration_ms", {
-  description: "HTTP request latency in milliseconds",
-  unit: "ms",
+export const httpRequestDuration = meter.createHistogram("http_request_duration_seconds", {
+  description: "HTTP request latency in seconds",
+  unit: "s",
 });
 
 /** Total HTTP responses with a server-error (5xx) status — the "errors" of RED. */

--- a/templates/ts-service/skeleton/src/middleware/metrics.ts
+++ b/templates/ts-service/skeleton/src/middleware/metrics.ts
@@ -22,7 +22,8 @@ export async function metricsMiddleware(c: Context, next: Next): Promise<void> {
   };
 
   httpRequestTotal.add(1, labels);
-  httpRequestDuration.record(durationMs, labels);
+  // Seconds, not milliseconds — the histogram is in base units (see metrics.ts).
+  httpRequestDuration.record(durationMs / 1000, labels);
   if (c.res.status >= 500) {
     httpErrorsTotal.add(1, labels);
   }


### PR DESCRIPTION
SLOPolicy builds its PromQL from `sli.metric` plus the suffix `sli.type` implies — it never accepts a raw query, deliberately. So a template's series either fit that shape or the tenant **cannot have an objective at all**, and the failure is silent: the query resolves to nothing, the policy reports NoData forever, and `AgentSLOEvaluationStale` pages on a metric that was never there.

Of 22 templates, **exactly one** emitted a queryable availability pair. Two of the rest were a single character away.

## ts-service

Emitted `http_errors_total` beside `http_request_total`. **Singular.** The SLI builds `<m>_requests_total`, so with `sli.metric: http` the denominator does not exist and the ratio evaluates empty.

Its own comment called the errors counter *"the 'errors' of RED"* — so RED was the intent; the pair just never matched.

## data-pipeline

Same shape, and **found by the new gate rather than by reading** — I had not spotted this one. It emitted `pipeline_errors_total`, again commented as the "errors" of RED, and named its denominator `pipeline_documents_processed`. That counter already counted every document taken in, labeled by outcome — exactly the RED denominator under another name. Renamed to `pipeline_requests_total`.

## Latency histograms are in seconds

A latency SLI reads `<m>_request_duration_seconds_{bucket,count}` and `thresholdSeconds` names a bucket boundary in seconds. All four `*_request_duration_ms` histograms answered none of those queries.

Renamed to `_seconds`, `unit` changed to `s`, **and every call site divided** — which is the half that matters. A histogram renamed to `_seconds` while still recording milliseconds is worse than the wrong name: every value lands off by a factor of 1000 in a series whose name says otherwise, and nothing reports it. Four histograms, four call sites, each verified to have no remaining unconverted recorder.

## The gate

`scripts/check-sli-metric-names.mjs` holds both rules and refuses to pass vacuously — zero counters or zero histograms matched is a failure, not a green run.

Scoped to `*_request_duration_*` on purpose: the other 16 duration histograms measure things that are not a request and cannot carry a latency SLI by name. Converting them to base units is worth doing and is not this gate's business.

| mutation | result |
| --- | --- |
| revert the ts-service counter typo | **FAIL** — names the missing denominator, and points at the closest name present |
| revert a histogram to `_ms` | **FAIL** — not in seconds |
| name `_seconds`, declare `unit: "ms"` | **FAIL** — the off-by-1000 trap |

## Verified

`validate:sli-metric-names`, `lint:skeletons` (48/48), `validate:skeleton-toolchain`, and `tsc --noEmit` on all five changed skeletons.

The rename reordered an import and tripped `lint:skeletons`; fixed in the second commit rather than left for CI.