### PR TITLE
fix: state how a slashed dimension value renders as a k8s label

### DIFF
--- a/standards/resource-tagging.json
+++ b/standards/resource-tagging.json
@@ -7,7 +7,7 @@
   "content": {
     "transforms": {
       "aws": "Render the canonical kebab-case id as PascalCase (split on '-', capitalize each part, join). cost-center -> CostCenter.",
-      "k8s": "Well-known dimensions render under app.kubernetes.io/<leaf>; org dimensions render under <group>.nanohype.dev/<id>. The label value must match [a-z0-9A-Z._-]{0,63}.",
+      "k8s": "Well-known dimensions render under app.kubernetes.io/<leaf>; org dimensions render under <group>.nanohype.dev/<id>. The label value must match [a-z0-9A-Z._-]{0,63} and start and end alphanumeric — the API server's own rule, and narrower than an AWS tag value. A dimension whose canonical value carries a character outside that set renders it with '/' replaced by '.' on this surface only (repository: nanohype/eks-gitops -> nanohype.eks-gitops). Slashes are legal in a label KEY's prefix and in an AWS tag value, which is why one dimension is spelled differently per surface. A value that cannot survive the transform belongs in an annotation, whose values are unconstrained — annotations are not selectable, so that is a real trade.",
       "otel": "Dotted lower-case attribute names. Reserved namespace agents.* (tenant/platform/model identity) plus the well-known deployment.environment and service.version."
     },
     "reserved_prefixes": {
@@ -59,7 +59,7 @@
       {
         "id": "repository",
         "tier": "required",
-        "meaning": "The source repository as org/name (e.g. nanohype/landing-zone).",
+        "meaning": "The source repository as org/name (e.g. nanohype/landing-zone). The k8s label renders it org.name (nanohype.landing-zone) — a label value may not contain '/'.",
         "render": {
           "aws": "Repository",
           "k8s": "platform.nanohype.dev/repository",


### PR DESCRIPTION
## The contradiction

The k8s transform declared the grammar:

> The label value must match `[a-z0-9A-Z._-]{0,63}`.

The `repository` dimension declared its value:

> The source repository as **org/name** (e.g. `nanohype/landing-zone`).

…rendered to k8s as the label `platform.nanohype.dev/repository`. `/` is not in that character class. Both statements are in the same file, and a consumer reading them faithfully produces a label the API server rejects.

The transform block described how a dimension's **key** is spelled per surface and said nothing about its **value** — so the one dimension whose canonical value carries a character k8s forbids fell straight through the gap.

## Why it matters

Consumers inject these labels from this declaration rather than by hand, so the ambiguity reaches every object they stamp. In eks-gitops it reached all 30 ApplicationSet templates, and every Application the controller rendered failed admission:

```
Application.argoproj.io "cert-manager" is invalid: metadata.labels:
Invalid value: "nanohype/eks-gitops": a valid label must be an empty string or
consist of alphanumeric characters, '-', '_' or '.'
```

That fails the app-of-apps sync task, so app-of-apps sits `OutOfSync/Degraded` with zero children and the entire addon catalog goes uninstalled — on a cluster that otherwise looks healthy. Fixed downstream in nanohype/eks-gitops#197, which also adds a gate applying the API server's grammar to every label value it writes.

## The resolution

Slashes are legal in a label **key's** prefix and in an **AWS tag** value — which is precisely why this is a per-surface question, not a choice of one canonical spelling. The transform now says so:

- k8s renders the value with `/` replaced by `.` (`nanohype/eks-gitops` → `nanohype.eks-gitops`)
- the AWS tag surface keeps `org/name`
- a value that cannot survive the transform belongs in an annotation, whose values are unconstrained — noted alongside the fact that annotations are not selectable, so it is a real trade rather than an escape hatch

The grammar is also stated more completely: a label value must start and end alphanumeric, which the character class alone does not convey.

`npm run validate:standards` passes (11 files valid, plus the resource-tagging consistency check).

https://claude.ai/code/session_012iMnbboJuiUMSvu7n8oRhz