### PR TITLE
Name the ambient types these two skeletons compile against

### DIFF
--- a/templates/chrome-ext/skeleton/tsconfig.json
+++ b/templates/chrome-ext/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "types": ["chrome", "node"],
     "jsx": "react-jsx",
     "outDir": "dist",
     "rootDir": "src",

--- a/templates/test-automation/skeleton/tsconfig.json
+++ b/templates/test-automation/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": ".",
     "strict": true,


### PR DESCRIPTION
Stacked on #270. The last thing standing between #254 (TypeScript 7 across the
skeletons) and green.

## What #254 was actually blocked on

Its template-doctor run reports two errors, and neither is a missing
dependency:

| skeleton | errors under TS 7 | already declares |
|---|---|---|
| chrome-ext | 12 × `Cannot find name 'chrome'` | `@types/chrome`, `@types/node` |
| test-automation | 5 × `Cannot find name 'process'` | `@types/node` |

**TypeScript 7 stopped auto-including `node_modules/@types/*`.** Its own
diagnostic says so — "add 'node' to the types field in your tsconfig". The
packages are installed; nothing was pulling them into scope.

Probed each skeleton in a scratch copy against both compilers:

| | TS 5.9.3 | TS 7.0.2 | TS 7.0.2 + `types` |
|---|---|---|---|
| chrome-ext | clean | 12 errors | clean |
| test-automation | clean | 5 errors | clean |

chrome-ext's suite still passes, and both are clean on 5.9.3 — this repo is
still on 5, so the change has to be correct on both.

## Why it is right regardless of TypeScript 7

An ambient global that arrives because something else in the tree happened to
hoist it is a dependency the project never asked for and cannot see. That is
exactly how chrome-ext lost `process` in #270 — the vite upgrade stopped
dragging `@types/node` along behind it, and a skeleton that had typechecked for
months stopped. Declaring the package fixed the install; naming it fixes the
scope.

Nothing else needs this: the doctor runs `tsc --noEmit` on every skeleton under
TS 7 in #254, and these two are the only ones that fail.