### PR TITLE
Converge .editorconfig on the shared text

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,18 +1,24 @@
 root = true
 
 [*]
+charset = utf-8
+end_of_line = lf
 indent_style = space
 indent_size = 2
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = true
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
 
 [*.go]
 indent_style = tab
 
-[*.py]
-indent_size = 4
+# Braces at the start of a pattern match a whole filename, which is the only
+# form that catches a file named exactly `Makefile`. A `*.Makefile` entry in a
+# brace list matches nothing, since the name carries no dot.
+[{Makefile,*.mk}]
+indent_style = tab
 
 # Excalidraw writes its own export format and closes the JSON without a final
 # newline. Adding one here would be reverted the next time a diagram round-trips
@@ -20,8 +26,9 @@ indent_size = 4
 [*.excalidraw]
 insert_final_newline = false
 
+# Two trailing spaces are markdown's hard-break idiom, and lines across this org
+# rely on it — metadata blocks that would reflow into a single paragraph if the
+# whitespace were stripped. This is the one place the "no trailing whitespace"
+# style rule does not apply.
 [*.md]
 trim_trailing_whitespace = false
-
-[Makefile]
-indent_style = tab


### PR DESCRIPTION
Last of six. The Node repos in this org carried **four different
`.editorconfig` variants**, differing almost entirely in rules nothing enforces.
They now carry identical text.

This repo's file was already closest to it, so the diff is small:

- `[Makefile]` → `[{Makefile,*.mk}]`. The brace form matches the whole filename,
  which is the only spelling that catches a file named exactly `Makefile` while
  also covering `.mk`. Elsewhere in the org this appeared as
  `[*.{go,mk,Makefile}]`, which **never matched a Makefile at all** — a
  brace-list entry of `*.Makefile` needs a literal dot in the name — and needed
  a second `[Makefile]` section beside it to work.
- The rules that were already correct now say why they exist.

The **Excalidraw exception stays**, and stays repo-local rather than moving into
the shared text: the editor closes its own export format without a final newline
and reverts one added by hand. That is a fact about this repo's diagrams, not
about the org.

## Scope

The gate runs `editorconfig-checker -disable-indent-size -disable-indentation`,
so the enforced surface is charset, line endings, final newline and trailing
whitespace — unchanged by this. `npm run editorconfig` passes.

## The one measurement behind it

`[*.md] trim_trailing_whitespace = false` reads like it contradicts the org
style rule, so I checked whether anything depends on it before keeping it: 43
lines across `incident-response` and `slack-knowledge-bot` are genuine markdown
hard breaks — metadata blocks that would reflow into a single paragraph if the
whitespace were stripped. The stricter reading is not available, and the file
now records that.