### PR TITLE
Teach the gates to report inside a merge queue

### DIFF
--- a/.github/workflows/slo-constants.yml
+++ b/.github/workflows/slo-constants.yml
@@ -18,6 +18,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # The merge queue tests each entry on its own temporary branch. A required
+  # check that does not run there never reports, and the queue waits forever —
+  # so every workflow publishing a required check has to listen for this event.
+  merge_group:
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:
@@ -77,7 +81,7 @@ jobs:
     name: merge gate (slo)
     runs-on: ubuntu-latest
     needs: [check]
-    if: always() && github.event_name == 'pull_request'
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
     steps:
       - uses: nanohype/.github/actions/merge-gate@6ec6c5b3e6c4a8b15e12da4afd7ac4870a630092 # main
         with:

--- a/.github/workflows/template-doctor.yml
+++ b/.github/workflows/template-doctor.yml
@@ -16,6 +16,10 @@ on:
   # filter moved inside the jobs instead: they always run and always report, and
   # do the expensive work only when something they read actually changed.
   pull_request:
+  # The merge queue tests each entry on its own temporary branch. A required
+  # check that does not run there never reports, and the queue waits forever —
+  # so every workflow publishing a required check has to listen for this event.
+  merge_group:
   # Manual trigger for on-demand runs (e.g., before cutting a release).
   workflow_dispatch:
     inputs:
@@ -41,11 +45,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v6
 
       - name: audit (osv-scanner)
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
           scan-args: |-
@@ -121,8 +125,10 @@ jobs:
         if: steps.scope.outputs.relevant == 'true'
         env:
           ONLY: ${{ github.event.inputs.only || 'ts,go,java,python,cross,standards' }}
-          # Gate pull requests on hard errors; cron / manual runs stay report-only.
-          FAIL_ON: ${{ github.event_name == 'pull_request' && 'error' || '' }}
+          # Gate both merge paths on hard errors; cron / manual runs stay
+          # report-only. Leaving merge_group out would let the queue's own gate
+          # pass on a catalog the pull-request gate had just rejected.
+          FAIL_ON: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'error' || '' }}
         run: |
           args=(--only "$ONLY" --format markdown)
           [ -n "$FAIL_ON" ] && args+=(--fail-on "$FAIL_ON")
@@ -195,7 +201,7 @@ jobs:
     permissions:
       contents: read
     needs: [audit, doctor]
-    if: always() && github.event_name == 'pull_request'
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
     steps:
       - uses: nanohype/.github/actions/merge-gate@6ec6c5b3e6c4a8b15e12da4afd7ac4870a630092 # main
         with:

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # The merge queue tests each entry on its own temporary branch. A required
+  # check that does not run there never reports, and the queue waits forever —
+  # so every workflow publishing a required check has to listen for this event.
+  merge_group:
 
 permissions:
   contents: read
@@ -305,11 +309,15 @@ jobs:
     # and GitHub counts a skipped check as passing for branch protection, so the
     # gate would report green exactly when something broke.
     #
-    # Restricted to pull_request because the gate treats a skipped dependency as
-    # a failure, and a job carrying `if: github.event_name == 'pull_request'` is
-    # legitimately skipped on a push to main. The gate exists to gate merges, and
-    # merges come from pull requests; on push it is skipped and gates nothing.
-    if: always() && github.event_name == 'pull_request'
+    # Restricted to the two events a merge can come through, because the gate
+    # treats a skipped dependency as a failure and a job carrying
+    # `if: github.event_name == 'pull_request'` is legitimately skipped on a push
+    # to main. On push it is skipped and gates nothing.
+    #
+    # merge_group is the other one: the queue tests each entry on a temporary
+    # branch, and a required check that does not report there stalls the queue
+    # indefinitely.
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
     steps:
       - uses: nanohype/.github/actions/merge-gate@6ec6c5b3e6c4a8b15e12da4afd7ac4870a630092 # main
         with:


### PR DESCRIPTION
Groundwork for turning on a merge queue. **This does not enable it** — the
triggers have to be on main first, or the first entry stalls.

## Why

Required checks are strict, so every merge puts each remaining pull request
behind main and forces a rebase plus a full CI cycle before the next can go.
Landing the current Renovate backlog costs one serial cycle per PR, and this
repository's cycle is the slow one. Right now that is visible: ~90 runs queued
across the org to land a dozen one-line dependency bumps.

A merge queue tests entries together against the projected merge result instead
of one at a time against a main that keeps moving.

## The trap this avoids

The queue tests each entry on a temporary branch and raises `merge_group`, not
`pull_request`. A workflow that does not listen for it never runs there, so its
check is never created — and a required check that is never created leaves the
entry waiting on a status that will not arrive.

That is precisely the failure mode fixed in #264 for path filters, arriving from
a different direction. Silent, and permanent.

## What changed

All three workflows publishing a required check now listen for `merge_group`,
and their gate jobs run on both events:

| workflow | check |
|---|---|
| `validate-templates.yml` | `merge gate` |
| `template-doctor.yml` | `merge gate (templates)` |
| `slo-constants.yml` | `merge gate (slo)` |

Two conditions had to move with them:

- **`FAIL_ON` was keyed on `pull_request` alone.** Inside the queue the doctor
  would have run report-only, so the queue's gate would pass on a catalog the
  pull-request gate had just rejected. Worse than not running it.
- **The osv-scanner job now skips on `merge_group` too**, for the reason it
  already skips on `pull_request`: `validate-templates.yml` scans that tree, and
  this copy exists for the weekly cron.

The doctor's scope step needs no change — it treats anything that is not a pull
request as a full pass, which is what an entry about to land on main should get.

## Verified

Every job in each of the three workflows is watched by its gate, so nothing can
go green by not running.