### PR TITLE
feat(runtime): duration() records seconds, and can say how long a duration gets

### DIFF
--- a/library/runtime/src/metrics.test.ts
+++ b/library/runtime/src/metrics.test.ts
@@ -87,6 +87,43 @@ describe("createMetrics", () => {
     expect(metric.dataPoints[0]?.value.sum).toBe(400);
   });
 
+  it("records durations as seconds histograms", async () => {
+    const m = createMetrics(cfg);
+    m.duration("assembly", 1.5);
+    m.duration("assembly", 2.5);
+
+    const instruments = await collectedInstruments();
+    const metric = instruments.get("test_service.assembly") as {
+      descriptor: { unit: string };
+      dataPoints: { value: { count: number; sum: number } }[];
+    };
+    // `s`, not `ms`. The SLI contract queries *_duration_seconds, so a
+    // millisecond histogram cannot satisfy it whatever it is named.
+    expect(metric.descriptor.unit).toBe("s");
+    expect(metric.dataPoints[0]?.value.count).toBe(2);
+    expect(metric.dataPoints[0]?.value.sum).toBe(4);
+  });
+
+  it("lets a duration set bucket edges past OTel's ms-scale default", async () => {
+    // The defect this exists to prevent: OTel's default edges top out at 10000,
+    // which reads as ten seconds once the unit is `s`. histogram_quantile cannot
+    // return above the highest finite edge, so an alert thresholded past it is
+    // false for every possible input. Two shipped alerts were dead exactly here.
+    const m = createMetrics(cfg);
+    const boundaries = [30, 60, 120, 300, 600];
+    m.duration("assembly", 450, undefined, { boundaries });
+
+    const instruments = await collectedInstruments();
+    const metric = instruments.get("test_service.assembly") as {
+      descriptor: { unit: string };
+      dataPoints: { value: { buckets: { boundaries: number[]; counts: number[] } } }[];
+    };
+    expect(metric.descriptor.unit).toBe("s");
+    expect(metric.dataPoints[0]?.value.buckets.boundaries).toEqual(boundaries);
+    // 450 lands in (300,600] — the second-to-last bucket, not the overflow one.
+    expect(metric.dataPoints[0]?.value.buckets.counts).toEqual([0, 0, 0, 0, 1, 0]);
+  });
+
   it("applies explicit bucket boundaries to distributions", async () => {
     const m = createMetrics(cfg);
     const boundaries = [0, 0.5, 1];

--- a/library/runtime/src/metrics.ts
+++ b/library/runtime/src/metrics.ts
@@ -48,6 +48,19 @@ export interface Metrics {
   counter(name: string, value?: number, attributes?: Attributes, opts?: InstrumentOptions): void;
   /** Record a duration in milliseconds (histogram, unit `ms`). */
   timing(name: string, ms: number, attributes?: Attributes): void;
+  /**
+   * Record a duration in SECONDS (histogram, unit `s`). The base unit, and the
+   * one the SLI contract queries — an SLI names `*_request_duration_seconds`,
+   * so a millisecond histogram cannot satisfy it whatever it is called.
+   *
+   * Pass `boundaries` whenever the duration can exceed ten seconds. OTel's
+   * default bucket edges top out at 10000, which is fine as milliseconds and
+   * badly wrong as seconds: `histogram_quantile` cannot return a value above
+   * the highest finite edge, so an alert thresholded past it is false for every
+   * possible input. Two shipped alerts were dead for exactly that reason, at 30x
+   * and 60x the top edge.
+   */
+  duration(name: string, seconds: number, attributes?: Attributes, opts?: InstrumentOptions): void;
   /** Record a unitless value into a histogram (unit `1` unless overridden). */
   distribution(
     name: string,
@@ -121,6 +134,10 @@ export function createMetrics(cfg: MetricsConfig): Metrics {
 
     timing(name, ms, attributes): void {
       histogramInstrument(name, { unit: "ms" }).record(ms, attributes);
+    },
+
+    duration(name, seconds, attributes, opts): void {
+      histogramInstrument(name, { unit: "s", ...opts }).record(seconds, attributes);
     },
 
     distribution(name, value, attributes, opts): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fast-uri": "^3.1.3",
     "linkify-it": "^5.0.2",
     "markdownlint-cli2": {
-      "js-yaml": "^4.2.0",
+      "js-yaml": "^4.3.1",
       "markdown-it": "^14.2.0"
     }
   }

--- a/standards/telemetry-pipeline.json
+++ b/standards/telemetry-pipeline.json
@@ -3,47 +3,47 @@
   "kind": "nanohype/standards/telemetry-pipeline",
   "version": "1",
   "title": "Telemetry pipeline standard",
-  "summary": "How telemetry moves on the nanohype stack, as three contracts. The collection contract: every workload emits OTLP to one stable in-cluster endpoint and never names a backend, so backends stay swappable without touching an application. The tier contract: a cluster declares floor or full, which changes where telemetry lands and nothing else \u2014 the endpoint, the collector and the emitting workload are identical at both. The signal contract: what the platform publishes back when it acts on telemetry, and where an agent discovers the resources to read. Companion to observability-slo, which owns what to measure and when to alert; this owns how the measurements travel and who may read them.",
+  "summary": "How telemetry moves on the nanohype stack, as three contracts. The collection contract: every workload emits OTLP to one stable in-cluster endpoint and never names a backend, so backends stay swappable without touching an application. The tier contract: a cluster declares floor or full, which changes where telemetry lands and nothing else — the endpoint, the collector and the emitting workload are identical at both. The signal contract: what the platform publishes back when it acts on telemetry, and where an agent discovers the resources to read. Companion to observability-slo, which owns what to measure and when to alert; this owns how the measurements travel and who may read them.",
   "content": {
     "principles": {
-      "neutral_waist": "OTLP is the contract, not the collector. A workload emits OTLP to a stable endpoint and never learns which collector implements it or which backend stores it. That is what makes a backend a deployment decision rather than an application rewrite \u2014 and it is the only reason a cluster can change tiers without a single tenant change.",
+      "neutral_waist": "OTLP is the contract, not the collector. A workload emits OTLP to a stable endpoint and never learns which collector implements it or which backend stores it. That is what makes a backend a deployment decision rather than an application rewrite — and it is the only reason a cluster can change tiers without a single tenant change.",
       "one_egress": "Exports concentrate at one gateway per cluster, never at the node agent and never in the application. Collection and delivery are separate concerns: an agent that also exported would put the backend's identity, credentials and failure modes on every node.",
       "absent_is_not_healthy": "A signal that is missing and a signal that reads zero are different facts and must stay distinguishable end to end. A pipeline that renders a silent workload as a healthy one turns an outage into a green dashboard.",
       "cost_is_a_design_input": "Cardinality and retention are chosen at the pipeline, not discovered on an invoice. Dimension rollups, resource-attribute promotion and log duplication are decided explicitly, and the narrow choice is the default."
     },
     "collection_contract": {
       "protocol": "OTLP. gRPC on 4317, HTTP/protobuf on 4318.",
-      "endpoint": "telemetry.<monitoring-namespace>.svc.cluster.local \u2014 a stable alias Service deliberately NOT named for the collector that implements it. A workload configures OTEL_EXPORTER_OTLP_ENDPOINT against this name and nothing else.",
-      "endpoint_rationale": "Naming the endpoint after the collector (otel-gateway, alloy, \u2026) makes every consumer a hostage of the implementation: swapping collectors becomes a coordinated edit across every tenant chart. The alias costs one Service and buys the freedom the whole waist exists for.",
+      "endpoint": "telemetry.<monitoring-namespace>.svc.cluster.local — a stable alias Service deliberately NOT named for the collector that implements it. A workload configures OTEL_EXPORTER_OTLP_ENDPOINT against this name and nothing else.",
+      "endpoint_rationale": "Naming the endpoint after the collector (otel-gateway, alloy, …) makes every consumer a hostage of the implementation: swapping collectors becomes a coordinated edit across every tenant chart. The alias costs one Service and buys the freedom the whole waist exists for.",
       "topology": [
         {
           "tier": "agent",
           "shape": "DaemonSet",
-          "owns": "collection \u2014 node-local scrape and pod-log tailing",
+          "owns": "collection — node-local scrape and pod-log tailing",
           "never": "exports to a backend, and does not accept workload OTLP: opening an ingest port on a DaemonSet puts a hostPort on every node, and the workload already has a stable cluster-wide endpoint to reach"
         },
         {
           "tier": "gateway",
           "shape": "Deployment",
-          "owns": "all OTLP ingest \u2014 from the node agents and directly from workloads \u2014 plus cross-cutting processing and every backend export; publishes the tenant-facing endpoint alias",
+          "owns": "all OTLP ingest — from the node agents and directly from workloads — plus cross-cutting processing and every backend export; publishes the tenant-facing endpoint alias",
           "never": "scrapes nodes"
         }
       ],
-      "node_scoping": "A node agent scrapes only its own node. Cluster-wide scrape targets on a DaemonSet produce one copy of every series per node \u2014 an N-fold duplication that looks like healthy redundancy and reads as inflated rates.",
+      "node_scoping": "A node agent scrapes only its own node. Cluster-wide scrape targets on a DaemonSet produce one copy of every series per node — an N-fold duplication that looks like healthy redundancy and reads as inflated rates.",
       "workload_requirements": [
         "Emit OTLP to the endpoint above; never to a backend's own protocol.",
         "Carry service.namespace, service.version and the tenant/platform resource attributes so telemetry is attributable without a naming convention on the metric name.",
-        "Allow egress to the endpoint. A default-deny NetworkPolicy that omits it drops telemetry silently \u2014 the SDK retries and the workload stays healthy, so nothing surfaces."
+        "Allow egress to the endpoint. A default-deny NetworkPolicy that omits it drops telemetry silently — the SDK retries and the workload stays healthy, so nothing surfaces."
       ],
       "ingest": "Workloads emit to the gateway through the alias Service, not to the node agent. Terminating ingest at one place keeps the endpoint a single name with a single set of receivers, and keeps the agent free of a hostPort."
     },
     "tiers": {
       "rule": "A cluster declares exactly one tier as an always-set label. Generators select on a value; they cannot branch on a key's absence, so a conditional label makes every tier-gated generator silently match nothing.",
-      "invariant": "Both tiers run the same agent, the same gateway and the same endpoint. Only the gateway's exporters differ. A workload chart is byte-identical across tiers \u2014 if a tier change requires an application change, the tiering is wrong.",
+      "invariant": "Both tiers run the same agent, the same gateway and the same endpoint. Only the gateway's exporters differ. A workload chart is byte-identical across tiers — if a tier change requires an application change, the tiering is wrong.",
       "levels": [
         {
           "id": "floor",
-          "intent": "the cheap, always-available substrate \u2014 a cluster is born here",
+          "intent": "the cheap, always-available substrate — a cluster is born here",
           "metrics": "cloud-provider-native (CloudWatch, via the provider's Container Insights producer for infrastructure and EMF for application metrics)",
           "logs": "cloud-provider-native log service",
           "traces": "provider-native tracing service; never left unrouted and never silently discarded",
@@ -55,12 +55,12 @@
           "metrics": "floor plus a Prometheus-compatible store",
           "logs": "floor plus a log-query store",
           "traces": "a trace store",
-          "requires": "a managed-monitoring substrate provisioned for the cluster \u2014 opting up is not only a label change"
+          "requires": "a managed-monitoring substrate provisioned for the cluster — opting up is not only a label change"
         }
       ],
       "default": "floor",
       "default_rationale": "floor. A vended cluster is born light and opting up is deliberate. Every cluster that already runs the higher tier pins it explicitly rather than inheriting it, so no live cluster can lose telemetry to a change in what the default means.",
-      "unrouted_traces": "A tier still routes every signal it accepts. If a backend genuinely does not exist for one, the pipeline still terminates it explicitly \u2014 omitting the pipeline makes the OTLP receiver answer UNIMPLEMENTED, so every SDK on the cluster logs export failures forever for a condition that is by design."
+      "unrouted_traces": "A tier still routes every signal it accepts. If a backend genuinely does not exist for one, the pipeline still terminates it explicitly — omitting the pipeline makes the OTLP receiver answer UNIMPLEMENTED, so every SDK on the cluster logs export failures forever for a condition that is by design."
     },
     "signal_contract": {
       "summary": "What the platform publishes when telemetry causes it to act, so the action is auditable and routable rather than buried in a controller's logs. Events go to the cluster's governance event bus; the bus archive is the compliance record.",
@@ -82,7 +82,7 @@
             "errorBudgetRemaining",
             "reason"
           ],
-          "severity": "critical for a page-tier pair, warning for a ticket tier \u2014 the observability-slo fleet_alerting tiers, which is also what routes it"
+          "severity": "critical for a page-tier pair, warning for a ticket tier — the observability-slo fleet_alerting tiers, which is also what routes it"
         },
         {
           "detail_type": "BudgetBreach",
@@ -103,12 +103,12 @@
       ],
       "rules": [
         "Every event source and detail-type pair on a shared bus must be disjoint from every other, and a test must assert it. Two governance loops sharing a bus is fine; one matching the other's events is a tenant suspended for a latency regression.",
-        "Publishing an event is not the same as the action taking effect. A loop that acts on telemetry verifies the effect it intended and reports when the effect did not land \u2014 a control loop that records a false success is worse than one that never fired.",
+        "Publishing an event is not the same as the action taking effect. A loop that acts on telemetry verifies the effect it intended and reports when the effect did not land — a control loop that records a false success is worse than one that never fired.",
         "An event carries enough detail to render an audit line without re-reading cluster state."
       ]
     },
     "discovery": {
-      "summary": "Where a client \u2014 a controller, an agent, an operator \u2014 finds the telemetry resources for a cluster without being told. One prefix, keyed by the consumer rather than the producer, so the contract holds regardless of which component produced the value.",
+      "summary": "Where a client — a controller, an agent, an operator — finds the telemetry resources for a cluster without being told. One prefix, keyed by the consumer rather than the producer, so the contract holds regardless of which component produced the value.",
       "prefix": "/eks-agent-platform/<cluster-name>/<component>/<key>",
       "paths": [
         {
@@ -136,7 +136,7 @@
           "is": "the automated-response machine the bus routes to"
         }
       ],
-      "absence_is_meaningful": "A path that does not exist means the cluster does not run that substrate \u2014 a floor cluster publishes no query endpoint. A consumer degrades and says so; it does not fail to start, and it does not treat the absence as an error."
+      "absence_is_meaningful": "A path that does not exist means the cluster does not run that substrate — a floor cluster publishes no query endpoint. A consumer degrades and says so; it does not fail to start, and it does not treat the absence as an error."
     },
     "do": [
       "Point every workload at the neutral endpoint and let the cluster decide the backend.",
@@ -146,17 +146,27 @@
       "Keep no-data distinguishable from zero through every hop, and refuse to act on a signal you do not have.",
       "Assert event source and detail-type disjointness in a test when a bus carries more than one loop.",
       "Verify that an automated action took effect, and publish a signal when it did not.",
-      "Measure custom-metric cardinality on the first cluster of a new tier, before vending a second. Cardinality is billed as it is emitted and narrowing later does not refund it, so this is a step in a runbook rather than an item in a backlog."
+      "Measure custom-metric cardinality on the first cluster of a new tier, before vending a second. Cardinality is billed as it is emitted and narrowing later does not refund it, so this is a step in a runbook rather than an item in a backlog.",
+      "Record durations with `duration(name, seconds, attrs, { boundaries })` from the runtime metrics module — it declares unit `s` for you, and the boundaries argument is where the range gets stated."
     ],
     "do_not": [
       "Name the tenant-facing endpoint after the collector that implements it.",
       "Export to a backend from the node agent, or from an application.",
-      "Run two log collectors over the same files \u2014 one pipeline owns logs, and duplicate ingestion is duplicate cost.",
+      "Run two log collectors over the same files — one pipeline owns logs, and duplicate ingestion is duplicate cost.",
       "Gate a tier on a label that is only present sometimes.",
       "Let a tier difference reach a workload chart.",
       "Accept telemetry into a pipeline with no exporter, or leave a signal type unrouted so every SDK retries against UNIMPLEMENTED forever.",
       "Promote unbounded resource attributes into metric dimensions without deciding the cardinality first.",
-      "Release an automated hold or suspension because the signal that justified it became unavailable \u2014 losing telemetry during an incident is when reverting the action is worst."
-    ]
+      "Release an automated hold or suspension because the signal that justified it became unavailable — losing telemetry during an incident is when reverting the action is worst.",
+      "Do not ship a duration histogram whose range exceeds ten seconds without explicit bucket boundaries. The alert you write against it cannot fire.",
+      "Do not rename a `_ms` histogram to `_seconds` without converting its call sites in the same change."
+    ],
+    "instrument_contract": {
+      "summary": "What a workload's instruments must be called and what they must carry, so a dashboard, an alert and an SLI can be written against a series without reading the code that emits it.",
+      "base_units": "Durations are recorded in SECONDS, named `*_duration_seconds`, and declared with OTel unit `s`. Seconds is the OTel and Prometheus base unit, so a `_ms` series is wrong against the convention every dashboard and alert in the org already assumes, not only against the SLI contract — a latency SLI reads `<m>_request_duration_seconds_bucket` and `thresholdSeconds` names a bucket edge in seconds, so a millisecond histogram answers none of those queries whatever it is named.",
+      "name_unit_and_value_agree": "The name, the declared unit, and what the call site actually records must all say the same thing. Renaming a histogram to `_seconds` while a call site still records a `Date.now()` delta puts every observation 1000x high in a series whose name and unit both promise seconds — strictly worse than the wrong name, because the wrong name is at least honest.",
+      "bucket_edges_are_declared_whenever_range_exceeds_the_default": "A duration that can exceed ten seconds MUST set explicit bucket boundaries. OTel's default edges top out at 10000, which is reasonable as milliseconds and badly wrong as seconds, and `histogram_quantile` cannot return a value above the highest finite edge. An alert thresholded past that edge is not merely imprecise — it is false for every possible input, and it reads as a healthy service forever. Two shipped alerts were dead for exactly this reason, at 30x and 60x the top edge respectively.",
+      "ratios_declare_edges_too": "A 0–1 ratio recorded into a histogram with default edges collapses every value into the first bucket. Declare boundaries."
+    }
   }
 }


