### PR TITLE
Scaffold ExternalSecrets at the version the cluster serves

### DIFF
--- a/templates/k8s-app-tenant/skeleton/chart/templates/externalsecret.yaml
+++ b/templates/k8s-app-tenant/skeleton/chart/templates/externalsecret.yaml
@@ -5,7 +5,20 @@
 # eks-gitops external-secrets addon). `dataFrom.extract` pulls every property of the
 # named secret; for selective keys, swap it for an explicit `data:` list (see the
 # tenant repos for examples).
-apiVersion: external-secrets.io/v1beta1
+# v1, not v1beta1. The external-secrets release the eks-gitops addon installs still
+# DECLARES v1beta1 on the CRD but no longer serves it:
+#
+#   $ kubectl get crd externalsecrets.external-secrets.io \
+#       -o jsonpath='{range .spec.versions[*]}{.name}{" served="}{.served}{"\n"}{end}'
+#   v1      served=true
+#   v1beta1 served=false
+#
+# A declared-but-unserved version is the confusing case: the CRD lists it, so the
+# manifest looks like it targets something real, and the install fails at admission
+# with `no matches for kind "ExternalSecret" in version
+# "external-secrets.io/v1beta1"`. Every field this template uses is present in v1
+# unchanged, and the ClusterSecretStore it references was always v1.
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "tenant-chart-base.fullname" . }}-secrets


### PR DESCRIPTION
The `k8s-app-tenant` skeleton declared `external-secrets.io/v1beta1`. The release the eks-gitops addon installs still *lists* that version on the CRD but no longer serves it:

```
$ kubectl get crd externalsecrets.external-secrets.io \
    -o jsonpath='{range .spec.versions[*]}{.name}{" served="}{.served}{"\n"}{end}'
v1      served=true
v1beta1 served=false
```

Declared-but-unserved is the confusing shape: the CRD names the version, so the manifest looks like it targets something real, and **nothing local disagrees** — helm renders it, schema validation accepts it, `template.yaml` checks pass. Only the API server knows, and it answers at install time with `no matches for kind "ExternalSecret" in version "external-secrets.io/v1beta1"`.

## Why this one first

This skeleton is what every new k8s app is scaffolded from, so its default gets minted into each of them. Fixing it here is what stops the next generated app from arriving broken.

Found while sweeping the org after this bit a live install (nanohype/portal#162, nanohype/digest-pipeline#75). Three tenant repos still carry the same declaration — `competitive-intelligence`, `incident-response`, `slack-knowledge-bot` — tracked in nanohype/eks-gitops#203.

Every field the skeleton uses (`refreshInterval`, `secretStoreRef`, `target`, `dataFrom.extract`) exists in `v1` unchanged, and the `ClusterSecretStore` it references was always `v1`. Version bump, nothing more.

`./scripts/validate.sh templates/k8s-app-tenant` passes.