### PR TITLE
Name @types/node in the thirteen skeletons that rely on it

### DIFF
--- a/templates/api-gateway/skeleton/tsconfig.json
+++ b/templates/api-gateway/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/fine-tune-pipeline/skeleton/tsconfig.json
+++ b/templates/fine-tune-pipeline/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": ".",
     "strict": true,

--- a/templates/guardrails/skeleton/tsconfig.json
+++ b/templates/guardrails/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-analytics-ts/skeleton/tsconfig.json
+++ b/templates/module-analytics-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-auth-ts/skeleton/tsconfig.json
+++ b/templates/module-auth-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-knowledge-base-ts/skeleton/tsconfig.json
+++ b/templates/module-knowledge-base-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-media-ts/skeleton/tsconfig.json
+++ b/templates/module-media-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-project-mgmt-ts/skeleton/tsconfig.json
+++ b/templates/module-project-mgmt-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-queue-ts/skeleton/tsconfig.json
+++ b/templates/module-queue-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-search-ts/skeleton/tsconfig.json
+++ b/templates/module-search-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-storage-ts/skeleton/tsconfig.json
+++ b/templates/module-storage-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/module-webhook-ts/skeleton/tsconfig.json
+++ b/templates/module-webhook-ts/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/templates/worker-service/skeleton/tsconfig.json
+++ b/templates/worker-service/skeleton/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
Unblocks #254 the rest of the way. Same fix as #271, thirteen more skeletons.

## What the doctor found

With TypeScript 7, thirteen skeletons fail `tsc --noEmit` on Node globals they
all already declare `@types/node` for:

| skeleton | errors | first failure |
|---|---|---|
| api-gateway | 91 | `typeof globalThis has no index signature` |
| module-project-mgmt-ts | 79 | `Cannot find name 'process'` |
| module-media-ts | 69 | `Cannot find name 'Buffer'` |
| module-knowledge-base-ts / module-search-ts | 54 | `process` |
| module-storage-ts | 48 | `Cannot find name 'node:fs/promises'` |
| module-analytics-ts | 42 | `Cannot find name 'setTimeout'` |
| worker-service | 35 | `process` |
| module-queue-ts | 32 | `process` |
| module-auth-ts | 26 | `Cannot find name 'TextEncoder'` |
| module-webhook-ts | 18 | `node:crypto` |
| fine-tune-pipeline | 72 | `process` |
| guardrails | 8 | `process` |

api-gateway's reads differently — TS7017 rather than a missing name — but it is
the same cause: `globalThis` gets its index signature from the Node types.

## Verification

Per skeleton, not in aggregate: scratch copy, `npm install`, its own `tsc`.

- All thirteen exit 0 on **7.0.2**
- Re-checked on **5.9.3**, since that is what main compiles with today
- Suites re-run on the ones with the largest diffs — still green

## Why this surfaced late, and why I was wrong earlier

I said on #271 that chrome-ext and test-automation were "the only ones that
fail", citing #254's doctor run. That was true of the run and false of the
repository.

These same thirteen typechecked **clean** under TypeScript 7 before the vitest
3→4 and zod 3→4 moves landed — unchanged tsconfig, `@types/node` present in
`node_modules/@types` in both trees. Confirmed by rebuilding the pre-#269
skeleton from `cf503f8`, installing it with TypeScript 7, and getting exit 0.

So the ambient types were reaching the program through some path those upgrades
removed, and a two-skeleton reading was a thirteen-skeleton problem waiting on
an unrelated bump. I have not pinned down which of the two upgrades dropped the
path; the fix does not depend on knowing, and naming the dependency is what
stops it mattering — a project should not typecheck because of what happens to
be installed next to it.