### PR DESCRIPTION
`timing()` hardcodes unit `ms`, so every consumer recording a duration through the runtime got a millisecond histogram whatever it named the series. A latency SLI reads `<m>_request_duration_seconds_bucket` and `thresholdSeconds` names a bucket edge in seconds, so those histograms answer none of the SLI queries — and seconds is the OTel and Prometheus base unit besides.

`duration(name, seconds, attributes, opts)` declares unit `s` and forwards `boundaries`.

## Why the boundaries matter more than the rename

OTel's default bucket edges top out at **10000**. Reasonable as milliseconds; badly wrong as seconds. `histogram_quantile` cannot return a value above the highest finite edge, so an alert thresholded past it is not imprecise — it is **false for every possible input**, and renders as a healthy service forever.

Two shipped alerts are dead right now for exactly this reason:

| alert | threshold | vs top bucket edge |
|---|---|---|
| `IncidentResponseAssemblyDurationBreach` | `> 300000` | **30x** |
| `DigestPipelineRunDurationP95Breach` | `> 600000` | **60x** |

Neither instrument sets explicit boundaries, so both inherit the defaults. Fixes for those land in their own repos alongside the re-vendor.

The tests cover both halves: that a duration is recorded as `s`, and that a 450-second observation lands in its declared `(300,600]` bucket rather than an overflow bucket the quantile cannot reach.

## The rule, written where it can be read

The base-unit rule existed **only as a comment inside `scripts/check-sli-metric-names.mjs`** — the wrong place for something every tenant repo has to follow, since that script is vendored nowhere and no generated artifact reads it.

`standards/telemetry-pipeline.json` gains an `instrument_contract`:

- durations in seconds, named `*_duration_seconds`, declared unit `s`
- name, unit and recorded value must all agree — a histogram renamed to `_seconds` while its call sites still record `Date.now()` deltas is **strictly worse** than the wrong name, because the wrong name is at least honest
- explicit bucket edges whenever the range exceeds the default, with the dead-alert consequence spelled out
- the same for 0–1 ratios, which otherwise collapse into the first bucket

## Verification

`npm run validate:standards` — 11 files valid. `check-sli-metric-names.mjs` — 41 counters and 22 histograms across 1021 template sources, still green. Runtime suite: 8 files, 116 tests.