### PR TITLE
Let the template and SLO gates hold a merge

### DIFF
--- a/.github/workflows/slo-constants.yml
+++ b/.github/workflows/slo-constants.yml
@@ -1,17 +1,26 @@
 name: SLO constants
 
+# The check reads three repositories and this one owns only the standard. Both
+# of the numbers it protects live somewhere else, so the trigger cannot be keyed
+# on changes here.
+#
+# It used to be, filtered to the standard, the script and this file. That makes
+# it a consumer-drift detector that only runs when the source of truth moves —
+# eks-gitops or the operator could drift for as long as nobody touched
+# standards/. They did: a minimum-traffic gate landed in eks-gitops on
+# 2026-08-07, this check went red against it, and nothing observed that for five
+# days until a dependency bump happened to edit the workflow file.
+#
+# So: every pull request (it is one node script over three sparse checkouts,
+# seconds of runtime), and daily, which is the only trigger that sees a consumer
+# change at all.
 on:
   push:
     branches: [main]
-    paths:
-      - "standards/observability-slo.json"
-      - "scripts/check-slo-constants.mjs"
-      - ".github/workflows/slo-constants.yml"
   pull_request:
-    paths:
-      - "standards/observability-slo.json"
-      - "scripts/check-slo-constants.mjs"
-      - ".github/workflows/slo-constants.yml"
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -55,3 +64,22 @@ jobs:
           node scripts/check-slo-constants.mjs \
             eks-gitops/dashboards/base/alerting \
             eks-agent-platform/operators/internal/controller
+
+  # The single required status check for this workflow. `always()` is
+  # load-bearing: without it a failed dependency skips this job, and GitHub
+  # counts a skipped check as passing for branch protection — the gate would
+  # report green exactly when the drift check failed.
+  #
+  # Named distinctly from validate-templates.yml's gate on purpose. Branch
+  # protection matches a required check by name, so two workflows publishing the
+  # same name are two checks GitHub cannot tell apart.
+  merge-gate:
+    name: merge gate (slo)
+    runs-on: ubuntu-latest
+    needs: [check]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - uses: nanohype/.github/actions/merge-gate@6ec6c5b3e6c4a8b15e12da4afd7ac4870a630092 # main
+        with:
+          needs: ${{ toJSON(needs) }}
+          gate-job-id: merge-gate

--- a/.github/workflows/template-doctor.yml
+++ b/.github/workflows/template-doctor.yml
@@ -188,6 +188,12 @@ jobs:
   merge-gate:
     name: merge gate (templates)
     runs-on: ubuntu-latest
+    # This workflow sets no top-level default, so a job without its own block
+    # inherits whatever the repository grants. The gate reads the calling
+    # workflow file back to check that no job in it escapes the gate, and wants
+    # nothing beyond that.
+    permissions:
+      contents: read
     needs: [audit, doctor]
     if: always() && github.event_name == 'pull_request'
     steps:

--- a/.github/workflows/template-doctor.yml
+++ b/.github/workflows/template-doctor.yml
@@ -8,16 +8,14 @@ on:
   # Gate PRs that touch templates, composites, or the doctor itself: fail on
   # hard errors so typecheck/build/lint/ref debt can't land silently. Advisory
   # findings (outdated deps, dead deps) are reported but don't block.
+  #
+  # No `paths:` filter here, deliberately, even though only a few paths matter.
+  # A path-filtered workflow does not run at all when nothing matches, so its
+  # check is never created — and a required check that is never created leaves
+  # every unrelated pull request waiting on a status that will not arrive. The
+  # filter moved inside the jobs instead: they always run and always report, and
+  # do the expensive work only when something they read actually changed.
   pull_request:
-    paths:
-      - 'templates/**'
-      - 'composites/**'
-      - 'scripts/template-doctor/**'
-      - '.github/workflows/template-doctor.yml'
-      # The standards group compares skeleton configs against these files, so
-      # raising a published floor has to run the check that enforces it —
-      # otherwise the bar moves and the catalog silently stops meeting it.
-      - 'standards/**'
   # Manual trigger for on-demand runs (e.g., before cutting a release).
   workflow_dispatch:
     inputs:
