### PR TITLE
fix: a template the catalog could not render, and the gate that never looked

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -202,6 +202,19 @@ jobs:
       - name: Verify vendored library copies are in sync
         run: npm run verify:library
 
+      # Every gate above this line reads the catalog UNRENDERED — the schema
+      # validator checks template.yaml, the skeleton linter lints files with
+      # placeholders still in them, and validate.sh asserts placeholders ARE
+      # present. All of them pass on a template that throws the moment anyone
+      # scaffolds it, which is what shipped: infra-aws could not render at all
+      # and took four composites with it. This is the only check that runs the
+      # thing the repository sells.
+      - name: Build the SDK the catalog renders through
+        run: npm --prefix sdk ci && npm --prefix sdk run build
+
+      - name: Verify every template and composite renders
+        run: node scripts/check-catalog-renders.mjs
+
   test-templates:
     name: Test template skeletons
     runs-on: ubuntu-latest

--- a/scripts/check-catalog-renders.mjs
+++ b/scripts/check-catalog-renders.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+/**
+ * Every template and every composite in the catalog must actually render.
+ *
+ * This is the catalog's load-bearing test and it did not exist. The SDK's
+ * renderer suite builds its manifests by hand, so no test anywhere calls
+ * renderTemplate() on a real catalog entry — the thing this repository ships.
+ * Every other gate reads the catalog UNRENDERED: the schema validator checks
+ * template.yaml, the skeleton linter lints files with placeholders still in
+ * them, and validate.sh asserts that placeholders ARE present. All of them pass
+ * on a template that throws the moment somebody scaffolds it.
+ *
+ * One did. `infra-aws/skeleton/lib/stack.ts` carried a `#endif` with no opening
+ * `#if` — the imports were alphabetized and the marker comments stayed where
+ * they were — so the template could not be scaffolded at all, and it took four
+ * composites down with it. Green catalog, green CI, dead product surface.
+ *
+ * Two assertions per entry:
+ *   1. it renders without throwing
+ *   2. no placeholder survives into the rendered output
+ *
+ * The second matters as much as the first. A template that renders but leaves
+ * `__PROJECT_NAME__` in a file is not a scaffold, and nothing else looks.
+ *
+ * Required variables with no default are given a probed value that satisfies
+ * their declared pattern, because the alternative — a fixture per template —
+ * is a second copy of the catalog that drifts from the first.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderComposite } from "../sdk/dist/composite.js";
+import { renderTemplate } from "../sdk/dist/renderer.js";
+import { LocalSource } from "../sdk/dist/sources/local.js";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// The prefix renderComposite uses when an entry throws. This gate reads that
+// wording, so it is asserted against the source below: reword the message
+// without updating this and the gate fails loudly instead of quietly passing
+// every composite, which is the failure mode this whole check exists to catch.
+const FAILED_ENTRY = "Failed to render entry";
+const compositeSource = readFileSync(resolve(ROOT, "sdk/src/composite.ts"), "utf-8");
+if (!compositeSource.includes(FAILED_ENTRY)) {
+  console.error(
+    `FAIL  sdk/src/composite.ts no longer emits "${FAILED_ENTRY}" — this gate reads that\n` +
+      "      wording to tell a failed entry from a conditionally-excluded one, so it can\n" +
+      "      no longer see a composite that renders partially. Update both together.",
+  );
+  process.exit(1);
+}
+
+// Ordered so the first candidate satisfies the widest set of patterns in the
+// catalog. Single-word and separator-free is deliberate: several variables
+// default to `${SomeOtherVar}` under a stricter pattern than the variable they
+// derive from — k8s-app-tenant's AppMetric is `${AppName}` under snake_case,
+// and its own description says a multi-word name has to set it explicitly. A
+// dashed probe would fail that documented path and report a template defect
+// that is not one.
+//
+// The trade is stated: this prober exercises the default path a single-word
+// name takes, so a derived default that only breaks on multi-word input is not
+// covered here. That is the template's documented contract to keep, not this
+// gate's to second-guess.
+//
+// A variable no candidate satisfies is a real gap and is reported, not skipped.
+const CANDIDATES = ["myapp", "my-app", "my_app", "MyApp", "my.app", "1"];
+
+/** A value satisfying the variable's declared constraints, or null if none of
+ *  the candidates do — in which case the variable, not the render, is at fault. */
+function probeValue(variable) {
+  if (variable.type === "bool") return "true";
+  if (variable.type === "number") return "1";
+  const pattern = variable.validation?.pattern;
+  if (!pattern) return CANDIDATES[0];
+  const re = new RegExp(`^(?:${pattern})$`);
+  return CANDIDATES.find((c) => re.test(c)) ?? null;
+}
+
+/** Every required-without-default variable, probed. */
+function probeAll(variables, unsatisfiable) {
+  const values = {};
+  for (const v of variables ?? []) {
+    if (!v.required || "default" in v) continue;
+    const probed = probeValue(v);
+    if (probed === null) {
+      unsatisfiable.push(`${v.name} (pattern ${v.validation.pattern})`);
+      continue;
+    }
+    values[v.name] = probed;
+  }
+  return values;
+}
+
+/** Placeholders the renderer should have consumed. Declared placeholders only —
+ *  a `__SCREAMING_SNAKE__` run in prose that no variable declares is not a
+ *  rendering failure. */
+function survivingPlaceholders(files, variables) {
+  const declared = (variables ?? []).map((v) => v.placeholder).filter(Boolean);
+  if (declared.length === 0) return [];
+  const found = new Set();
+  for (const file of files) {
+    for (const placeholder of declared) {
+      if (file.path.includes(placeholder) || file.content.includes(placeholder)) {
+        found.add(placeholder);
+      }
+    }
+  }
+  return [...found];
+}
+
+const source = new LocalSource({ rootDir: ROOT });
+const failures = [];
+
+const templates = await source.listTemplates();
+if (templates.length === 0) {
+  console.error("FAIL  the catalog listed zero templates — this check evaluated nothing.");
+  process.exit(1);
+}
+
+for (const entry of templates) {
+  let manifest;
+  let files;
+  try {
+    ({ manifest, files } = await source.fetchTemplate(entry.name));
+  } catch (err) {
+    failures.push(`${entry.name}: could not be read — ${err.message}`);
+    continue;
+  }
+  const unsatisfiable = [];
+  const values = probeAll(manifest.variables, unsatisfiable);
+  if (unsatisfiable.length > 0) {
+    failures.push(`${entry.name}: no probe value satisfies ${unsatisfiable.join(", ")}`);
+    continue;
+  }
+  try {
+    const result = renderTemplate(manifest, files, values);
+    const left = survivingPlaceholders(result.files, manifest.variables);
+    if (left.length > 0) {
+      failures.push(`${entry.name}: rendered output still contains ${left.join(", ")}`);
+    }
+  } catch (err) {
+    failures.push(`${entry.name}: ${err.message}`);
+  }
+}
+
+const composites = await source.listComposites();
+if (composites.length === 0) {
+  console.error("FAIL  the catalog listed zero composites — this check evaluated nothing.");
+  process.exit(1);
+}
+
+for (const entry of composites) {
+  let manifest;
+  try {
+    manifest = await source.fetchComposite(entry.name);
+  } catch (err) {
+    failures.push(`${entry.name} (composite): could not be read — ${err.message}`);
+    continue;
+  }
+  const unsatisfiable = [];
+  const values = probeAll(manifest.variables, unsatisfiable);
+  if (unsatisfiable.length > 0) {
+    failures.push(
+      `${entry.name} (composite): no probe value satisfies ${unsatisfiable.join(", ")}`,
+    );
+    continue;
+  }
+  try {
+    const result = await renderComposite(manifest, values, source);
+    // renderComposite catches a per-entry render failure, records it as a
+    // warning and returns a success shape carrying a partial tree — so a
+    // composite that lost half its templates looks like one that rendered.
+    //
+    // The warnings list is mixed: prerequisite notices are informational, and
+    // an entry excluded by its `condition` is a correct outcome, not a failure.
+    // So the signal is the render-failure warning specifically. That couples
+    // this gate to a string in the SDK, which is why FAILED_ENTRY is asserted
+    // against composite.ts below — a reworded message fails loudly here rather
+    // than turning this check green.
+    for (const warning of result.warnings ?? []) {
+      if (warning.startsWith(FAILED_ENTRY)) {
+        failures.push(`${entry.name} (composite): ${warning}`);
+      }
+    }
+    if ((result.entries?.length ?? 0) === 0) {
+      failures.push(`${entry.name} (composite): rendered no entries at all`);
+    }
+  } catch (err) {
+    failures.push(`${entry.name} (composite): ${err.message}`);
+  }
+}
+
+for (const failure of failures) console.error(`FAIL  ${failure}`);
+
+if (failures.length > 0) {
+  console.error(
+    `\n${failures.length} failure(s) across ${templates.length} templates and ${composites.length} composites.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `catalog renders — ${templates.length} templates and ${composites.length} composites render with no surviving placeholders.`,
+);

--- a/sdk/src/composite.ts
+++ b/sdk/src/composite.ts
@@ -1,5 +1,6 @@
 import { VariableResolutionError } from "./errors.js";
 import { renderTemplate } from "./renderer.js";
+import { resolveVariables } from "./resolver.js";
 import type { CatalogSource } from "./source.js";
 import type {
   CompositeManifest,
@@ -30,21 +31,25 @@ export async function renderComposite(
   const allHooks: { pre: TemplateHook[]; post: TemplateHook[] } = { pre: [], post: [] };
   const entries: { template: string; path?: string; fileCount: number }[] = [];
 
-  // Resolve composite-level variables
-  const resolved: Record<string, string> = {};
+  // Resolve composite-level variables through the same resolver a template
+  // uses. A composite declares variables in the template shape, so the cascade
+  // is identical — and re-implementing it here dropped the `${VarName}`
+  // expansion pass, which is not an omission a composite can survive. A
+  // composite default like `${GroupId}.app` reached the child template as
+  // literal text, and the child does not declare `GroupId`, so the render died
+  // inside the entry rather than at the composite that wrote it.
+  //
+  // Required-variable failures keep their composite wording: at this layer the
+  // caller supplied composite inputs, not template ones, and naming the wrong
+  // layer is the difference between a fixable error and a confusing one.
   for (const v of manifest.variables) {
-    if (v.name in values) {
-      resolved[v.name] = String(values[v.name]);
-    } else if (v.default !== undefined) {
-      resolved[v.name] = String(v.default);
-    } else if (v.required) {
+    if (v.required && !(v.name in values) && v.default === undefined) {
       throw new VariableResolutionError(
         `Required composite variable '${v.name}' has no value and no default`,
       );
-    } else {
-      resolved[v.name] = v.type === "bool" ? "false" : v.type === "int" ? "0" : "";
     }
   }
+  const resolved = resolveVariables(manifest.variables, values);
 
   // Evaluate conditions and order entries (root first)
   const activeEntries = manifest.templates.filter((entry) => {

--- a/templates/infra-aws/skeleton/lib/stack.ts
+++ b/templates/infra-aws/skeleton/lib/stack.ts
@@ -3,12 +3,12 @@ import type * as ec2 from "aws-cdk-lib/aws-ec2";
 import type { Construct } from "constructs";
 import { ApiConstruct } from "./constructs/api";
 import { ComputeConstruct } from "./constructs/compute";
-// #endif
 // #if IncludeRds
 import { DatabaseConstruct } from "./constructs/database";
 // #endif
 // #if IncludeMonitoring
 import { MonitoringConstruct } from "./constructs/monitoring";
+// #endif
 // #if IncludeVpc || IncludeRds
 import { VpcConstruct } from "./constructs/vpc";
 // #endif


### PR DESCRIPTION
## Two bugs, one shape

**`infra-aws` could not be scaffolded.** `skeleton/lib/stack.ts` opened with a `#endif` that closed nothing — the imports had been alphabetized and the conditional markers stayed where they were, so the block boundaries no longer matched the imports they guarded. The renderer throws on an unmatched marker, and `lib/stack.ts` is not in the template's `conditionals` list, so it renders in every configuration. **The template was unscaffoldable, always**, and it took four composites with it: `ai-web-app`, `document-intelligence`, `multi-agent`, `rag-agent`.

**Two more composites died separately.** `renderComposite` resolved its own variables by hand instead of through `resolveVariables`, and the hand-rolled cascade dropped the `${VarName}` expansion pass. A composite default of `${GroupId}.app` reached the child template as literal text; the child doesn't declare `GroupId`; the render failed inside the entry rather than at the composite that wrote it. `identity-aware-service` and `spring-boot-microservice`.

## Why nothing caught either

Every gate here reads the catalog **unrendered**:

| gate | what it reads |
| --- | --- |
| schema validator | `template.yaml` |
| skeleton linter | files with placeholders still in them |
| `validate.sh` | asserts placeholders **are** present |
| SDK renderer suite | manifests built by hand — never a real catalog entry |

All of them pass on a template that throws the moment somebody scaffolds it.

## The gate

`scripts/check-catalog-renders.mjs` renders all 94 templates and all 25 composites, asserting per entry that it renders without throwing **and** that no declared placeholder survives. The second matters as much as the first — a template that renders but leaves `__PROJECT_NAME__` behind is not a scaffold.

Composites need care. A failed entry is recorded as a warning while the result still reports success, and the warning list also carries prerequisite notices and entries correctly excluded by a `condition`. So the gate reads the render-failure wording specifically — and asserts that wording still exists in `composite.ts`, so rewording it without updating the gate fails CI loudly rather than turning it green on every composite.

## How tested

```
this tree:      catalog renders — 94 templates and 25 composites render
                with no surviving placeholders.                        exit 0

previous tree:  7 failures
                infra-aws: '#endif' without matching '#if' at line 6
                ai-web-app / document-intelligence / multi-agent / rag-agent
                  (composite): Failed to render entry 'infra-aws'
                identity-aware-service / spring-boot-microservice
                  (composite): Variable 'JavaPackage' references unknown
                  variable 'GroupId'                                   exit 1
```

Also: the gate fails when it lists zero templates or zero composites, and when `composite.ts` stops emitting the wording it keys on.

`sdk` — 140 tests pass. `npm run lint` — clean across 127 files.

## One limitation, stated

The value prober picks a single-word name first, deliberately: several variables default to `${SomeOtherVar}` under a stricter pattern than the variable they derive from. `k8s-app-tenant`'s `AppMetric` is `${AppName}` under snake_case, and its own description says a multi-word name must set it explicitly. So a derived default that breaks *only* on multi-word input is not covered here — that is the template's documented contract to keep, not this gate's to second-guess.