### PR TITLE
fix(templates): duration histograms are in seconds, and the gate reads the call sites

### DIFF
--- a/scripts/check-sli-metric-names.mjs
+++ b/scripts/check-sli-metric-names.mjs
@@ -17,18 +17,23 @@
 //    evaluates empty. A template that publishes an errors counter must publish
 //    the matching requests counter, spelled the way the query builder spells it.
 //
-// 2. A LATENCY HISTOGRAM IS IN SECONDS.
+// 2. A DURATION HISTOGRAM IS IN SECONDS.
 //    A latency SLI reads `<m>_request_duration_seconds_{bucket,count}` and
 //    `thresholdSeconds` names a bucket boundary in seconds. A histogram called
-//    `_request_duration_ms` answers none of those queries, and one renamed to
-//    `_seconds` while still recording milliseconds is worse — every value off by
-//    1000 with nothing to say so. So the name and the declared unit have to
-//    agree, and both have to be base units.
+//    `_duration_ms` answers none of those queries. Seconds is also the OTel and
+//    Prometheus base unit, so a `_ms` series is wrong against the convention
+//    every dashboard and alert in the org already assumes, not only against the
+//    SLI contract. So the name and the declared unit have to agree, and both
+//    have to be base units.
 //
-// Scoped to `*_request_duration_*` deliberately. Other duration histograms in
-// these templates measure things that are not a request and cannot carry a
-// latency SLI by name; converting them is worth doing and is not this gate's
-// business.
+// 3. AND IT IS FED SECONDS.
+//    A histogram renamed to `_seconds` while a call site still records
+//    `performance.now() - start` is worse than the wrong name: every value lands
+//    off by a factor of 1000, in a series whose name and unit both say
+//    otherwise, and no gate above this one can see it. A rename touches one
+//    line; the call sites are spread across the module. So every `.record()` on
+//    a seconds-named duration histogram has to show its conversion — a division
+//    by 1000, or a value already named seconds.
 //
 // Usage: node scripts/check-sli-metric-names.mjs
 
