### PR TITLE
ci: check every tracked file against .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,12 @@ indent_style = tab
 [*.py]
 indent_size = 4
 
+# Excalidraw writes its own export format and closes the JSON without a final
+# newline. Adding one here would be reverted the next time a diagram round-trips
+# through the editor, so this states what the format actually is.
+[*.excalidraw]
+insert_final_newline = false
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -27,6 +27,36 @@ jobs:
             --recursive
             ./
 
+  # .editorconfig declares charset, LF endings, a final newline and no trailing
+  # whitespace for every file. Biome covers TS and JSON, so those rules held for
+  # part of the tree and were unobserved everywhere else — YAML, Markdown, the
+  # template skeletons, shell.
+  #
+  # This job lives here rather than in a workflow of its own because the gate
+  # covers every tracked file, so it has to run on every change, and this is the
+  # one workflow with no path filter. A path-filtered editorconfig gate would be
+  # unable to observe most of what it checks.
+  #
+  # Indentation checks stay off: Go answers to gofmt, TS and JSON to biome, and a
+  # Makefile needs tabs for its recipes and spaces for the continuation lines
+  # inside them — the skeleton Makefiles are correct and would be flagged. This
+  # takes the rules nothing else owns.
+  editorconfig:
+    name: editorconfig
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - run: npm ci
+      - run: npm run editorconfig
+
   validate:
     name: Validate template catalog
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@biomejs/biome": "2.5.6",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
+        "editorconfig-checker": "6.1.1",
         "js-yaml": "^5.2.1",
         "markdownlint-cli2": "^0.22.1"
       },
@@ -439,6 +440,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/editorconfig-checker": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-6.1.1.tgz",
+      "integrity": "sha512-kiOb6qaWpMNt7Z/43ba0Pa1Inhr2/t9nKbvEKtCeXJ5AesztoM9AgLOOQVB4QUv/nGjgz3xkbx4pcogVRD2NWw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ec": "dist/index.js",
+        "editorconfig-checker": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "funding": {
+        "type": "buymeacoffee",
+        "url": "https://www.buymeacoffee.com/mstruebing"
       }
     },
     "node_modules/entities": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanohype",
   "private": true,
-  "description": "Template catalog for AI-focused projects \u2014 MCP servers, agentic loops, RAG pipelines, and more",
+  "description": "Template catalog for AI-focused projects — MCP servers, agentic loops, RAG pipelines, and more",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -42,6 +42,7 @@
     "sync:library": "node scripts/sync-library.mjs",
     "verify:library": "node scripts/sync-library.mjs --check",
     "lint": "biome check .",
+    "editorconfig": "editorconfig-checker -disable-indent-size -disable-indentation",
     "format": "biome check --write .",
     "lint:docs": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!templates/*/skeleton/**' '!.plans/**'",
     "validate:sli-metric-names": "node scripts/check-sli-metric-names.mjs"
@@ -50,6 +51,7 @@
     "@biomejs/biome": "2.5.6",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
+    "editorconfig-checker": "6.1.1",
     "js-yaml": "^5.2.1",
     "markdownlint-cli2": "^0.22.1"
   },


### PR DESCRIPTION
## What

Adds `editorconfig-checker` over every git-tracked file.

## Why

`.editorconfig` declares charset, LF line endings, a final newline and no trailing whitespace for the whole repo. Biome covers TypeScript and JSON, so those rules held across part of the tree and were observed nowhere else — YAML, Markdown, the template skeletons and shell ran on the honour system.

That matters more here than in a leaf repo: this is the factory's vocabulary, so a skeleton that drifts ships that drift into every tenant scaffolded from it.

## Where the job lives

In `validate-templates.yml` rather than a workflow of its own. The gate covers every tracked file, so it has to run on every change, and that is the one workflow with no path filter. A path-filtered editorconfig gate could not observe most of what it checks.

## The Excalidraw exemption

Excalidraw closes its JSON export without a final newline, and `CLAUDE.md` documents the workflow as editing the `.excalidraw` source and re-exporting — so a newline added by hand comes back off the next time a diagram round-trips. `insert_final_newline` is therefore off for `*.excalidraw` in `.editorconfig`, which states what the format is, rather than hiding those files from the checker.

## Which checks, and why not the rest

Kept: charset, end-of-line, insert-final-newline, trim-trailing-whitespace.

Indentation and indent-size are disabled. Go answers to `gofmt`, TypeScript and JSON to biome, and a Makefile needs tabs for recipes and spaces for the continuation lines inside them — the `go-cli`, `go-service` and `module-auth-go` skeleton Makefiles are correct and would be flagged. This gate takes the four rules no other tool owns.

## Negative-tested

| mutation | gate |
| --- | --- |
| stripped final newline on `catalog.json` | fails |
| Excalidraw exemption removed from `.editorconfig` | fails |
| unmodified tree | passes |

The second case is what proves the exemption is load-bearing rather than decorative.

## Day-one cost

None. The tree is already clean under these rules, so this goes green without a reformatting commit.