@@ -30,6 +28,12 @@ jobs:
   # Supply-chain gate. osv-scanner checks the committed lockfiles against the
   # OSV database and exits non-zero on a known vulnerability. Pinned to an exact
   # version (its behaviour can shift in a patch).
+  #
+  # validate-templates.yml runs this same scan, unfiltered, on every pull request
+  # and every push to main. What it cannot cover is the weekly cron: an advisory
+  # published against a lockfile nobody touched. That is the case this job is
+  # here for, so on a pull request the step is skipped and the job reports
+  # success rather than scanning the same tree twice.
   audit:
     name: audit (osv-scanner)
     runs-on: ubuntu-latest
@@ -37,9 +41,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v6
 
       - name: audit (osv-scanner)
+        if: github.event_name != 'pull_request'
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
           scan-args: |-
@@ -57,13 +63,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # The scope step below diffs against the merge base, which needs more
+          # than the default single commit.
+          fetch-depth: 0
+
+      # What the `paths:` filter used to do, moved to where it can no-op instead
+      # of preventing the job from reporting. Anything other than a pull request
+      # — the weekly cron, a manual run — always does the full pass.
+      - name: Decide whether this change reaches the catalog
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE_SHA"...HEAD | grep -qE \
+            '^(templates/|composites/|standards/|scripts/template-doctor/|\.github/workflows/template-doctor\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "catalog paths changed — running the full doctor pass"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no catalog paths changed — nothing for the doctor to read"
+          fi
 
       - name: Set up Node
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Set up Go
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-go@v6
         with:
           # go-service's pgx/otel deps require go 1.25; keep the doctor on a
@@ -71,18 +104,21 @@ jobs:
           go-version: '1.26'
 
       - name: Set up JDK
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Set up Python
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Run doctor
         id: doctor
+        if: steps.scope.outputs.relevant == 'true'
         env:
           ONLY: ${{ github.event.inputs.only || 'ts,go,java,python,cross,standards' }}
           # Gate pull requests on hard errors; cron / manual runs stay report-only.
@@ -93,11 +129,11 @@ jobs:
           ./scripts/template-doctor/run.sh "${args[@]}" > doctor-report.md
 
       - name: Post report to job summary
-        if: always()
+        if: always() && steps.scope.outputs.relevant == 'true'
         run: cat doctor-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload report artifact
-        if: always()
+        if: always() && steps.scope.outputs.relevant == 'true'
         uses: actions/upload-artifact@v5
         with:
           name: doctor-report
@@ -139,3 +175,23 @@ jobs:
               });
               core.info("Opened new tracking issue");
             }
+
+  # The single required status check for this workflow — the thing that makes
+  # the sentence at the top of this file true. Template Doctor is the only gate
+  # that typechecks a rendered skeleton against the dependencies it just took,
+  # and until this job existed it reported into nothing: branch protection
+  # required one check, `merge gate`, published by validate-templates.yml, and a
+  # red doctor could not hold a merge.
+  #
+  # `always()` is load-bearing: without it a failed dependency skips this job,
+  # and GitHub counts a skipped check as passing for branch protection.
+  merge-gate:
+    name: merge gate (templates)
+    runs-on: ubuntu-latest
+    needs: [audit, doctor]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - uses: nanohype/.github/actions/merge-gate@6ec6c5b3e6c4a8b15e12da4afd7ac4870a630092 # main
+        with:
+          needs: ${{ toJSON(needs) }}
+          gate-job-id: merge-gate

