### PR TITLE
chore: adopt the shared renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>nanohype/.github"]
+}


### PR DESCRIPTION
Renovate is installed org-wide and this repo had no config, so it would otherwise take Renovate's **stock** posture rather than the org's reviewed one.

This adopts the shared preset:

```json
{ "extends": ["github>nanohype/.github"] }
```

## What that brings

| | |
|---|---|
| patch + minor | open a PR, wait for a human — **not** automerged, and never `automergeType: branch`, which commits straight to the base branch without opening a PR at all |
| major | labelled `deps`,`major` for review |
| CVE-triggered | excluded from automerge twice over (`vulnerabilityAlerts` **and** a last-position packageRule, since per-package rules override top-level settings) |
| GitHub Actions | grouped into one PR and **pinned to commit SHAs** |
| related packages | move together, so a split PR cannot land half an upgrade |

## Adoption was decided per repo, not by default

Repos with nothing to manage are deliberately **not** getting a config — `homebrew-tap` has no manifests and no workflows, and a config there would be a control managing nothing. `tenants` and `clusters` are skipped too: they are portal-driven GitOps, machine-written, and bot PRs into a repo another system writes are noise nobody reviews.

https://claude.ai/code/session_012iMnbboJuiUMSvu7n8oRhz

## What there is to manage here

the Go module, the pnpm workspace, template Dockerfiles and tofu, a Helm chart, and the actions across 12 workflows