@@ -39,6 +44,41 @@ const TEMPLATES = "templates";
 
 const COUNTER = /createCounter\(\s*["']([a-z0-9_]+)["']/g;
 const HISTOGRAM = /createHistogram\(\s*["']([a-z0-9_]+)["']/g;
+
+// The instrument's variable name alongside its series name, so rule 3 can find
+// the call sites. The series name may sit on the line after the open paren.
+const HISTOGRAM_BINDING =
+  /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*\w+\.createHistogram\(\s*["']([a-z0-9_]+)["']/g;
+
+// A recorded value has to show its conversion: an explicit division by 1000, or
+// a value whose own name already says seconds.
+const CONVERTS = /\/\s*1000\b|[Ss]econds\b/;
+
+// The first argument of a call, given the index just past its open paren.
+// Depth-aware and string-aware, so a comma inside `{ operation: "get" }` or
+// inside a quoted label does not end the argument early.
+function firstArgument(src, from) {
+  let depth = 0;
+  let quote = null;
+  for (let i = from; i < src.length; i++) {
+    const c = src[i];
+    if (quote) {
+      if (c === "\\") i++;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      continue;
+    }
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") {
+      if (depth === 0) return src.slice(from, i);
+      depth--;
+    } else if (c === "," && depth === 0) return src.slice(from, i);
+  }
+  return null;
+}
 
 function walk(dir, out = []) {
   for (const e of readdirSync(dir)) {
@@ -82,18 +122,18 @@ for (const f of files) {
     }
   }
 
-  // Rule 2 — a latency histogram is in seconds, in both name and unit.
+  // Rule 2 — a duration histogram is in seconds, in both name and unit.
   for (const m of src.matchAll(HISTOGRAM)) {
     histograms++;
     const name = m[1];
-    if (!name.includes("_request_duration_")) continue;
+    if (!name.includes("_duration_")) continue;
     if (!name.endsWith("_seconds")) {
       errors.push(
         `${f}\n` +
-          `    ${name} is a latency histogram not in seconds.\n` +
-          `    A latency SLI reads <metric>_request_duration_seconds_{bucket,count} and\n` +
-          `    thresholdSeconds names a bucket boundary in seconds, so this answers none\n` +
-          `    of those queries.`,
+          `    ${name} is a duration histogram not in seconds.\n` +
+          `    Seconds is the base unit Prometheus and OTel both assume, and a latency SLI\n` +
+          `    reads <metric>_request_duration_seconds_{bucket,count} with thresholdSeconds\n` +
+          `    naming a bucket boundary in seconds — so this answers none of those queries.`,
       );
       continue;
     }
@@ -111,9 +151,66 @@ for (const f of files) {
   }
 }
 
+// Rule 3 — every recorded value shows its conversion to seconds.
+//
+// Scoped per template, because instrument variables are module-scoped and two
+// templates each declare a `cacheOperationDuration` over different series.
+const byTemplate = new Map();
+for (const f of files) {
+  const root = f.split("/").slice(0, 2).join("/");
+  if (!byTemplate.has(root)) byTemplate.set(root, []);
+  byTemplate.get(root).push(f);
+}
+
+let instrumentCount = 0;
+let recordSites = 0;
+
+for (const group of byTemplate.values()) {
+  const instruments = new Map();
+  for (const f of group) {
+    for (const m of readFileSync(f, "utf-8").matchAll(HISTOGRAM_BINDING)) {
+      const [, variable, series] = m;
+      if (series.includes("_duration_") && series.endsWith("_seconds")) {
+        instruments.set(variable, series);
+      }
+    }
+  }
+  if (instruments.size === 0) continue;
+  instrumentCount += instruments.size;
+
+  for (const f of group) {
+    const src = readFileSync(f, "utf-8");
+    for (const [variable, series] of instruments) {
+      for (const m of src.matchAll(new RegExp(`\\b${variable}\\.record\\(`, "g"))) {
+        const arg = firstArgument(src, m.index + m[0].length);
+        if (arg === null) continue;
+        recordSites++;
+        if (CONVERTS.test(arg)) continue;
+        const line = src.slice(0, m.index).split("\n").length;
+        errors.push(
+          `${f}:${line}\n` +
+            `    ${variable}.record(${arg.trim()}) feeds ${series} a value that never\n` +
+            `    converts to seconds. performance.now() and Date.now() are milliseconds, so\n` +
+            `    this lands every observation off by a factor of 1000 in a series whose name\n` +
+            `    and unit both say otherwise.\n` +
+            `    Divide by 1000 at the call site, or record a value named for seconds.`,
+        );
+      }
+    }
+  }
+}
+
 if (counters === 0 || histograms === 0) {
   console.error(`matched ${counters} counter(s) and ${histograms} histogram(s) — the instrument`);
   console.error("patterns stopped matching, so this check is asserting nothing.");
+  process.exit(2);
+}
+
+if (instrumentCount === 0 || recordSites === 0) {
+  console.error(
+    `rule 3 bound ${instrumentCount} seconds-named duration histogram(s) to ${recordSites} call site(s) —`,
+  );
+  console.error("the binding or call-site pattern stopped matching, so it is asserting nothing.");
   process.exit(2);
 }
 
@@ -124,5 +221,6 @@ if (errors.length > 0) {
 
 console.log(
   `SLI metric names ok — ${counters} counters and ${histograms} histograms across ${files.length} template sources; ` +
-    "every errors counter has its denominator and every latency histogram is in seconds.",
+    "every errors counter has its denominator, every duration histogram is in seconds, and all " +
+    `${recordSites} call sites on those ${instrumentCount} instruments convert.`,
 );

--- a/templates/agent-orchestrator/skeleton/src/orchestrator/metrics.ts
+++ b/templates/agent-orchestrator/skeleton/src/orchestrator/metrics.ts
@@ -20,14 +20,14 @@ export const subtaskTotal = meter.createCounter("orchestrator_subtask_total", {
   description: "Total subtasks created by the planner",
 });
 
-/** Agent execution duration in milliseconds, labeled by agent name. */
-export const agentDuration = meter.createHistogram("orchestrator_agent_duration_ms", {
-  description: "Agent execution latency in milliseconds",
-  unit: "ms",
+/** Agent execution duration in seconds, labeled by agent name. */
+export const agentDuration = meter.createHistogram("orchestrator_agent_duration_seconds", {
+  description: "Agent execution latency in seconds",
+  unit: "s",
 });
 
-/** Total orchestration duration in milliseconds. */
-export const orchestrationDuration = meter.createHistogram("orchestrator_duration_ms", {
-  description: "Total orchestration latency in milliseconds",
-  unit: "ms",
+/** Total orchestration duration in seconds. */
+export const orchestrationDuration = meter.createHistogram("orchestrator_duration_seconds", {
+  description: "Total orchestration latency in seconds",
+  unit: "s",
 });

--- a/templates/agent-orchestrator/skeleton/src/orchestrator/orchestrator.ts
+++ b/templates/agent-orchestrator/skeleton/src/orchestrator/orchestrator.ts
@@ -233,7 +233,7 @@ export function createOrchestratorInstance(config: ValidatedConfig): Orchestrato
           };
         }
 
-        agentDuration.record(result.durationMs, { agent: agentName });
+        agentDuration.record(result.durationMs / 1000, { agent: agentName });
         results.set(subtask.id, result);
         previousAgent = agentName;
 
@@ -246,7 +246,7 @@ export function createOrchestratorInstance(config: ValidatedConfig): Orchestrato
       }
 
       const totalDuration = performance.now() - start;
-      orchestrationDuration.record(totalDuration);
+      orchestrationDuration.record(totalDuration / 1000);
 
       const allSucceeded = Array.from(results.values()).every((r) => r.success);
 

--- a/templates/api-gateway/skeleton/src/gateway/index.ts
+++ b/templates/api-gateway/skeleton/src/gateway/index.ts
@@ -218,7 +218,7 @@ export function createGateway(config: GatewayConfig) {
       status: String(proxyResponse.status),
     };
     gatewayProxyTotal.add(1, labels);
-    gatewayProxyDuration.record(durationMs, labels);
+    gatewayProxyDuration.record(durationMs / 1000, labels);
 
     // Build the response
     const response = new Response(proxyResponse.body, {

--- a/templates/api-gateway/skeleton/src/gateway/metrics.ts
+++ b/templates/api-gateway/skeleton/src/gateway/metrics.ts
@@ -15,10 +15,10 @@ export const gatewayProxyTotal = meter.createCounter("gateway_proxy_total", {
   description: "Total number of proxied requests",
 });
 
-/** Proxy request duration in milliseconds, labeled by method, route path, upstream, and status. */
-export const gatewayProxyDuration = meter.createHistogram("gateway_proxy_duration_ms", {
-  description: "Proxy request latency in milliseconds",
-  unit: "ms",
+/** Proxy request duration in seconds, labeled by method, route path, upstream, and status. */
+export const gatewayProxyDuration = meter.createHistogram("gateway_proxy_duration_seconds", {
+  description: "Proxy request latency in seconds",
+  unit: "s",
 });
 
 /** Upstream health status gauge (1 = healthy, 0 = unhealthy). */

--- a/templates/data-pipeline/skeleton/src/pipeline/metrics.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/metrics.ts
@@ -26,10 +26,10 @@ export const pipelineChunksCreated = meter.createCounter("pipeline_chunks_create
   description: "Total number of chunks created by the transform stage",
 });
 
-/** Full pipeline run duration in milliseconds. */
-export const pipelineDuration = meter.createHistogram("pipeline_duration_ms", {
-  description: "Pipeline run duration in milliseconds",
-  unit: "ms",
+/** Full pipeline run duration in seconds. */
+export const pipelineDuration = meter.createHistogram("pipeline_duration_seconds", {
+  description: "Pipeline run duration in seconds",
+  unit: "s",
 });
 
 /** Terminal stage errors, labeled by stage (ingest/transform/embed/output) — the

--- a/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
+++ b/templates/data-pipeline/skeleton/src/pipeline/orchestrator.ts
@@ -223,7 +223,7 @@ export async function runPipeline(opts: OrchestratorOptions): Promise<PipelineRe
   progress({ stage: "index", processed: embeddedChunks.length, total: embeddedChunks.length });
 
   const durationMs = Date.now() - startTime;
-  pipelineDuration.record(durationMs);
+  pipelineDuration.record(durationMs / 1000);
 
   logger.info("Pipeline complete", {
     documentsIngested: documents.length,

--- a/templates/module-analytics-ts/skeleton/src/analytics/index.ts
+++ b/templates/module-analytics-ts/skeleton/src/analytics/index.ts
@@ -9,11 +9,7 @@ import { z } from "zod";
 import { validateBootstrap } from "./bootstrap.js";
 import type { AnalyticsClientConfig } from "./config.js";
 import { AnalyticsClientConfigSchema } from "./config.js";
-import {
-  analyticsEventsTracked,
-  analyticsFlushDurationMs,
-  analyticsFlushTotal,
-} from "./metrics.js";
+import { analyticsEventsTracked, analyticsFlushDuration, analyticsFlushTotal } from "./metrics.js";
 import { getProvider, listProviders } from "./providers/index.js";
 import type { AnalyticsProvider } from "./providers/types.js";
 import type {
@@ -131,14 +127,18 @@ export async function createAnalyticsClient(
       const start = performance.now();
       await provider.flush();
       analyticsFlushTotal.add(1, { provider: providerName });
-      analyticsFlushDurationMs.record(performance.now() - start, { provider: providerName });
+      analyticsFlushDuration.record((performance.now() - start) / 1000, {
+        provider: providerName,
+      });
     },
 
     async close(): Promise<void> {
       const start = performance.now();
       await provider.close();
       analyticsFlushTotal.add(1, { provider: providerName });
-      analyticsFlushDurationMs.record(performance.now() - start, { provider: providerName });
+      analyticsFlushDuration.record((performance.now() - start) / 1000, {
+        provider: providerName,
+      });
     },
   };
 }

--- a/templates/module-analytics-ts/skeleton/src/analytics/metrics.ts
+++ b/templates/module-analytics-ts/skeleton/src/analytics/metrics.ts
@@ -19,8 +19,8 @@ export const analyticsFlushTotal = meter.createCounter("analytics_flush_total", 
   description: "Total analytics flush operations by provider",
 });
 
-/** Flush duration in milliseconds, labeled by provider. */
-export const analyticsFlushDurationMs = meter.createHistogram("analytics_flush_duration_ms", {
-  description: "Analytics flush latency in milliseconds",
-  unit: "ms",
+/** Flush duration in seconds, labeled by provider. */
+export const analyticsFlushDuration = meter.createHistogram("analytics_flush_duration_seconds", {
+  description: "Analytics flush latency in seconds",
+  unit: "s",
 });

--- a/templates/module-cache-ts/skeleton/src/cache/index.ts
+++ b/templates/module-cache-ts/skeleton/src/cache/index.ts
@@ -100,7 +100,7 @@ export async function createCache(
       const raw = await provider.get(nsKey(key));
       const durationMs = performance.now() - start;
 
-      cacheOperationDuration.record(durationMs, { operation: "get" });
+      cacheOperationDuration.record(durationMs / 1000, { operation: "get" });
 
       if (raw === undefined) {
         cacheGetTotal.add(1, { result: "miss" });
@@ -115,26 +115,26 @@ export async function createCache(
       const start = performance.now();
       const serialized = JSON.stringify(value);
       await provider.set(nsKey(key), serialized, opts?.ttl);
-      cacheOperationDuration.record(performance.now() - start, { operation: "set" });
+      cacheOperationDuration.record((performance.now() - start) / 1000, { operation: "set" });
     },
 
     async delete(key: string): Promise<void> {
       const start = performance.now();
       await provider.delete(nsKey(key));
-      cacheOperationDuration.record(performance.now() - start, { operation: "delete" });
+      cacheOperationDuration.record((performance.now() - start) / 1000, { operation: "delete" });
     },
 
     async has(key: string): Promise<boolean> {
       const start = performance.now();
       const exists = await provider.has(nsKey(key));
-      cacheOperationDuration.record(performance.now() - start, { operation: "has" });
+      cacheOperationDuration.record((performance.now() - start) / 1000, { operation: "has" });
       return exists;
     },
 
     async clear(): Promise<void> {
       const start = performance.now();
       await provider.clear();
-      cacheOperationDuration.record(performance.now() - start, { operation: "clear" });
+      cacheOperationDuration.record((performance.now() - start) / 1000, { operation: "clear" });
     },
 
     async getOrSet<T = unknown>(
@@ -145,13 +145,15 @@ export async function createCache(
       const start = performance.now();
       const existing = await cache.get<T>(key);
       if (existing !== undefined) {
-        cacheOperationDuration.record(performance.now() - start, { operation: "getOrSet" });
+        cacheOperationDuration.record((performance.now() - start) / 1000, {
+          operation: "getOrSet",
+        });
         return existing;
       }
 
       const value = await factory();
       await cache.set(key, value, opts);
-      cacheOperationDuration.record(performance.now() - start, { operation: "getOrSet" });
+      cacheOperationDuration.record((performance.now() - start) / 1000, { operation: "getOrSet" });
       return value;
     },
 

--- a/templates/module-cache-ts/skeleton/src/cache/metrics.ts
+++ b/templates/module-cache-ts/skeleton/src/cache/metrics.ts
@@ -14,8 +14,8 @@ export const cacheGetTotal = meter.createCounter("cache_get_total", {
   description: "Total cache get operations by result",
 });
 
-/** Cache operation duration in milliseconds, labeled by operation name. */
-export const cacheOperationDuration = meter.createHistogram("cache_operation_duration_ms", {
-  description: "Cache operation latency in milliseconds",
-  unit: "ms",
+/** Cache operation duration in seconds, labeled by operation name. */
+export const cacheOperationDuration = meter.createHistogram("cache_operation_duration_seconds", {
+  description: "Cache operation latency in seconds",
+  unit: "s",
 });

--- a/templates/module-feature-flags-ts/skeleton/src/feature-flags/index.ts
+++ b/templates/module-feature-flags-ts/skeleton/src/feature-flags/index.ts
@@ -108,7 +108,7 @@ export async function createFlagService(config: FlagServiceConfig = {}): Promise
       const flag = await store.getFlag(flagKey);
       if (!flag) {
         const result = notFoundResult(flagKey);
-        flagEvalDuration.record(performance.now() - start);
+        flagEvalDuration.record((performance.now() - start) / 1000);
         return result;
       }
 
@@ -116,7 +116,7 @@ export async function createFlagService(config: FlagServiceConfig = {}): Promise
       const durationMs = performance.now() - start;
 
       flagEvalTotal.add(1, { flagKey, variant: result.variant });
-      flagEvalDuration.record(durationMs);
+      flagEvalDuration.record(durationMs / 1000);
 
       if (tracker) {
         tracker.record(flagKey, result.variant, context.userId);

--- a/templates/module-feature-flags-ts/skeleton/src/feature-flags/metrics.ts
+++ b/templates/module-feature-flags-ts/skeleton/src/feature-flags/metrics.ts
@@ -14,10 +14,10 @@ export const flagEvalTotal = meter.createCounter("flag_eval_total", {
   description: "Total flag evaluations by flag key and variant",
 });
 
-/** Flag evaluation duration in milliseconds. */
-export const flagEvalDuration = meter.createHistogram("flag_eval_duration_ms", {
-  description: "Flag evaluation latency in milliseconds",
-  unit: "ms",
+/** Flag evaluation duration in seconds. */
+export const flagEvalDuration = meter.createHistogram("flag_eval_duration_seconds", {
+  description: "Flag evaluation latency in seconds",
+  unit: "s",
 });
 
 /** Variant tracking records emitted. */

--- a/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/index.ts
+++ b/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/index.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { validateBootstrap } from "./bootstrap.js";
 import type { KnowledgeConfig } from "./config.js";
 import { KnowledgeConfigSchema } from "./config.js";
-import { knowledgeBaseDurationMs, knowledgeBaseRequestTotal } from "./metrics.js";
+import { knowledgeBaseDuration, knowledgeBaseRequestTotal } from "./metrics.js";
 import { getProvider, listProviders } from "./providers/index.js";
 import type { KnowledgeProvider } from "./providers/types.js";
 import type {
@@ -103,7 +103,7 @@ export async function createKnowledgeClient(
     return fn().then(
       (result) => {
         knowledgeBaseRequestTotal.add(1, { provider: config.provider, operation });
-        knowledgeBaseDurationMs.record(performance.now() - start, {
+        knowledgeBaseDuration.record((performance.now() - start) / 1000, {
           provider: config.provider,
           operation,
         });
@@ -115,7 +115,7 @@ export async function createKnowledgeClient(
           operation,
           error: "true",
         });
-        knowledgeBaseDurationMs.record(performance.now() - start, {
+        knowledgeBaseDuration.record((performance.now() - start) / 1000, {
           provider: config.provider,
           operation,
         });

--- a/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/metrics.ts
+++ b/templates/module-knowledge-base-ts/skeleton/src/knowledge-base/metrics.ts
@@ -14,8 +14,8 @@ export const knowledgeBaseRequestTotal = meter.createCounter("knowledge_base_req
   description: "Total knowledge base requests by provider and operation",
 });
 
-/** Knowledge base request duration in milliseconds, labeled by provider and operation. */
-export const knowledgeBaseDurationMs = meter.createHistogram("knowledge_base_duration_ms", {
-  description: "Knowledge base request latency in milliseconds",
-  unit: "ms",
+/** Knowledge base request duration in seconds, labeled by provider and operation. */
+export const knowledgeBaseDuration = meter.createHistogram("knowledge_base_duration_seconds", {
+  description: "Knowledge base request latency in seconds",
+  unit: "s",
 });

--- a/templates/module-llm-observability/skeleton/src/llm-observability/metrics.ts
+++ b/templates/module-llm-observability/skeleton/src/llm-observability/metrics.ts
@@ -22,9 +22,9 @@ export function createLlmMetrics(serviceName: string): LlmMetrics {
     unit: "{call}",
   });
 
-  const traceDuration = meter.createHistogram("llm_trace_duration_ms", {
-    description: "Duration of traced LLM calls in milliseconds",
-    unit: "ms",
+  const traceDuration = meter.createHistogram("llm_trace_duration_seconds", {
+    description: "Duration of traced LLM calls in seconds",
+    unit: "s",
   });
 
   const qualityScore = meter.createHistogram("llm_quality_score", {
@@ -41,7 +41,7 @@ export function createLlmMetrics(serviceName: string): LlmMetrics {
         "llm.success": String(success),
       };
       traceTotal.add(1, attributes);
-      traceDuration.record(durationMs, attributes);
+      traceDuration.record(durationMs / 1000, attributes);
     },
 
     recordQuality(score: number, model?: string) {

--- a/templates/module-llm-providers/skeleton/src/llm-providers/index.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/index.ts
@@ -8,11 +8,7 @@
 import { validateBootstrap } from "./bootstrap.js";
 import type { ProviderConfig } from "./config.js";
 import { ProviderConfigSchema } from "./config.js";
-import {
-  llmProviderDurationMs,
-  llmProviderRequestTotal,
-  llmProviderTokenUsage,
-} from "./metrics.js";
+import { llmProviderDuration, llmProviderRequestTotal, llmProviderTokenUsage } from "./metrics.js";
 import { getProvider, listProviders } from "./providers/index.js";
 import type { LlmProvider } from "./providers/types.js";
 import type { ChatMessage, ChatOptions, LlmResponse, StreamResponse } from "./types.js";
@@ -108,7 +104,7 @@ export function createProviderRegistry(rawConfig: Partial<ProviderConfig> = {}):
       provider: response.provider,
       model: response.model,
     });
-    llmProviderDurationMs.record(response.latencyMs, {
+    llmProviderDuration.record(response.latencyMs / 1000, {
       provider: response.provider,
     });
     llmProviderTokenUsage.add(response.usage.inputTokens, {

--- a/templates/module-llm-providers/skeleton/src/llm-providers/metrics.ts
+++ b/templates/module-llm-providers/skeleton/src/llm-providers/metrics.ts
@@ -14,10 +14,10 @@ export const llmProviderRequestTotal = meter.createCounter("llm_provider_request
   description: "Total LLM provider requests by provider and model",
 });
 
-/** LLM provider request duration in milliseconds, labeled by provider. */
-export const llmProviderDurationMs = meter.createHistogram("llm_provider_duration_ms", {
-  description: "LLM provider request latency in milliseconds",
-  unit: "ms",
+/** LLM provider request duration in seconds, labeled by provider. */
+export const llmProviderDuration = meter.createHistogram("llm_provider_duration_seconds", {
+  description: "LLM provider request latency in seconds",
+  unit: "s",
 });
 
 /** Token usage per request, labeled by provider, model, and direction (input/output). */

--- a/templates/module-media-ts/skeleton/src/media/index.ts
+++ b/templates/module-media-ts/skeleton/src/media/index.ts
@@ -8,7 +8,7 @@
 import { z } from "zod";
 import { validateBootstrap } from "./bootstrap.js";
 import { MediaClientConfigSchema } from "./config.js";
-import { mediaDurationMs, mediaTransformTotal, mediaUploadTotal } from "./metrics.js";
+import { mediaDuration, mediaTransformTotal, mediaUploadTotal } from "./metrics.js";
 import { getProvider, listProviders } from "./providers/index.js";
 import type { MediaProvider } from "./providers/types.js";
 import type {
@@ -121,7 +121,7 @@ export async function createMediaClient(
       const durationMs = performance.now() - start;
 
       mediaUploadTotal.add(1, { provider: providerName });
-      mediaDurationMs.record(durationMs, { operation: "upload" });
+      mediaDuration.record(durationMs / 1000, { operation: "upload" });
 
       return asset;
     },
@@ -136,13 +136,13 @@ export async function createMediaClient(
     async delete(assetId: string): Promise<void> {
       const start = performance.now();
       await provider.delete(assetId);
-      mediaDurationMs.record(performance.now() - start, { operation: "delete" });
+      mediaDuration.record((performance.now() - start) / 1000, { operation: "delete" });
     },
 
     async list(options?: ListOptions): Promise<ListResult> {
       const start = performance.now();
       const result = await provider.list(options);
-      mediaDurationMs.record(performance.now() - start, { operation: "list" });
+      mediaDuration.record((performance.now() - start) / 1000, { operation: "list" });
       return result;
     },
 

--- a/templates/module-media-ts/skeleton/src/media/metrics.ts
+++ b/templates/module-media-ts/skeleton/src/media/metrics.ts
@@ -19,8 +19,8 @@ export const mediaTransformTotal = meter.createCounter("media_transform_total", 
   description: "Total media transform operations by provider",
 });
 
-/** Media operation duration in milliseconds, labeled by operation. */
-export const mediaDurationMs = meter.createHistogram("media_duration_ms", {
-  description: "Media operation latency in milliseconds",
-  unit: "ms",
+/** Media operation duration in seconds, labeled by operation. */
+export const mediaDuration = meter.createHistogram("media_duration_seconds", {
+  description: "Media operation latency in seconds",
+  unit: "s",
 });

--- a/templates/module-project-mgmt-ts/skeleton/src/project-mgmt/index.ts
+++ b/templates/module-project-mgmt-ts/skeleton/src/project-mgmt/index.ts
@@ -8,7 +8,7 @@
 import { validateBootstrap } from "./bootstrap.js";
 import type { ProjectConfig } from "./config.js";
 import { ProjectConfigSchema } from "./config.js";
-import { projectMgmtDurationMs, projectMgmtRequestTotal } from "./metrics.js";
+import { projectMgmtDuration, projectMgmtRequestTotal } from "./metrics.js";
 import { getProvider, listProviders } from "./providers/index.js";
 import type { ProjectProvider } from "./providers/types.js";
 import type {
@@ -130,7 +130,7 @@ export function createProjectClient(rawConfig: Partial<ProjectConfig> = {}): Pro
       projectMgmtRequestTotal.add(1, { provider: providerName, operation, status: "error" });
       throw error;
     } finally {
-      projectMgmtDurationMs.record(performance.now() - start, {
+      projectMgmtDuration.record((performance.now() - start) / 1000, {
         provider: providerName,
         operation,
       });

--- a/templates/module-project-mgmt-ts/skeleton/src/project-mgmt/metrics.ts
+++ b/templates/module-project-mgmt-ts/skeleton/src/project-mgmt/metrics.ts
@@ -14,8 +14,8 @@ export const projectMgmtRequestTotal = meter.createCounter("project_mgmt_request
   description: "Total project management requests by provider and operation",
 });
 
-/** Project management request duration in milliseconds, labeled by provider and operation. */
-export const projectMgmtDurationMs = meter.createHistogram("project_mgmt_duration_ms", {
-  description: "Project management request latency in milliseconds",
-  unit: "ms",
+/** Project management request duration in seconds, labeled by provider and operation. */
+export const projectMgmtDuration = meter.createHistogram("project_mgmt_duration_seconds", {
+  description: "Project management request latency in seconds",
+  unit: "s",
 });

--- a/templates/module-queue-ts/skeleton/src/queue/metrics.ts
+++ b/templates/module-queue-ts/skeleton/src/queue/metrics.ts
@@ -13,8 +13,8 @@ export const queueJobTotal = meter.createCounter("queue_job_total", {
   description: "Total number of queue jobs processed",
 });
 
-/** Job processing duration in milliseconds, labeled by job name. */
-export const queueJobDuration = meter.createHistogram("queue_job_duration_ms", {
-  description: "Queue job processing latency in milliseconds",
-  unit: "ms",
+/** Job processing duration in seconds, labeled by job name. */
+export const queueJobDuration = meter.createHistogram("queue_job_duration_seconds", {
+  description: "Queue job processing latency in seconds",
+  unit: "s",
 });

--- a/templates/module-queue-ts/skeleton/src/queue/worker.ts
+++ b/templates/module-queue-ts/skeleton/src/queue/worker.ts
@@ -72,14 +72,14 @@ export function createWorker(
 
       const durationMs = performance.now() - start;
       queueJobTotal.add(1, { job_name: job.name, status: "success" });
-      queueJobDuration.record(durationMs, { job_name: job.name });
+      queueJobDuration.record(durationMs / 1000, { job_name: job.name });
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       console.error(`[worker] Job "${job.name}" (${job.id}) failed: ${error.message}`);
 
       const durationMs = performance.now() - start;
       queueJobTotal.add(1, { job_name: job.name, status: "error" });
-      queueJobDuration.record(durationMs, { job_name: job.name });
+      queueJobDuration.record(durationMs / 1000, { job_name: job.name });
 
       await provider.fail(job.id, error);
     }

--- a/templates/module-search-ts/skeleton/src/search/index.ts
+++ b/templates/module-search-ts/skeleton/src/search/index.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { validateBootstrap } from "./bootstrap.js";
 import type { SearchClientConfig } from "./config.js";
 import { SearchClientConfigSchema } from "./config.js";
-import { searchDurationMs, searchIndexTotal, searchRequestTotal } from "./metrics.js";
+import { searchDuration, searchIndexTotal, searchRequestTotal } from "./metrics.js";
 import { getProvider, listProviders } from "./providers/index.js";
 import type { SearchProvider } from "./providers/types.js";
 import type {
@@ -119,7 +119,7 @@ export async function createSearchClient(
     async indexDocuments(indexName: string, documents: SearchDocument[]): Promise<void> {
       const start = performance.now();
       await provider.indexDocuments(indexName, documents);
-      searchDurationMs.record(performance.now() - start, { operation: "index" });
+      searchDuration.record((performance.now() - start) / 1000, { operation: "index" });
     },
 
     async search(indexName: string, query: SearchQuery): Promise<SearchResult> {
@@ -128,7 +128,7 @@ export async function createSearchClient(
       const durationMs = performance.now() - start;
 
       searchRequestTotal.add(1, { provider: providerName, index: indexName });
-      searchDurationMs.record(durationMs, { operation: "search" });
+      searchDuration.record(durationMs / 1000, { operation: "search" });
 
       return result;
     },

--- a/templates/module-search-ts/skeleton/src/search/metrics.ts
+++ b/templates/module-search-ts/skeleton/src/search/metrics.ts
@@ -14,10 +14,10 @@ export const searchRequestTotal = meter.createCounter("search_request_total", {
   description: "Total search requests by provider and index",
 });
 
-/** Search request duration in milliseconds, labeled by provider. */
-export const searchDurationMs = meter.createHistogram("search_duration_ms", {
-  description: "Search request latency in milliseconds",
-  unit: "ms",
+/** Search request duration in seconds, labeled by provider. */
+export const searchDuration = meter.createHistogram("search_duration_seconds", {
+  description: "Search request latency in seconds",
+  unit: "s",
 });
 
 /** Total index operations (create, delete), labeled by operation. */

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/index.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/index.ts
@@ -129,13 +129,13 @@ export async function createSemanticCache(
       // Generate embedding for the query prompt
       const embedStart = performance.now();
       const embedding = await embedder.embed(prompt);
-      embeddingDuration.record(performance.now() - embedStart);
+      embeddingDuration.record((performance.now() - embedStart) / 1000);
 
       // Search the vector store
       const hit = await vectorStore.search(embedding, similarityThreshold);
 
       const durationMs = performance.now() - lookupStart;
-      cacheOperationDuration.record(durationMs, { operation: "lookup" });
+      cacheOperationDuration.record(durationMs / 1000, { operation: "lookup" });
 
       if (!hit) {
         cacheLookupTotal.add(1, { result: "miss" });
@@ -152,7 +152,7 @@ export async function createSemanticCache(
       // Generate embedding for the prompt
       const embedStart = performance.now();
       const embedding = await embedder.embed(prompt);
-      embeddingDuration.record(performance.now() - embedStart);
+      embeddingDuration.record((performance.now() - embedStart) / 1000);
 
       const entry: CacheVector = {
         id: randomUUID(),
@@ -164,13 +164,17 @@ export async function createSemanticCache(
 
       await vectorStore.upsert(entry);
 
-      cacheOperationDuration.record(performance.now() - storeStart, { operation: "store" });
+      cacheOperationDuration.record((performance.now() - storeStart) / 1000, {
+        operation: "store",
+      });
     },
 
     async invalidate(id: string): Promise<void> {
       const start = performance.now();
       await vectorStore.delete(id);
-      cacheOperationDuration.record(performance.now() - start, { operation: "invalidate" });
+      cacheOperationDuration.record((performance.now() - start) / 1000, {
+        operation: "invalidate",
+      });
     },
 
     async close(): Promise<void> {

--- a/templates/module-semantic-cache/skeleton/src/semantic-cache/metrics.ts
+++ b/templates/module-semantic-cache/skeleton/src/semantic-cache/metrics.ts
@@ -14,17 +14,20 @@ export const cacheLookupTotal = meter.createCounter("semantic_cache_lookup_total
   description: "Total semantic cache lookup operations by result",
 });
 
-/** Semantic cache operation duration in milliseconds, labeled by operation name. */
+/** Semantic cache operation duration in seconds, labeled by operation name. */
 export const cacheOperationDuration = meter.createHistogram(
-  "semantic_cache_operation_duration_ms",
+  "semantic_cache_operation_duration_seconds",
   {
-    description: "Semantic cache operation latency in milliseconds",
-    unit: "ms",
+    description: "Semantic cache operation latency in seconds",
+    unit: "s",
   },
 );
 
-/** Embedding generation duration in milliseconds. */
-export const embeddingDuration = meter.createHistogram("semantic_cache_embedding_duration_ms", {
-  description: "Embedding generation latency in milliseconds",
-  unit: "ms",
-});
+/** Embedding generation duration in seconds. */
+export const embeddingDuration = meter.createHistogram(
+  "semantic_cache_embedding_duration_seconds",
+  {
+    description: "Embedding generation latency in seconds",
+    unit: "s",
+  },
+);

--- a/templates/worker-service/skeleton/src/worker/consumer/handler.ts
+++ b/templates/worker-service/skeleton/src/worker/consumer/handler.ts
@@ -71,7 +71,7 @@ export function createQueueConsumer(
 
       const durationMs = performance.now() - start;
       workerJobTotal.add(1, { job_name: job.name, status: "success" });
-      workerJobDuration.record(durationMs, { job_name: job.name });
+      workerJobDuration.record(durationMs / 1000, { job_name: job.name });
 
       logger.debug(`Job completed: ${job.name}`, {
         jobId: job.id,
@@ -82,7 +82,7 @@ export function createQueueConsumer(
       const durationMs = performance.now() - start;
 
       workerJobTotal.add(1, { job_name: job.name, status: "error" });
-      workerJobDuration.record(durationMs, { job_name: job.name });
+      workerJobDuration.record(durationMs / 1000, { job_name: job.name });
 
       logger.error(`Job failed: ${job.name}`, {
         jobId: job.id,

--- a/templates/worker-service/skeleton/src/worker/metrics.ts
+++ b/templates/worker-service/skeleton/src/worker/metrics.ts
@@ -14,10 +14,10 @@ export const workerJobTotal = meter.createCounter("worker_job_total", {
   description: "Total number of queue jobs processed",
 });
 
-/** Queue job processing duration in milliseconds, labeled by job name. */
-export const workerJobDuration = meter.createHistogram("worker_job_duration_ms", {
-  description: "Queue job processing latency in milliseconds",
-  unit: "ms",
+/** Queue job processing duration in seconds, labeled by job name. */
+export const workerJobDuration = meter.createHistogram("worker_job_duration_seconds", {
+  description: "Queue job processing latency in seconds",
+  unit: "s",
 });
 
 /** Total cron job executions, labeled by job name and outcome status. */


### PR DESCRIPTION
## The gap

Seventeen histograms across fifteen templates emitted `_duration_ms`. Seconds is the base unit Prometheus and OTel both assume, and a latency SLI reads `<metric>_request_duration_seconds_{bucket,count}` with `thresholdSeconds` naming a bucket boundary in seconds — so a millisecond series answers none of those queries, and anything reading one reads a number 1000× off from what its name implies.

## The conversion

Each histogram renamed to `_seconds`, declaring `unit: "s"`. Six exported instruments carried the unit in their variable name too (`searchDurationMs` and friends) and drop the suffix.

All **thirty-four** call sites divide by 1000. Where a duration variable already existed, the division sits at the record site — `durationMs / 1000` — so the variable still says what it holds and the conversion is visible where the observation is made.

Values arriving from outside (`result.durationMs` from an agent result, `response.latencyMs` from a provider response) keep their millisecond types and convert at the boundary. Those are domain fields, not instrument state.

## The check that would have caught it

`check-sli-metric-names.mjs` could not have caught any of this:

- its unit rule was scoped to `*_request_duration_*`, which **none** of these names matched
- it never looked at a `.record()` argument at all

So the worse failure — a histogram renamed to seconds while a call site still passes `performance.now() - start`, name and unit both claiming seconds while every value is off by 1000 — was invisible to it.

**Rule 2** now covers every `_duration_` histogram.

**Rule 3** binds each seconds-named instrument to its call sites and requires each recorded value to show its conversion: a division by 1000, or a value already named for seconds. Argument extraction is depth- and string-aware, so a comma inside `{ operation: "get" }` doesn't end the argument early.

Both new patterns carry vacuity guards — if the binding or call-site regex stops matching, the check exits 2 rather than reporting success over nothing.

## Negative tests

| mutation | expected | got |
|---|---|---|
| series renamed back to `_ms` | fail | fail |
| unit reverted to `ms` while name says seconds | fail | fail |
| a call site stops converting | fail | fail |
| raw ms variable fed to a seconds series | fail | fail |
| instrument-binding pattern stops matching | exit 2 | exit 2 |
| call-site pattern stops matching | exit 2 | exit 2 |

Gate green before and after; each mutation restored from content read before it, not from git.

Gate output: 41 counters and 22 histograms across 1021 template sources; **38 call sites on 21 instruments** all convert. `lint:skeletons` passes all 48 skeletons, `validate:catalog` passes with 0 errors.