--- a/scripts/check-slo-constants.mjs
+++ b/scripts/check-slo-constants.mjs
@@ -59,13 +59,21 @@ const usedFactors = new Set();
 
 for (const f of files) {
   const text = readFileSync(join(alertDir, f), "utf-8");
-  // "> bool <factor>" is the multi-window/multi-burn-rate comparison.
-  for (const m of text.matchAll(/> bool ([0-9]+(?:\.[0-9]+)?)/g)) {
-    const factor = Number(m[1]);
+  // A burn-rate comparison is the error ratio divided by (1 - objective), then
+  // compared against the factor: "… / 0.001 > bool 14.4". The division is what
+  // makes the number on the right a burn rate, so it is part of the pattern.
+  //
+  // Matching a bare "> bool <n>" cannot work. PromQL uses that operator for any
+  // comparison, and both alert files gate on minimum traffic with
+  // "sum(rate(…)) > bool 0.0167" — ~1 event/minute, so a ratio computed over a
+  // nearly-idle series cannot page. Read as a burn-rate factor, 0.0167 is not
+  // one, and the check fails on a file that is correct.
+  for (const m of text.matchAll(/\/ (0\.[0-9]+) > bool ([0-9]+(?:\.[0-9]+)?)/g)) {
+    const factor = Number(m[2]);
     usedFactors.add(factor);
     if (!allFactors.has(factor)) {
       errors.push(
-        `${f}: burn-rate factor ${factor} ("> bool ${m[1]}") is not a factor in ${STANDARD} (defined: ${[...allFactors].sort((a, b) => a - b).join(", ")})`,
+        `${f}: burn-rate factor ${factor} ("/ ${m[1]} > bool ${m[2]}") is not a factor in ${STANDARD} (defined: ${[...allFactors].sort((a, b) => a - b).join(", ")})`,
       );
     }
   }


### PR DESCRIPTION
Two gates in this repository could go red without holding anything back, and one
of them was red for the wrong reason.

Branch protection requires exactly one status check — `merge gate`, published by
`validate-templates.yml`. Eleven workflows do not feed it, including the two
that catch the most:

| workflow | the only thing that checks it | was |
|---|---|---|
| `template-doctor.yml` | typechecks every rendered skeleton against its new deps | red on 7 open PRs, blocking none |
| `slo-constants.yml` | diffs eks-gitops + the operator against the SLO standard | red, and wrong |

`template-doctor.yml`'s own header says it exists to "gate PRs that touch
templates … so typecheck/build/lint/ref debt can't land silently." Branch
protection did not implement that sentence.

## The SLO check was failing on correct files

It extracted burn-rate factors with `/> bool ([0-9.]+)/`, which reads any PromQL
comparison as a burn rate. Both alert files gate on minimum traffic with
`sum(rate(...)) > bool 0.0167` — about one event per minute, so a ratio over a
nearly-idle series cannot page — and 0.0167 is not one of the standard's factors
(1, 3, 6, 14.4).

A burn-rate comparison is the error ratio divided by `(1 - objective)` and then
compared, so the division is now part of the match. Against the live alert files
that keeps all 16 real comparisons and drops exactly the 6 traffic gates.

Verified by mutation, not just by passing:

| mutation | result |
|---|---|
| unmodified consumers | passes |
| `/ 0.001 > bool 14.4` → `15.4` | caught |
| `/ 0.001` → `/ 0.005` | caught |
| operator `6h/30m` factor `6` → `5` | caught, both directions |

## The trigger was the deeper defect

`slo-constants.yml` was filtered to `standards/observability-slo.json`, the
script, and its own workflow file — a consumer-drift detector that only ran when
the source of truth changed. Neither consumer lives in this repository. One
drifted: the minimum-traffic gate landed in eks-gitops on 2026-08-07, this check
went red against it, and nothing saw that for five days, until a dependency bump
happened to edit the workflow YAML.

It now runs on every pull request and daily.

## Path filters and required checks do not compose

A path-filtered workflow does not run when nothing matches, so its check is
never created — and a required check that is never created leaves every
unrelated pull request waiting on a status that will not arrive. The filter
moved inside the jobs: they always run and always report, and reach for Node,
Go, the JDK and Python only when the diff touches the catalog.

The osv-scanner job is scoped from the other side. It duplicates a scan
`validate-templates.yml` already runs on every pull request and push to main;
what that cannot cover is the weekly cron. On a pull request its steps are
skipped and the job reports success rather than scanning the same tree twice.

## Not in this change

Adding `merge gate (slo)` or `merge gate (templates)` to the required set is a
repository-settings change and is deliberately left out. The checks should be
observed reporting correctly first — including on a pull request that touches no
templates, which is the case the old path filter could never produce.